### PR TITLE
Restrict logger to rank 0 to cope with preCICE v2.0

### DIFF
--- a/tutorials/CHT/flow-over-plate/buoyantPimpleFoam-laplacianFoam/precice-config.xml
+++ b/tutorials/CHT/flow-over-plate/buoyantPimpleFoam-laplacianFoam/precice-config.xml
@@ -3,7 +3,7 @@
 <precice-configuration>
 
     <log>
-        <sink filter="%Severity% > debug" format="---[precice] %ColorizedSeverity% %Message%" enabled="true"/>
+        <sink filter="%Severity% > debug and %Rank% = 0" format="---[precice] %ColorizedSeverity% %Message%" enabled="true"/>
     </log>
 
     <solver-interface dimensions="3">

--- a/tutorials/CHT/flow-over-plate/buoyantPimpleFoam-laplacianFoam_nearest-projection/precice-config.xml
+++ b/tutorials/CHT/flow-over-plate/buoyantPimpleFoam-laplacianFoam_nearest-projection/precice-config.xml
@@ -3,7 +3,7 @@
 <precice-configuration>
 
     <log>
-        <sink filter= "%Severity% > debug" format="---[precice] %ColorizedSeverity% %Message%" enabled="true" />
+        <sink filter= "%Severity% > debug and %Rank% = 0" format="---[precice] %ColorizedSeverity% %Message%" enabled="true" />
     </log>
 
     <solver-interface dimensions="3">


### PR DESCRIPTION
Previously, we explicitly printed INFO statements only for rank 0. This changed with v2.0. Now, instead we set the default of the logger to rank 0. The default gets however overwritten as soon as you set a different logger. So, the logger here also needs to restrict to rank 0 to not have INFO statements for every rank.