### PR TITLE
Support stress data

### DIFF
--- a/FSI/FSI.C
+++ b/FSI/FSI.C
@@ -188,6 +188,16 @@ void preciceAdapter::FSI::FluidStructureInteraction::addWriters(std::string data
         );
         DEBUG(adapterInfo("Added writer: Displacement."));
     }
+    else if(dataName.find("Stress") == 0)
+    {
+      interface->addCouplingDataWriter
+          (
+              dataName,
+              new Stress(mesh_, runTime_.timeName(), solverType_) /* TODO: Add any other arguments here */
+              );
+      DEBUG(adapterInfo("Added writer: Stress."));
+    }
+    // TODO: Add an exception for else
 
     // NOTE: If you want to couple another variable, you need
     // to add your new coupling data user as a coupling data
@@ -225,6 +235,17 @@ void preciceAdapter::FSI::FluidStructureInteraction::addReaders(std::string data
         );
         DEBUG(adapterInfo("Added reader: Displacement."));
     }
+    else if(dataName.find("Stress") == 0)
+    {
+      interface->addCouplingDataReader
+          (
+              dataName,
+              new Stress(mesh_, runTime_.timeName(), solverType_) /* TODO: Add any other arguments here */
+              );
+      DEBUG(adapterInfo("Added reader: Stress."));
+    }
+    // TODO: Add an exception for else
+
     // NOTE: If you want to couple another variable, you need
     // to add your new coupling data user as a coupling data
     // writer here (and as a writer above).

--- a/FSI/FSI.C
+++ b/FSI/FSI.C
@@ -197,7 +197,6 @@ void preciceAdapter::FSI::FluidStructureInteraction::addWriters(std::string data
               );
       DEBUG(adapterInfo("Added writer: Stress."));
     }
-    // TODO: Add an exception for else
 
     // NOTE: If you want to couple another variable, you need
     // to add your new coupling data user as a coupling data
@@ -244,7 +243,6 @@ void preciceAdapter::FSI::FluidStructureInteraction::addReaders(std::string data
               );
       DEBUG(adapterInfo("Added reader: Stress."));
     }
-    // TODO: Add an exception for else
 
     // NOTE: If you want to couple another variable, you need
     // to add your new coupling data user as a coupling data

--- a/FSI/FSI.H
+++ b/FSI/FSI.H
@@ -6,6 +6,7 @@
 #include "FSI/Displacement.H"
 #include "FSI/DisplacementDelta.H"
 #include "FSI/Force.H"
+#include "FSI/Stress.H"
 
 #include "fvCFD.H"
 

--- a/FSI/Force.C
+++ b/FSI/Force.C
@@ -178,7 +178,7 @@ Foam::tmp<Foam::volScalarField> preciceAdapter::FSI::Force::mu() const
     }
 }
 
-void preciceAdapter::FSI::Force::write(double * buffer, bool /*meshConnectivity*/, const unsigned int dim)
+void preciceAdapter::FSI::Force::write(double * buffer, bool meshConnectivity, const unsigned int dim)
 {
     // Compute forces. See the Forces function object.
 
@@ -255,7 +255,7 @@ void preciceAdapter::FSI::Force::write(double * buffer, bool /*meshConnectivity*
     }
 }
 
-void preciceAdapter::FSI::Force::read(double * /*buffer*/, const unsigned int /*dim*/)
+void preciceAdapter::FSI::Force::read(double * buffer, const unsigned int dim)
 {
     /* TODO: Implement
     * We need two nested for-loops for each patch,

--- a/FSI/Force.C
+++ b/FSI/Force.C
@@ -4,6 +4,17 @@ using namespace Foam;
 
 preciceAdapter::FSI::Force::Force
 (
+        const Foam::fvMesh& mesh,
+        const std::string solverType
+)
+:
+mesh_(mesh),solverType_(solverType)
+{}
+
+
+
+preciceAdapter::FSI::Force::Force
+(
     const Foam::fvMesh& mesh,
     const fileName& timeName,
     const std::string solverType
@@ -167,7 +178,7 @@ Foam::tmp<Foam::volScalarField> preciceAdapter::FSI::Force::mu() const
     }
 }
 
-void preciceAdapter::FSI::Force::write(double * buffer, bool meshConnectivity, const unsigned int dim)
+void preciceAdapter::FSI::Force::write(double * buffer, bool /*meshConnectivity*/, const unsigned int dim)
 {
     // Compute forces. See the Forces function object.
 
@@ -244,7 +255,7 @@ void preciceAdapter::FSI::Force::write(double * buffer, bool meshConnectivity, c
     }
 }
 
-void preciceAdapter::FSI::Force::read(double * buffer, const unsigned int dim)
+void preciceAdapter::FSI::Force::read(double * /*buffer*/, const unsigned int /*dim*/)
 {
     /* TODO: Implement
     * We need two nested for-loops for each patch,

--- a/FSI/Force.C
+++ b/FSI/Force.C
@@ -12,7 +12,6 @@ mesh_(mesh),solverType_(solverType)
 {}
 
 
-
 preciceAdapter::FSI::Force::Force
 (
     const Foam::fvMesh& mesh,
@@ -24,8 +23,7 @@ preciceAdapter::FSI::Force::Force
     */
 )
 :
-mesh_(mesh),
-solverType_(solverType)
+Force(mesh, solverType)
 {
     //What about type "basic"?
     if (solverType_.compare("incompressible") != 0 && solverType_.compare("compressible") != 0) 

--- a/FSI/Force.H
+++ b/FSI/Force.H
@@ -5,7 +5,6 @@
 
 #include "fvCFD.H"
 
-// TEMPORARY
 #include "pointFields.H"
 #include "vectorField.H"
 #include "immiscibleIncompressibleTwoPhaseMixture.H"

--- a/FSI/Force.H
+++ b/FSI/Force.H
@@ -64,10 +64,10 @@ public:
     );
 
     //- Write the displacement values into the buffer
-    virtual void write(double * buffer, bool meshConnectivity, const unsigned int dim);
+    void write(double * buffer, bool meshConnectivity, const unsigned int dim);
 
     //- Read the displacement values from the buffer
-    virtual void read(double * buffer, const unsigned int dim);
+    void read(double * buffer, const unsigned int dim);
 
     //- Destructor
     ~Force();

--- a/FSI/Force.H
+++ b/FSI/Force.H
@@ -62,10 +62,10 @@ public:
         const std::string solverType
     );
 
-    //- Write the displacement values into the buffer
+    //- Write the forces values into the buffer
     void write(double * buffer, bool meshConnectivity, const unsigned int dim);
 
-    //- Read the displacement values from the buffer
+    //- Read the forces values from the buffer
     void read(double * buffer, const unsigned int dim);
 
     //- Destructor

--- a/FSI/Stress.C
+++ b/FSI/Stress.C
@@ -1,0 +1,142 @@
+#include "Stress.H"
+
+using namespace Foam;
+
+preciceAdapter::FSI::Stress::Stress
+(
+    const Foam::fvMesh& mesh,
+    const fileName& timeName,
+    const std::string solverType
+    /* TODO: We should add any required field names here.
+    /  They would need to be vector fields.
+    /  See FSI/Temperature.C for details.
+    */
+)
+:
+Force(mesh,solverType),
+mesh_(mesh),
+solverType_(solverType)
+{
+    //What about type "basic"?
+    if (solverType_.compare("incompressible") != 0 && solverType_.compare("compressible") != 0) 
+    {
+        FatalErrorInFunction
+            << "Forces calculation does only support "
+            << "compressible or incompressible solver type."
+            << exit(FatalError);
+    }
+    
+    dataType_ = vector;
+
+    Stress_ = new volVectorField
+    (
+        IOobject
+        (
+            "Stress",
+            timeName,
+            mesh,
+            IOobject::NO_READ,
+            IOobject::AUTO_WRITE
+        ),
+        mesh,
+        dimensionedVector
+        (
+            "pdim",
+            dimensionSet(1,-1,-2,0,0,0,0),
+            Foam::vector::zero
+        )
+    );
+}
+
+void preciceAdapter::FSI::Stress::write(double * buffer, bool /*meshConnectivity*/, const unsigned int dim)
+{
+    // Compute stress. See the Forces function object.
+
+    // Stress tensor boundary field
+    tmp<volSymmTensorField> tdevRhoReff = this->devRhoReff();
+    const volSymmTensorField::Boundary& devRhoReffb =
+        tdevRhoReff().boundaryField();
+
+    // Density boundary field
+    tmp<volScalarField> trho = this->rho();
+    const volScalarField::Boundary& rhob =
+        trho().boundaryField();
+
+    // Pressure boundary field
+    tmp<volScalarField> tp = mesh_.lookupObject<volScalarField>("p");
+    const volScalarField::Boundary& pb =
+        tp().boundaryField();        
+
+    int bufferIndex = 0;
+    // For every boundary patch of the interface
+    for (uint j = 0; j < patchIDs_.size(); j++)
+    {
+
+        int patchID = patchIDs_.at(j);
+
+        // Compute normal vectors on each patch
+        const vectorField nV = mesh_.boundary()[patchID].nf();
+
+        // Pressure constribution
+        if (solverType_.compare("incompressible") == 0)
+        {
+            Stress_->boundaryFieldRef()[patchID] =
+                nV * pb[patchID] * rhob[patchID];
+        }
+        else if (solverType_.compare("compressible") == 0)
+        {
+            Stress_->boundaryFieldRef()[patchID] =
+                nV * pb[patchID];
+        }
+        else
+        {
+            FatalErrorInFunction
+                << "Stress calculation does only support "
+                << "compressible or incompressible solver type."
+                << exit(FatalError);
+        }
+
+        // Viscous forces
+        Stress_->boundaryFieldRef()[patchID] +=
+            nV & devRhoReffb[patchID];
+
+        // Write the forces to the preCICE buffer
+        // For every cell of the patch
+        forAll(Stress_->boundaryFieldRef()[patchID], i)
+        {
+            // Copy the force into the buffer
+            // x-dimension
+            buffer[bufferIndex++]
+            = 
+            Stress_->boundaryFieldRef()[patchID][i].x();
+
+            // y-dimension
+            buffer[bufferIndex++]
+            =
+            Stress_->boundaryFieldRef()[patchID][i].y();
+
+            if(dim == 3)
+                // z-dimension
+                buffer[bufferIndex++]
+                        =
+                        Stress_->boundaryFieldRef()[patchID][i].z();
+        }
+    }
+}
+
+void preciceAdapter::FSI::Stress::read(double * /*buffer*/, const unsigned int /*dim*/)
+{
+    /* TODO: Implement
+    * We need two nested for-loops for each patch,
+    * the outer for the locations and the inner for the dimensions.
+    * See the preCICE readBlockVectorData() implementation.
+    */
+    FatalErrorInFunction
+        << "Reading stresses is not supported."
+        << exit(FatalError);
+}
+
+preciceAdapter::FSI::Stress::~Stress()
+{
+    delete Stress_;
+}

--- a/FSI/Stress.C
+++ b/FSI/Stress.C
@@ -21,7 +21,7 @@ solverType_(solverType)
     if (solverType_.compare("incompressible") != 0 && solverType_.compare("compressible") != 0) 
     {
         FatalErrorInFunction
-            << "Forces calculation does only support "
+            << "Stresses calculation only supports "
             << "compressible or incompressible solver type."
             << exit(FatalError);
     }

--- a/FSI/Stress.C
+++ b/FSI/Stress.C
@@ -95,15 +95,15 @@ void preciceAdapter::FSI::Stress::write(double * buffer, bool meshConnectivity, 
                 << exit(FatalError);
         }
 
-        // Viscous forces
+        // Viscous contribution
         Stress_->boundaryFieldRef()[patchID] +=
             nV & devRhoReffb[patchID];
 
-        // Write the forces to the preCICE buffer
+        // Write the stress to the preCICE buffer
         // For every cell of the patch
         forAll(Stress_->boundaryFieldRef()[patchID], i)
         {
-            // Copy the force into the buffer
+            // Copy the stress into the buffer
             // x-dimension
             buffer[bufferIndex++]
             = 

--- a/FSI/Stress.C
+++ b/FSI/Stress.C
@@ -17,8 +17,7 @@ Force(mesh,solverType),
 mesh_(mesh),
 solverType_(solverType)
 {
-    //What about type "basic"?
-    if (solverType_.compare("incompressible") != 0 && solverType_.compare("compressible") != 0) 
+    if (solverType_.compare("incompressible") != 0 && solverType_.compare("compressible") != 0)
     {
         FatalErrorInFunction
             << "Stresses calculation only supports "
@@ -48,7 +47,7 @@ solverType_(solverType)
     );
 }
 
-void preciceAdapter::FSI::Stress::write(double * buffer, bool /*meshConnectivity*/, const unsigned int dim)
+void preciceAdapter::FSI::Stress::write(double * buffer, bool meshConnectivity, const unsigned int dim)
 {
     // Compute stress. See the Forces function object.
 
@@ -124,7 +123,7 @@ void preciceAdapter::FSI::Stress::write(double * buffer, bool /*meshConnectivity
     }
 }
 
-void preciceAdapter::FSI::Stress::read(double * /*buffer*/, const unsigned int /*dim*/)
+void preciceAdapter::FSI::Stress::read(double * buffer, const unsigned int dim)
 {
     /* TODO: Implement
     * We need two nested for-loops for each patch,

--- a/FSI/Stress.H
+++ b/FSI/Stress.H
@@ -1,7 +1,8 @@
-#ifndef FSI_FORCE_H
-#define FSI_FORCE_H
+#ifndef FSI_STRESS_H
+#define FSI_STRESS_H
 
 #include "CouplingDataUser.H"
+#include "Force.H"
 
 #include "fvCFD.H"
 
@@ -18,7 +19,7 @@ namespace FSI
 {
 
 //- Class that writes and reads force
-class Force : public CouplingDataUser
+class Stress : public Force
 {
 
 private:
@@ -28,22 +29,14 @@ private:
     
     const std::string solverType_;
 
-    //- Force field
-    Foam::volVectorField * Force_;
-
-protected:
-    //- Stress tensor (see the OpenFOAM "Forces" function object)
-    Foam::tmp<Foam::volSymmTensorField> devRhoReff() const;
-    
-    Foam::tmp<Foam::volScalarField> rho() const;
-    
-    Foam::tmp<Foam::volScalarField> mu() const;
+    //- Stress field
+    Foam::volVectorField * Stress_;
 
 
 public:
 
     //- Constructor
-    Force
+    Stress
     (
         const Foam::fvMesh& mesh,
         const fileName& timeName,
@@ -56,21 +49,15 @@ public:
         */
     );
 
-    //- Constructor
-    Force
-    (
-        const Foam::fvMesh& mesh,
-        const std::string solverType
-    );
-
     //- Write the displacement values into the buffer
-    virtual void write(double * buffer, bool meshConnectivity, const unsigned int dim);
+    void write
+    (double * buffer, bool meshConnectivity, const unsigned int dim) override;
 
     //- Read the displacement values from the buffer
-    virtual void read(double * buffer, const unsigned int dim);
+    void read(double * buffer, const unsigned int dim) override;
 
     //- Destructor
-    ~Force();
+    ~Stress();
 
 };
 

--- a/FSI/Stress.H
+++ b/FSI/Stress.H
@@ -17,9 +17,12 @@ namespace preciceAdapter
 namespace FSI
 {
 
-//- Class that writes and reads force
-class Stress : public Force
-{
+//- Class that writes and reads stress [N/m^2]:
+// This is essentially a force (in spatial coordinates) scaled by the deformed
+// cell face. Thus, a conservative quantity. Calculation concept has been copied
+// from the force module, but the scaled version here is commonly used in FEM
+// applications.
+class Stress : public Force {
 
 private:
 
@@ -42,24 +45,19 @@ public:
         const std::string solverType
         // We create an IOobject and we need the time directory
         /* TODO: We should add any required field names here.
-        /  They would need to be vector fields.
-        /  See CHT/Temperature.H for details.
-        /  Apply any changes also to Force.C.
         */
     );
 
-    //- Write the displacement values into the buffer
+    //- Write the stress values into the buffer
     void write
     (double * buffer, bool meshConnectivity, const unsigned int dim);
 
-    //- Read the displacement values from the buffer
+    //- Read the stress values from the buffer
     void read(double * buffer, const unsigned int dim);
 
     //- Destructor
     ~Stress();
-
 };
-
 }
 }
 

--- a/FSI/Stress.H
+++ b/FSI/Stress.H
@@ -51,10 +51,10 @@ public:
 
     //- Write the displacement values into the buffer
     void write
-    (double * buffer, bool meshConnectivity, const unsigned int dim) override;
+    (double * buffer, bool meshConnectivity, const unsigned int dim);
 
     //- Read the displacement values from the buffer
-    void read(double * buffer, const unsigned int dim) override;
+    void read(double * buffer, const unsigned int dim);
 
     //- Destructor
     ~Stress();

--- a/FSI/Stress.H
+++ b/FSI/Stress.H
@@ -6,7 +6,6 @@
 
 #include "fvCFD.H"
 
-// TEMPORARY
 #include "pointFields.H"
 #include "vectorField.H"
 #include "immiscibleIncompressibleTwoPhaseMixture.H"

--- a/FSI/Stress.H
+++ b/FSI/Stress.H
@@ -19,7 +19,7 @@ namespace FSI
 
 //- Class that writes and reads stress [N/m^2]:
 // This is essentially a force (in spatial coordinates) scaled by the deformed
-// cell face. Thus, a conservative quantity. Calculation concept has been copied
+// cell face. Thus, a consistent quantity. Calculation concept has been copied
 // from the force module, but the scaled version here is commonly used in FEM
 // applications.
 class Stress : public Force {

--- a/FSI/Stress.H
+++ b/FSI/Stress.H
@@ -49,8 +49,7 @@ public:
     );
 
     //- Write the stress values into the buffer
-    void write
-    (double * buffer, bool meshConnectivity, const unsigned int dim);
+    void write(double * buffer, bool meshConnectivity, const unsigned int dim);
 
     //- Read the stress values from the buffer
     void read(double * buffer, const unsigned int dim);

--- a/Make/files
+++ b/Make/files
@@ -14,6 +14,7 @@ CHT/CHT.C
 
 FSI/FSI.C
 FSI/Force.C
+FSI/Stress.C
 FSI/Displacement.C
 FSI/DisplacementDelta.C
 


### PR DESCRIPTION
This PR adds an option for users to map stresses instead of forces.

 I tried to balance the similarity between the existing forces module by inheriting it and reuse some existing functionalities there Therefore, it still has its own class (as usual for each data module). The stress calculation is very similar: The multiplication by the face are is skipped and a normal vector is used instead.

The code runs, but it is not testes yet.

Closes #41.