### PR TITLE
Force.C: Change rho lookup to be compatible with v1812

### DIFF
--- a/FSI/Force.C
+++ b/FSI/Force.C
@@ -62,7 +62,9 @@ void preciceAdapter::FSI::Force::write(double * buffer)
 
     // Density
     // TODO: Extend to cover also compressible solvers
-    dimensionedScalar rho = mesh_.lookupObject<IOdictionary>("transportProperties").lookup("rho");
+    const dictionary& transportProperties =
+        mesh_.lookupObject<IOdictionary>("transportProperties");
+    const dimensionedScalar rho(transportProperties.lookup("rho"));
 
     // Stress tensor
     tmp<volSymmTensorField> tdevRhoReff = devRhoReff(rho);


### PR DESCRIPTION
We are either way using this form everywhere else (even in the same file, for nu).

Fixes #59.

The problem originated from deprecating the `dimensionedScalar` constructors using IStream in this OpenFOAM commit: https://develop.openfoam.com/Development/OpenFOAM-plus/commit/1cc0e66f0c22366d02f320d853f4e958a2a37a02