### PR TITLE
Add prefix ---[precice] to tutorial preCICE log

### DIFF
--- a/tutorials/CHT/flow-over-plate/buoyantPimpleFoam-laplacianFoam/precice-config_parallel.xml
+++ b/tutorials/CHT/flow-over-plate/buoyantPimpleFoam-laplacianFoam/precice-config_parallel.xml
@@ -3,7 +3,7 @@
 <precice-configuration>
 
     <log>
-        <sink type="stream" output="stdout" filter="%Severity% > debug" enabled="true"/>
+        <sink type="stream" output="stdout" filter="%Severity% > debug" format="---[precice] %ColorizedSeverity% %Message%" enabled="true"/>
     </log>
 
     <solver-interface dimensions="3">

--- a/tutorials/CHT/flow-over-plate/buoyantPimpleFoam-laplacianFoam/precice-config_parallel.xml
+++ b/tutorials/CHT/flow-over-plate/buoyantPimpleFoam-laplacianFoam/precice-config_parallel.xml
@@ -3,7 +3,7 @@
 <precice-configuration>
 
     <log>
-        <sink type="stream" output="stdout" filter="%Severity% > debug" format="---[precice] %ColorizedSeverity% %Message%" enabled="true"/>
+        <sink filter="%Severity% > debug" format="---[precice] %ColorizedSeverity% %Message%" enabled="true"/>
     </log>
 
     <solver-interface dimensions="3">

--- a/tutorials/CHT/flow-over-plate/buoyantPimpleFoam-laplacianFoam/precice-config_serial.xml
+++ b/tutorials/CHT/flow-over-plate/buoyantPimpleFoam-laplacianFoam/precice-config_serial.xml
@@ -3,7 +3,7 @@
 <precice-configuration>
 
     <log>
-        <sink type="stream" output="stdout" filter="%Severity% > debug" enabled="true"/>
+        <sink type="stream" output="stdout" filter="%Severity% > debug" format="---[precice] %ColorizedSeverity% %Message%" enabled="true"/>
     </log>
 
     <solver-interface dimensions="3">

--- a/tutorials/CHT/flow-over-plate/buoyantPimpleFoam-laplacianFoam/precice-config_serial.xml
+++ b/tutorials/CHT/flow-over-plate/buoyantPimpleFoam-laplacianFoam/precice-config_serial.xml
@@ -3,7 +3,7 @@
 <precice-configuration>
 
     <log>
-        <sink type="stream" output="stdout" filter="%Severity% > debug" format="---[precice] %ColorizedSeverity% %Message%" enabled="true"/>
+        <sink filter="%Severity% > debug" format="---[precice] %ColorizedSeverity% %Message%" enabled="true"/>
     </log>
 
     <solver-interface dimensions="3">

--- a/tutorials/CHT/flow-over-plate/buoyantPimpleFoam-laplacianFoam_nearest-projection/precice-config_parallel.xml
+++ b/tutorials/CHT/flow-over-plate/buoyantPimpleFoam-laplacianFoam_nearest-projection/precice-config_parallel.xml
@@ -3,7 +3,7 @@
 <precice-configuration>
 
     <log>
-        <sink type="stream" output="stdout"  filter= "%Severity% >= debug" format="---[precice] %ColorizedSeverity% %Message%" enabled="true" />	
+        <sink filter= "%Severity% >= debug" format="---[precice] %ColorizedSeverity% %Message%" enabled="true" />
     </log>
 
     <solver-interface dimensions="3">

--- a/tutorials/CHT/flow-over-plate/buoyantPimpleFoam-laplacianFoam_nearest-projection/precice-config_parallel.xml
+++ b/tutorials/CHT/flow-over-plate/buoyantPimpleFoam-laplacianFoam_nearest-projection/precice-config_parallel.xml
@@ -3,7 +3,7 @@
 <precice-configuration>
 
     <log>
-        <sink type="stream" output="stdout"  filter= "%Severity% >= debug"  enabled="true" />	
+        <sink type="stream" output="stdout"  filter= "%Severity% >= debug" format="---[precice] %ColorizedSeverity% %Message%" enabled="true" />	
     </log>
 
     <solver-interface dimensions="3">

--- a/tutorials/CHT/flow-over-plate/buoyantPimpleFoam-laplacianFoam_nearest-projection/precice-config_serial.xml
+++ b/tutorials/CHT/flow-over-plate/buoyantPimpleFoam-laplacianFoam_nearest-projection/precice-config_serial.xml
@@ -3,7 +3,7 @@
 <precice-configuration>
 
     <log>
-        <sink type="stream" output="stdout"  filter= "%Severity% >= debug" format="---[precice] %ColorizedSeverity% %Message%" enabled="true" />	
+        <sink filter= "%Severity% >= debug" format="---[precice] %ColorizedSeverity% %Message%" enabled="true" />
     </log>
 
     <solver-interface dimensions="3">

--- a/tutorials/CHT/flow-over-plate/buoyantPimpleFoam-laplacianFoam_nearest-projection/precice-config_serial.xml
+++ b/tutorials/CHT/flow-over-plate/buoyantPimpleFoam-laplacianFoam_nearest-projection/precice-config_serial.xml
@@ -3,7 +3,7 @@
 <precice-configuration>
 
     <log>
-        <sink type="stream" output="stdout"  filter= "%Severity% >= debug"  enabled="true" />	
+        <sink type="stream" output="stdout"  filter= "%Severity% >= debug" format="---[precice] %ColorizedSeverity% %Message%" enabled="true" />	
     </log>
 
     <solver-interface dimensions="3">


### PR DESCRIPTION
This adds a custom format to every tutorial's preCICE configuration file to easily distinguish the preCICE output from the output of OpenFOAM and of the adapter. It is also consistent with the one we use for the adapter.

Related to #89 and to https://github.com/precice/tutorials/issues/41