### PR TITLE
Add travis integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,13 @@
+sudo: true
+dist: trusty
+language: python
+python:
+  - "3.5"
+jobs:
+  include:
+    # trigger systemtests build only when pushing to master
+    - if: branch = master or branch = develop 
+      script: 
+        - curl -LO --retry 3 https://raw.githubusercontent.com/shkodm/systemtests/master/trigger_systemtests.py
+        - travis_wait 60 python trigger_systemtests.py --adapter openfoam --wait
+

--- a/README.md
+++ b/README.md
@@ -1,4 +1,7 @@
 # preCICE-adapter for the CFD code OpenFOAM
+<a style="text-decoration: none" href="https://travis-ci.org/precice/openfoam-adapter" target="_blank">
+    <img src="https://travis-ci.org/precice/openfoam-adapter.svg?branch=master" alt="Build status">
+</a>
 
 _**Note:** This adapter is currently in a testing phase. Please [report any issues](https://github.com/precice/openfoam-adapter/issues) here and give us feedback through the [preCICE mailing list](https://mailman.informatik.uni-stuttgart.de/mailman/listinfo/precice)._
 


### PR DESCRIPTION
As  described in detail in this  [pull request]( https://github.com/precice/systemtests/pull/22 ) for systemtests, it is now possible for an adapter to trigger custom set of tests on the [systemtests](https://github.com/precice/systemtests) repository. Therefore I add simple Travis set up that will test OpenFOAM-OpenFOAM coupling and OpenFOAM-CalculiX coupling.