### PR TITLE
Point Travis to proper repository

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,6 @@ jobs:
     # trigger systemtests build only when pushing to master
     - if: branch = master or branch = develop 
       script: 
-        - curl -LO --retry 3 https://raw.githubusercontent.com/shkodm/systemtests/master/trigger_systemtests.py
+        - curl -LO --retry 3 https://raw.githubusercontent.com/precice/systemtests/master/trigger_systemtests.py
         - travis_wait 60 python trigger_systemtests.py --adapter openfoam --wait
 


### PR DESCRIPTION
Before it pointed to my systemtests fork (which is used for testing,etc, so not reliable). 
I did not spot it in #65 .