### PR TITLE
Fix "maybe uninitialized" numFaceCenters/Nodes

### DIFF
--- a/Interface.C
+++ b/Interface.C
@@ -88,15 +88,11 @@ void preciceAdapter::Interface::configureMesh(const fvMesh& mesh)
         for (uint j = 0; j < patchIDs_.size(); j++)
         {
             // Get the face centers of the current patch
-            const vectorField & faceCenters =
+            const vectorField faceCenters =
                     mesh.boundaryMesh()[patchIDs_.at(j)].faceCentres();
 
-            // Initialize numFaceCenters to avoid GCC raising -Wmaybe-uninitialized
-            int numFaceCenters = 0;
-            if (faceCenters.size() > 0) numFaceCenters = faceCenters.size();
-
             // Assign the (x,y,z) locations to the vertices
-            for (int i = 0; i < numFaceCenters; i++)
+            for (int i = 0; i < faceCenters.size(); i++)
             {
                 vertices[verticesIndex++] = faceCenters[i].x();
                 vertices[verticesIndex++] = faceCenters[i].y();
@@ -138,16 +134,12 @@ void preciceAdapter::Interface::configureMesh(const fvMesh& mesh)
             // TODO: Check if this behaves correctly in parallel.
             // TODO: Check if this behaves correctly with multiple, connected patches.
             // TODO: Maybe this should be a pointVectorField?
-            const pointField & faceNodes =
+            const pointField faceNodes =
                     mesh.boundaryMesh()[patchIDs_.at(j)].localPoints();
-
-            // Initialize numFaceNodes to avoid GCC raising -Wmaybe-uninitialized
-            int numFaceNodes = 0;
-            if (faceNodes.size() > 0) numFaceNodes = faceNodes.size();
 
             // Assign the (x,y,z) locations to the vertices
             // TODO: Ensure consistent order when writing/reading
-            for (int i = 0; i < numFaceNodes; i++)
+            for (int i = 0; i < faceNodes.size(); i++)
             {
                 vertices[verticesIndex++] = faceNodes[i].x();
                 vertices[verticesIndex++] = faceNodes[i].y();

--- a/Interface.C
+++ b/Interface.C
@@ -91,8 +91,12 @@ void preciceAdapter::Interface::configureMesh(const fvMesh& mesh)
             const vectorField & faceCenters =
                     mesh.boundaryMesh()[patchIDs_.at(j)].faceCentres();
 
+            // Initialize numFaceCenters to avoid GCC raising -Wmaybe-uninitialized
+            int numFaceCenters = 0;
+            if (faceCenters.size() > 0) numFaceCenters = faceCenters.size();
+
             // Assign the (x,y,z) locations to the vertices
-            for (int i = 0; i < faceCenters.size(); i++)
+            for (int i = 0; i < numFaceCenters; i++)
             {
                 vertices[verticesIndex++] = faceCenters[i].x();
                 vertices[verticesIndex++] = faceCenters[i].y();
@@ -137,9 +141,13 @@ void preciceAdapter::Interface::configureMesh(const fvMesh& mesh)
             const pointField & faceNodes =
                     mesh.boundaryMesh()[patchIDs_.at(j)].localPoints();
 
+            // Initialize numFaceNodes to avoid GCC raising -Wmaybe-uninitialized
+            int numFaceNodes = 0;
+            if (faceNodes.size() > 0) numFaceNodes = faceNodes.size();
+
             // Assign the (x,y,z) locations to the vertices
             // TODO: Ensure consistent order when writing/reading
-            for (int i = 0; i < faceNodes.size(); i++)
+            for (int i = 0; i < numFaceNodes; i++)
             {
                 vertices[verticesIndex++] = faceNodes[i].x();
                 vertices[verticesIndex++] = faceNodes[i].y();


### PR DESCRIPTION
This is done to avoid GCC raising `-Wmaybe-uninitialized`.

**Edit:** The following (initial guess) is not enough to fix the issue.

<details><summary>(click to reveal, but be aware: this is not the solution)</summary>
<p>

Instead of directly using:
```c++
for (int i = 0; i < faceCenters.size(); i++)
```
(which, after being optimized, [is not liked by GCC](https://stackoverflow.com/a/14132910/2254346)) this is first initializing it and only overwriting it if `faceCenters.size()` is well-defined.

```c++
// Initialize numFaceCenters to avoid GCC raising -Wmaybe-uninitialized
int numFaceCenters = 0;
if (faceCenters.size() > 0) numFaceCenters = faceCenters.size();

// Assign the (x,y,z) locations to the vertices
for (int i = 0; i < numFaceCenters; i++)
```

However, I cannot reproduce the problem or test on my own system, so I would be happy if somebody with more recent GCC gave it a try.

</p>
</details>

I could not fix this in any other way than just not using a reference in the first place. We are getting an additional copy, but the code is not memory-optimized either way at the moment.

I have tested this on Ubuntu 18.04 (GCC 7.4.0).

Closes #28.