### PR TITLE
Move UPstream::initNull() to the constructor of the functionObject

### DIFF
--- a/preciceAdapterFunctionObject.C
+++ b/preciceAdapterFunctionObject.C
@@ -53,6 +53,13 @@ Foam::functionObjects::preciceAdapterFunctionObject::preciceAdapterFunctionObjec
     fvMeshFunctionObject(name, runTime, dict),
     adapter_(runTime, mesh_)
 {
+    #if defined OPENFOAM_PLUS || (defined OPENFOAM && (OPENFOAM > 1000))
+        // Patch for issue #27: warning "MPI was already finalized" while
+        // running in serial. This only affects openfoam.com, while initNull()
+        // does not exist in openfoam.org.
+        UPstream::initNull();
+    #endif
+
     read(dict);
 }
 
@@ -68,13 +75,6 @@ Foam::functionObjects::preciceAdapterFunctionObject::~preciceAdapterFunctionObje
 
 bool Foam::functionObjects::preciceAdapterFunctionObject::read(const dictionary& dict)
 {
-    #if defined OPENFOAM_PLUS || (defined OPENFOAM && (OPENFOAM > 1000))
-        // Patch for issue #27: warning "MPI was already finalized" while
-        // running in serial. This only affects openfoam.com, while initNull()
-        // does not exist in openfoam.org.
-        UPstream::initNull();
-    #endif
-
     adapter_.configure();
 
     return true;


### PR DESCRIPTION
This is a better fix for the (twin) issues https://github.com/precice/openfoam-adapter/issues/27 and https://github.com/precice/precice/issues/128. 

Before, I had put the patch in the `read()` method, assuming that it is called only once. Apparently, this can be called more times:

https://github.com/precice/openfoam-adapter/blob/ea179f199f6b86e6aba7692163f45423c3f727a9/preciceAdapterFunctionObject.C#L69-L81

Now:

```c++
Foam::functionObjects::preciceAdapterFunctionObject::preciceAdapterFunctionObject
(
    const word& name,
    const Time& runTime,
    const dictionary& dict
)
:
    fvMeshFunctionObject(name, runTime, dict),
    adapter_(runTime, mesh_)
{
    #if defined OPENFOAM_PLUS || (defined OPENFOAM && (OPENFOAM > 1000))
        // Patch for issue #27: warning "MPI was already finalized" while
        // running in serial. This only affects openfoam.com, while initNull()
        // does not exist in openfoam.org.
        UPstream::initNull();
    #endif

    read(dict);
}
```

Thanks to @olesenm for reporting this issue. 