### PR TITLE
[Will not merge] Compatibility with OpenFOAM4 (4.0, 4.1)

### DIFF
--- a/Adapter.C
+++ b/Adapter.C
@@ -44,16 +44,16 @@ bool preciceAdapter::Adapter::configFileRead()
     // NOTE: lookupType<T>("name") is deprecated in openfoam.com since v1812,
     // which recommends get<T>("name") instead. However, get<T>("name")
     // is not implemented in openfoam.org at the moment.
-    preciceConfigFilename_ = preciceDict.lookupType<fileName>("preciceConfig");
+    preciceConfigFilename_ = static_cast<word>(preciceDict.lookup("preciceConfig"));
     DEBUG(adapterInfo("  precice-config-file : " + preciceConfigFilename_));
 
     // Read and display the participant name
-    participantName_ = preciceDict.lookupType<word>("participant");
+    participantName_ = static_cast<word>(preciceDict.lookup("participant"));
     DEBUG(adapterInfo("  participant name    : " + participantName_));
 
     // Read and display the list of modules
     DEBUG(adapterInfo("  modules requested   : "));
-    wordList modules_ = preciceDict.lookupType<wordList>("modules");
+    wordList modules_ = static_cast<wordList>(preciceDict.lookup("modules"));
     for (auto module : modules_)
     {
         DEBUG(adapterInfo("  - " + module + "\n"));
@@ -85,7 +85,7 @@ bool preciceAdapter::Adapter::configFileRead()
           dictionary interfaceDict = interfaceDictEntry.dict();
           struct InterfaceConfig interfaceConfig;
           
-          interfaceConfig.meshName = interfaceDict.lookupType<word>("mesh");
+          interfaceConfig.meshName = static_cast<word>(interfaceDict.lookup("mesh"));
           DEBUG(adapterInfo("  - mesh         : " + interfaceConfig.meshName));
           
           // By default, assume "faceCenters" as locationsType
@@ -105,7 +105,7 @@ bool preciceAdapter::Adapter::configFileRead()
           DEBUG(adapterInfo("    connectivity : " + std::to_string(interfaceConfig.meshConnectivity)));
           
           DEBUG(adapterInfo("    patches      : "));
-          wordList patches = interfaceDict.lookupType<wordList>("patches");
+          wordList patches = static_cast<wordList>(interfaceDict.lookup("patches"));
           for (auto patch : patches)
           {
             interfaceConfig.patchNames.push_back(patch);
@@ -113,7 +113,7 @@ bool preciceAdapter::Adapter::configFileRead()
           }
           
           DEBUG(adapterInfo("    writeData    : "));
-          wordList writeData = interfaceDict.lookupType<wordList>("writeData");
+          wordList writeData = static_cast<wordList>(interfaceDict.lookup("writeData"));
           for (auto writeDatum : writeData)
           {
             interfaceConfig.writeData.push_back(writeDatum);
@@ -121,7 +121,7 @@ bool preciceAdapter::Adapter::configFileRead()
           }
           
           DEBUG(adapterInfo("    readData     : "));
-          wordList readData = interfaceDict.lookupType<wordList>("readData");
+          wordList readData = static_cast<wordList>(interfaceDict.lookup("readData"));
           for (auto readDatum : readData)
           {
             interfaceConfig.readData.push_back(readDatum);


### PR DESCRIPTION
#105 broke compatibility with OpenFOAM4, as `dict.lookupType<T>(entry)` was introduced in OpenFOAM5. This replaces it with `static_cast<T>(dict.lookup(entry))`.

In principle, we could use the same for every version, but I would postpone this until #32.

This should remain open.