### PR TITLE
Determine solver type by pressure dimension

### DIFF
--- a/CHT/CHT.C
+++ b/CHT/CHT.C
@@ -101,10 +101,13 @@ std::string preciceAdapter::CHT::ConjugateHeatTransfer::determineSolverType()
     }
 
     if (solverType == "unknown")
-      adapterInfo("Failed to determine the solver type. This might lead to "
-                  "issues during your simulation. Using 'basic' as solver type. "
-                  "Please specify the solver type in the preciceDict file.",
-                  "warning");
+      adapterInfo("Failed to determine the solver type. "
+                  "Please specify your solver type in the preciceDict. "
+                  "Known solver types are: "
+                  "Incompressible"
+                  "Compressible"
+                  "Basic",
+                  "error");
 
     return solverType;
 }

--- a/CHT/CHT.C
+++ b/CHT/CHT.C
@@ -85,22 +85,22 @@ std::string preciceAdapter::CHT::ConjugateHeatTransfer::determineSolverType()
     // NOTE: When coupling a different variable, you may want to
     // add more cases here. Or you may provide the solverType in the config.
 
-    std::string solverType = "basic";
+    std::string solverType = "unknown";
 
-    dimensionSet compressible_pressure_dimension(1, -1, -2, 0, 0, 0, 0);
-    dimensionSet incompressible_pressure_dimension(0, 2, -2, 0, 0, 0, 0);
+    dimensionSet pressureDimensionsCompressible(1, -1, -2, 0, 0, 0, 0);
+    dimensionSet pressureDimensionsIncompressible(0, 2, -2, 0, 0, 0, 0);
 
     if (mesh_.foundObject<volScalarField>("p"))
     {
       volScalarField p_ = mesh_.lookupObject<volScalarField>("p");
 
-      if (p_.dimensions() == compressible_pressure_dimension)
+      if (p_.dimensions() == pressureDimensionsCompressible)
         solverType = "compressible";
-      else if (p_.dimensions() == incompressible_pressure_dimension)
+      else if (p_.dimensions() == pressureDimensionsIncompressible)
         solverType = "incompressible";
     }
 
-    if (solverType == "basic")
+    if (solverType == "unknown")
       adapterInfo("Failed to determine the solver type. This might lead to "
                   "issues during your simulation. Using 'basic' as solver type. "
                   "Please specify the solver type in the preciceDict file.",

--- a/CHT/CHT.C
+++ b/CHT/CHT.C
@@ -102,11 +102,13 @@ std::string preciceAdapter::CHT::ConjugateHeatTransfer::determineSolverType()
 
     if (solverType == "unknown")
       adapterInfo("Failed to determine the solver type. "
-                  "Please specify your solver type in the preciceDict. "
-                  "Known solver types for CHT are: "
-                  "Incompressible"
-                  "Compressible",
+                  "Please specify your solver type in the CHT section of the "
+                  "preciceDict. Known solver types for CHT are: "
+                  "basic, incompressible and "
+                  "compressible",
                   "error");
+
+    DEBUG(adapterInfo("Automatically determined solver type : " + solverType));
 
     return solverType;
 }

--- a/CHT/CHT.C
+++ b/CHT/CHT.C
@@ -103,7 +103,7 @@ std::string preciceAdapter::CHT::ConjugateHeatTransfer::determineSolverType()
     if (solverType == "unknown")
       adapterInfo("Failed to determine the solver type. "
                   "Please specify your solver type in the preciceDict. "
-                  "Known solver types are: "
+                  "Known solver types for CHT are: "
                   "Incompressible"
                   "Compressible"
                   "Basic",

--- a/CHT/CHT.C
+++ b/CHT/CHT.C
@@ -105,8 +105,7 @@ std::string preciceAdapter::CHT::ConjugateHeatTransfer::determineSolverType()
                   "Please specify your solver type in the preciceDict. "
                   "Known solver types for CHT are: "
                   "Incompressible"
-                  "Compressible"
-                  "Basic",
+                  "Compressible",
                   "error");
 
     return solverType;

--- a/CHT/CHT.C
+++ b/CHT/CHT.C
@@ -48,7 +48,7 @@ bool preciceAdapter::CHT::ConjugateHeatTransfer::configure(const IOdictionary& a
 bool preciceAdapter::CHT::ConjugateHeatTransfer::readConfig(const IOdictionary& adapterConfig)
 {
     const dictionary CHTdict = adapterConfig.subOrEmptyDict("CHT");
-  
+
     // Read the solver type (if not specified, it is determined automatically)
     solverType_ = CHTdict.lookupOrDefault<word>("solverType", "");
     DEBUG(adapterInfo("    user-defined solver type : " + solverType_));
@@ -85,86 +85,26 @@ std::string preciceAdapter::CHT::ConjugateHeatTransfer::determineSolverType()
     // NOTE: When coupling a different variable, you may want to
     // add more cases here. Or you may provide the solverType in the config.
 
-    std::string solverType;
+    std::string solverType = "basic";
 
-    // Determine the solver type: Compressible, Incompressible or Basic.
-    // Look for the files transportProperties, turbulenceProperties,
-    // and thermophysicalProperties
-    bool transportPropertiesExists = false;
-    bool turbulencePropertiesExists = false;
-    bool thermophysicalPropertiesExists = false;
+    dimensionSet compressible_pressure_dimension(1, -1, -2, 0, 0, 0, 0);
+    dimensionSet incompressible_pressure_dimension(0, 2, -2, 0, 0, 0, 0);
 
-    if (mesh_.foundObject<IOdictionary>("transportProperties"))
+    if (mesh_.foundObject<volScalarField>("p"))
     {
-        transportPropertiesExists = true;
-        DEBUG(adapterInfo("Found the transportProperties dictionary."));
-    }
-    else
-    {
-        DEBUG(adapterInfo("Did not find the transportProperties dictionary."));
+      volScalarField p_ = mesh_.lookupObject<volScalarField>("p");
+
+      if (p_.dimensions() == compressible_pressure_dimension)
+        solverType = "compressible";
+      else if (p_.dimensions() == incompressible_pressure_dimension)
+        solverType = "incompressible";
     }
 
-    if (mesh_.foundObject<IOdictionary>(turbulenceModel::propertiesName))
-    {
-        turbulencePropertiesExists = true;
-        DEBUG(adapterInfo("Found the " + turbulenceModel::propertiesName
-            + " dictionary."));
-    }
-    else
-    {
-        DEBUG(adapterInfo("Did not find the " + turbulenceModel::propertiesName
-            + " dictionary."));
-    }
-
-    if (mesh_.foundObject<IOdictionary>("thermophysicalProperties"))
-    {
-        thermophysicalPropertiesExists = true;
-        DEBUG(adapterInfo("Found the thermophysicalProperties dictionary."));
-    }
-    else
-    {
-        DEBUG(adapterInfo("Did not find the thermophysicalProperties dictionary."));
-    }
-
-    if (turbulencePropertiesExists)
-    {
-        if (thermophysicalPropertiesExists)
-        {
-            solverType = "compressible";
-            DEBUG(adapterInfo("This is a compressible flow solver, "
-                "as turbulence and thermophysical properties are provided."));
-        }
-        else if (transportPropertiesExists)
-        {
-            solverType = "incompressible";
-            DEBUG(adapterInfo("This is an incompressible flow solver, "
-            "as turbulence and transport properties are provided."));
-        }
-        else
-        {
-            adapterInfo("Could not determine the solver type, or this is not "
-            "a compatible solver: although turbulence properties are provided, "
-            "neither transport or thermophysical properties are provided.",
-            "error");
-        }
-    }
-    else
-    {
-        if (transportPropertiesExists)
-        {
-            solverType = "basic";
-            DEBUG(adapterInfo("This is a basic solver, as transport properties "
-            "are provided, while turbulence or transport properties are not "
-            "provided."));
-        }
-        else
-        {
-            adapterInfo("Could not determine the solver type, or this is not a "
-            "compatible solver: neither transport, nor turbulence properties "
-            "are provided.",
-            "error");
-        }
-    }
+    if (solverType == "basic")
+      adapterInfo("Failed to determine the solver type. This might lead to "
+                  "issued during your simulation. Using 'basic' as solver type. "
+                  "Please specify the solver type in the preciceDict file.",
+                  "warning");
 
     return solverType;
 }

--- a/CHT/CHT.C
+++ b/CHT/CHT.C
@@ -102,7 +102,7 @@ std::string preciceAdapter::CHT::ConjugateHeatTransfer::determineSolverType()
 
     if (solverType == "basic")
       adapterInfo("Failed to determine the solver type. This might lead to "
-                  "issued during your simulation. Using 'basic' as solver type. "
+                  "issues during your simulation. Using 'basic' as solver type. "
                   "Please specify the solver type in the preciceDict file.",
                   "warning");
 

--- a/FSI/FSI.C
+++ b/FSI/FSI.C
@@ -27,8 +27,7 @@ bool preciceAdapter::FSI::FluidStructureInteraction::configure(const IOdictionar
     // Check the solver type and determine it if needed
     if (
         solverType_.compare("compressible") == 0 ||
-        solverType_.compare("incompressible") == 0 ||
-        solverType_.compare("basic") == 0
+        solverType_.compare("incompressible") == 0
     )
     {
         DEBUG(adapterInfo("Known solver type: " + solverType_));
@@ -89,11 +88,13 @@ std::string preciceAdapter::FSI::FluidStructureInteraction::determineSolverType(
 
     if (solverType == "unknown")
       adapterInfo("Failed to determine the solver type. "
-                  "Please specify your solver type in the preciceDict. "
-                  "Known solver types for FSI are: "
-                  "Incompressible"
-                  "Compressible",
+                  "Please specify your solver type in the FSI section of the "
+                  "preciceDict. Known solver types for FSI are: "
+                  "incompressible and "
+                  "compressible",
                   "error");
+
+    DEBUG(adapterInfo("Automatically determined solver type : " + solverType));
 
     return solverType;
 }

--- a/FSI/FSI.C
+++ b/FSI/FSI.C
@@ -90,7 +90,7 @@ std::string preciceAdapter::FSI::FluidStructureInteraction::determineSolverType(
     if (solverType == "unknown")
       adapterInfo("Failed to determine the solver type. "
                   "Please specify your solver type in the preciceDict. "
-                  "Known solver types are: "
+                  "Known solver types for FSI are: "
                   "Incompressible"
                   "Compressible"
                   "Basic",

--- a/FSI/FSI.C
+++ b/FSI/FSI.C
@@ -72,24 +72,24 @@ std::string preciceAdapter::FSI::FluidStructureInteraction::determineSolverType(
     // NOTE: When coupling a different variable, you may want to
     // add more cases here. Or you may provide the solverType in the config.
 
-    std::string solverType = "basic";
+    std::string solverType = "unknown";
 
-    dimensionSet compressible_pressure_dimension(1, -1, -2, 0, 0, 0, 0);
-    dimensionSet incompressible_pressure_dimension(0, 2, -2, 0, 0, 0, 0);
+    dimensionSet pressureDimensionsCompressible(1, -1, -2, 0, 0, 0, 0);
+    dimensionSet pressureDimensionsIncompressible(0, 2, -2, 0, 0, 0, 0);
 
     if (mesh_.foundObject<volScalarField>("p"))
     {
       volScalarField p_ = mesh_.lookupObject<volScalarField>("p");
 
-      if (p_.dimensions() == compressible_pressure_dimension)
+      if (p_.dimensions() == pressureDimensionsCompressible)
         solverType = "compressible";
-      else if (p_.dimensions() == incompressible_pressure_dimension)
+      else if (p_.dimensions() == pressureDimensionsIncompressible)
         solverType = "incompressible";
     }
 
-    if (solverType == "basic")
+    if (solverType == "unknown")
       adapterInfo("Failed to determine the solver type. This might lead to "
-                  "issued during your simulation. Using 'basic' as solver type. "
+                  "issues during your simulation. Using 'basic' as solver type. "
                   "Please specify the solver type in the preciceDict file.",
                   "warning");
 

--- a/FSI/FSI.C
+++ b/FSI/FSI.C
@@ -92,8 +92,7 @@ std::string preciceAdapter::FSI::FluidStructureInteraction::determineSolverType(
                   "Please specify your solver type in the preciceDict. "
                   "Known solver types for FSI are: "
                   "Incompressible"
-                  "Compressible"
-                  "Basic",
+                  "Compressible",
                   "error");
 
     return solverType;

--- a/FSI/FSI.C
+++ b/FSI/FSI.C
@@ -88,10 +88,13 @@ std::string preciceAdapter::FSI::FluidStructureInteraction::determineSolverType(
     }
 
     if (solverType == "unknown")
-      adapterInfo("Failed to determine the solver type. This might lead to "
-                  "issues during your simulation. Using 'basic' as solver type. "
-                  "Please specify the solver type in the preciceDict file.",
-                  "warning");
+      adapterInfo("Failed to determine the solver type. "
+                  "Please specify your solver type in the preciceDict. "
+                  "Known solver types are: "
+                  "Incompressible"
+                  "Compressible"
+                  "Basic",
+                  "error");
 
     return solverType;
 }


### PR DESCRIPTION
This PR determines the solver type via the pressure dimension. 

Here a few comments, following from our discussion in #31:

The type 'basic' is assumed instead of naming it 'other'. So we raise a warning and tell the user, that he might get issues with this settings. I preferred now 'basic', since this is an actual OpenFOAM type and the user might (or not) be fine with the settings. If we tell the user, that we calculate with type 'other', no one knows what this means without looking in the code.

I added the checker in the module classes and decided not to pass it in the adapter class, because we first read the configuration in the specific module and start afterwards to determine the type 'automatically' and we cannot access (without passing the whole class) the adapter class in the modules.
EDIT: We could determine it in the adapter class and overwrite it in the modules. 

However, there are just some conceptual questions. The general ingredients should be fine.

Closes #31.