### PR TITLE
 Make the adapter compatible with new pkg-config 

### DIFF
--- a/Adapter.H
+++ b/Adapter.H
@@ -22,7 +22,7 @@
 // YAML reader - Used to read the adapter's configuration file.
 #include "yaml-cpp/yaml.h"
 // preCICE Solver Interface
-#include "SolverInterface.hpp"
+#include "precice/SolverInterface.hpp"
 
 namespace preciceAdapter
 {

--- a/Allwmake
+++ b/Allwmake
@@ -62,7 +62,8 @@ export ADAPTER_TARGET_DIR
 export ADAPTER_GLOBAL_CPLUS_INC_PATHS
 export ADAPTER_GLOBAL_LD_LIBRARY_PATHS
 export ADAPTER_GLOBAL_LIBRARY_PATHS
-export ADAPTER_PKG_CONFIG_CFLAGS="`PKG_CONFIG_ALLOW_SYSTEM_CFLAGS=1 pkg-config --silence-errors --cflags libprecice`"
+export ADAPTER_PKG_CONFIG_CFLAGS="`pkg-config --silence-errors --cflags libprecice`"
+export ADAPTER_PKG_CONFIG_LIBS="`pkg-config --silence-errors --libs libprecice`"
 
 # Inform the user about the environment
 echo "Using the following environment variables:"

--- a/Allwmake
+++ b/Allwmake
@@ -62,7 +62,7 @@ export ADAPTER_TARGET_DIR
 export ADAPTER_GLOBAL_CPLUS_INC_PATHS
 export ADAPTER_GLOBAL_LD_LIBRARY_PATHS
 export ADAPTER_GLOBAL_LIBRARY_PATHS
-export ADAPTER_PKG_CONFIG_CFLAGS="`PKG_CONFIG_ALLOW_SYSTEM_CFLAGS=1 pkg-config --silence-errors --cflags precice`"
+export ADAPTER_PKG_CONFIG_CFLAGS="`PKG_CONFIG_ALLOW_SYSTEM_CFLAGS=1 pkg-config --silence-errors --cflags libprecice`"
 
 # Inform the user about the environment
 echo "Using the following environment variables:"

--- a/Make/options
+++ b/Make/options
@@ -21,6 +21,7 @@ LIB_LIBS = \
     $(ADAPTER_GLOBAL_LIBRARY_PATHS) \
     $(ADAPTER_GLOBAL_LD_LIBRARY_PATHS) \
     -L$(ADAPTER_PRECICE_ROOT)/build/last \
+    $(ADAPTER_PKG_CONFIG_LIBS) \
     -lprecice \
     $(ADAPTER_PRECICE_DEP) \
     -lyaml-cpp

--- a/Make/options
+++ b/Make/options
@@ -8,7 +8,7 @@ EXE_INC = \
     -I$(LIB_SRC)/TurbulenceModels/compressible/lnInclude \
     -I$(LIB_SRC)/TurbulenceModels/incompressible/lnInclude \
     $(ADAPTER_GLOBAL_CPLUS_INC_PATHS) \
-    -I$(ADAPTER_PRECICE_ROOT)/src/precice \
+    -I$(ADAPTER_PRECICE_ROOT)/src \
     $(ADAPTER_PKG_CONFIG_CFLAGS) \
     -I../ \
     $(ADAPTER_PREP_FLAGS)


### PR DESCRIPTION
* Add both the `--cflags` and the `--libs`.
* Remove the (unnecessary when linking, only useful when trying on the terminal) `PKG_CONFIG_ALLOW_SYSTEM_CFLAGS=1` (a corresponding `PKG_CONFIG_ALLOW_SYSTEM_LIBS=1` was eitherway missing).
* The `SolverInterface.hpp` is included as `precice/SolverInterface.hpp` (it's also an xSDK requirement).
* The `--silence_errors` is needed so that, if pkg-config information is not available, it will still try alternative ways.
* The package is now called `libprecice` (instead of `precice`).