### PR TITLE
Do not run travis on forks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,8 @@ python:
   - "3.5"
 jobs:
   include:
-    # trigger systemtests build only when pushing to master
-    - if: branch = master or branch = develop 
+    # trigger systemtests build only on main branches and not on external prs
+    - if: fork = false AND ( branch = master OR branch = develop )
       script: 
         - curl -LO --retry 3 https://raw.githubusercontent.com/precice/systemtests/master/trigger_systemtests.py
         - travis_wait 60 python trigger_systemtests.py --adapter openfoam --wait


### PR DESCRIPTION
As discussed in  [this issue](https://github.com/precice/systemtests/issues/42), forks do not have Travis secret variables, so they will always fail, when trying to trigger systemtests. Therefore we decided to skip them, until some better solution is found. 