### PR TITLE
Adapt KappaEffective to new transport/thermophysical model structure (OpenFOAM 8)

### DIFF
--- a/CHT/HeatFlux.C
+++ b/CHT/HeatFlux.C
@@ -138,7 +138,7 @@ preciceAdapter::CHT::HeatFlux_Incompressible::HeatFlux_Incompressible(
     const std::string namePr,
     const std::string nameAlphat)
 : HeatFlux(mesh, nameT),
-  Kappa_(new KappaEff_Incompressible(mesh, nameRho, nameCp, namePr, nameAlphat))
+  Kappa_(new KappaEff_Incompressible(mesh))
 {
 }
 

--- a/CHT/HeatTransferCoefficient.C
+++ b/CHT/HeatTransferCoefficient.C
@@ -156,7 +156,7 @@ preciceAdapter::CHT::HeatTransferCoefficient_Incompressible::
         const std::string namePr,
         const std::string nameAlphat)
 : HeatTransferCoefficient(mesh, nameT),
-  Kappa_(new KappaEff_Incompressible(mesh, nameRho, nameCp, namePr, nameAlphat))
+  Kappa_(new KappaEff_Incompressible(mesh))
 {
 }
 

--- a/CHT/KappaEffective.C
+++ b/CHT/KappaEffective.C
@@ -10,8 +10,8 @@ using namespace Foam;
 preciceAdapter::CHT::KappaEff_Compressible::KappaEff_Compressible(
     const Foam::fvMesh& mesh)
 : mesh_(mesh),
-  turbulence_(
-      mesh.lookupObject<compressible::turbulenceModel>(turbulenceModel::propertiesName))
+  thermophysicalTransportModel_(
+      mesh.lookupObject<thermophysicalTransportModel>(thermophysicalTransportModel::typeName))
 {
     DEBUG(adapterInfo("Constructed KappaEff_Compressible."));
 }
@@ -24,12 +24,12 @@ void preciceAdapter::CHT::KappaEff_Compressible::extract(uint patchID, bool mesh
         primitivePatchInterpolation patchInterpolator(mesh_.boundaryMesh()[patchID]);
 
         //Interpolate kappaEff_ from centers to nodes
-        kappaEff_ = patchInterpolator.faceToPointInterpolate(turbulence_.kappaEff()().boundaryField()[patchID]);
+        kappaEff_ = patchInterpolator.faceToPointInterpolate(thermophysicalTransportModel_.kappaEff()().boundaryField()[patchID]);
     }
     else
     {
-        // Extract kappaEff_ from the turbulence model
-        kappaEff_ = turbulence_.kappaEff()().boundaryField()[patchID];
+        // Extract kappaEff_ from the thermophysical transport model
+        kappaEff_ = thermophysicalTransportModel_.kappaEff()().boundaryField()[patchID];
     }
 }
 
@@ -42,116 +42,28 @@ scalar preciceAdapter::CHT::KappaEff_Compressible::getAt(int i)
 //----- preciceAdapter::CHT::KappaEff_Incompressible ------------------
 
 preciceAdapter::CHT::KappaEff_Incompressible::KappaEff_Incompressible(
-    const Foam::fvMesh& mesh,
-    const std::string nameRho,
-    const std::string nameCp,
-    const std::string namePr,
-    const std::string nameAlphat)
+    const Foam::fvMesh& mesh)
 : mesh_(mesh),
-  turbulence_(
-      mesh.lookupObject<incompressible::turbulenceModel>(turbulenceModel::propertiesName)),
-  nameRho_(nameRho),
-  nameCp_(nameCp),
-  namePr_(namePr),
-  nameAlphat_(nameAlphat)
+  thermophysicalTransportModel_(
+      mesh.lookupObject<thermophysicalTransportModel>(thermophysicalTransportModel::typeName))
 {
     DEBUG(adapterInfo("Constructed KappaEff_Incompressible."));
-    DEBUG(adapterInfo("  Name of density: " + nameRho_));
-    DEBUG(adapterInfo("  Name of heat capacity: " + nameCp_));
-    DEBUG(adapterInfo("  Name of Prandl number: " + namePr_));
-    DEBUG(adapterInfo("  Name of turbulent thermal diffusivity: " + nameAlphat_));
-
-    // Get the preciceDict/CHT dictionary
-    const dictionary CHTDict =
-        mesh_.lookupObject<IOdictionary>("preciceDict").subOrEmptyDict("CHT");
-
-    // Read the Prandtl number
-    if (!CHTDict.readIfPresent<dimensionedScalar>(namePr_, Pr_))
-    {
-        adapterInfo(
-            "Cannot find the Prandtl number in preciceDict/CHT using the name " + namePr_,
-            "error");
-    }
-    else
-    {
-        DEBUG(adapterInfo("  Pr = " + std::to_string(Pr_.value())));
-    }
-
-    // Read the density
-    if (!CHTDict.readIfPresent<dimensionedScalar>(nameRho_, rho_))
-    {
-        adapterInfo(
-            "Cannot find the density in preciceDict/CHT using the name " + nameRho_,
-            "error");
-    }
-    else
-    {
-        DEBUG(adapterInfo("  rho = " + std::to_string(rho_.value())));
-    }
-
-    // Read the heat capacity
-    if (!CHTDict.readIfPresent<dimensionedScalar>(nameCp_, Cp_))
-    {
-        adapterInfo(
-            "Cannot find the heat capacity in preciceDict/CHT using the name " + nameCp_,
-            "error");
-    }
-    else
-    {
-        DEBUG(adapterInfo("  Cp = " + std::to_string(Cp_.value())));
-    }
 }
 
 void preciceAdapter::CHT::KappaEff_Incompressible::extract(uint patchID, bool meshConnectivity)
 {
-    // Compute kappaEff_ from the turbulence model, using alpha and Prandl
-
-    // Get the laminar viscosity from the turbulence model
-    // TODO: Do we really need turbulence at the end?
-    const scalarField& nu(
-        turbulence_.nu()().boundaryField()[patchID]);
-
-    // Compute the effective thermal diffusivity
-    // (alphaEff = alpha + alphat = nu / Pr + nut / Prt)
-
-    scalarField alphaEff;
-
-    // Does the turbulent thermal diffusivity exist in the object registry?
-    if (mesh_.foundObject<volScalarField>(nameAlphat_))
-    {
-        const scalarField& alphat(
-            mesh_.lookupObject<volScalarField>(nameAlphat_).boundaryField()[patchID]);
-
-        alphaEff = nu / Pr_.value() + alphat;
-    }
-    else
-    {
-        WarningInFunction
-            << "The object alphat does not exist. "
-            << "An incompressible solver should create it explicitly "
-            << "(e.g. in the createFields.H)."
-            << "Assuming only the laminar part of the thermal diffusivity."
-            << nl;
-
-        alphaEff = nu / Pr_.value();
-    }
-
-    // Compute the effective thermal conductivity and store it in a temp variable
-    scalarField kappaEff_temp(
-        alphaEff * rho_.value() * Cp_.value());
-
     if (meshConnectivity)
     {
         //Create an Interpolation object at the boundary Field
         primitivePatchInterpolation patchInterpolator(mesh_.boundaryMesh()[patchID]);
 
-        //Interpolate kappaEff_ from centers to nodes, if desired
-        kappaEff_ = patchInterpolator.faceToPointInterpolate(kappaEff_temp);
+        //Interpolate kappaEff_ from centers to nodes
+        kappaEff_ = patchInterpolator.faceToPointInterpolate(thermophysicalTransportModel_.kappaEff()().boundaryField()[patchID]);
     }
     else
     {
-        // if no interpolation
-        kappaEff_ = kappaEff_temp;
+        // Extract kappaEff_ from the thermophysical transport model
+        kappaEff_ = thermophysicalTransportModel_.kappaEff()().boundaryField()[patchID];
     }
 }
 

--- a/CHT/KappaEffective.H
+++ b/CHT/KappaEffective.H
@@ -1,8 +1,9 @@
 #ifndef CHT_COMMON_KAPPAEFF_H
 #define CHT_COMMON_KAPPAEFF_H
 
-#include "turbulentFluidThermoModel.H"
-#include "turbulentTransportModel.H"
+#include "fluidThermoMomentumTransportModel.H"
+#include "kinematicMomentumTransportModel.H"
+#include "thermophysicalTransportModel.H"
 
 namespace preciceAdapter
 {
@@ -21,9 +22,8 @@ protected:
     //- Effective conductivity (it can be different for each cell)
     Foam::scalarField kappaEff_;
 
-    //- Turbulence (and thermo/transport) model, from which
-    //  kappaEff is drawn directly.
-    const Foam::compressible::turbulenceModel& turbulence_;
+    //- Thermophysical transport model, from which kappaEff is drawn directly.
+    const Foam::thermophysicalTransportModel& thermophysicalTransportModel_;
 
 public:
     //- Constructor
@@ -48,40 +48,13 @@ protected:
     //- Effective conductivity (it can be different for each cell)
     Foam::scalarField kappaEff_;
 
-    //- Turbulence (and thermo/transport) model.
-    //  The effective thermal diffusivity is drawn from it and
-    //  used to compute the effective thermal conductivity.
-    const Foam::incompressible::turbulenceModel& turbulence_;
-
-    //- Name of the user-provided density (in the preciceDict)
-    const std::string nameRho_;
-
-    //- Name of the user-provided heat capacity (in the preciceDict)
-    const std::string nameCp_;
-
-    //- Name of the user-provided Prandtl number (in the preciceDict)
-    const std::string namePr_;
-
-    //- Name of the turbulent thermal diffusivity field
-    const std::string nameAlphat_;
-
-    //- Density
-    Foam::dimensionedScalar rho_;
-
-    //- Heat capacity
-    Foam::dimensionedScalar Cp_;
-
-    //- Prandtl number
-    Foam::dimensionedScalar Pr_;
+    //- Thermophysical transport model, from which kappaEff is drawn directly.
+    const Foam::thermophysicalTransportModel& thermophysicalTransportModel_;
 
 public:
     //- Constructor
     KappaEff_Incompressible(
-        const Foam::fvMesh& mesh,
-        const std::string nameRho,
-        const std::string nameCp,
-        const std::string namePr,
-        const std::string nameAlphat);
+        const Foam::fvMesh& mesh);
 
     //- Extract the kappaEff on the specific patch and store it.
     void extract(uint patchID, bool meshConnectivity);

--- a/FSI/ForceBase.H
+++ b/FSI/ForceBase.H
@@ -8,9 +8,8 @@
 
 #include "pointFields.H"
 #include "vectorField.H"
-#include "immiscibleIncompressibleTwoPhaseMixture.H"
-#include "turbulentFluidThermoModel.H"
-#include "turbulentTransportModel.H"
+#include "fluidThermoMomentumTransportModel.H"
+#include "kinematicMomentumTransportModel.H"
 
 namespace preciceAdapter
 {

--- a/Make/options
+++ b/Make/options
@@ -2,15 +2,12 @@ EXE_INC = \
     -I$(LIB_SRC)/finiteVolume/lnInclude \
     -I$(LIB_SRC)/meshTools/lnInclude \
     -I$(LIB_SRC)/transportModels/ \
-    -I$(LIB_SRC)/transportModels/incompressible/lnInclude \
-    -I$(LIB_SRC)/transportModels/compressible/lnInclude \
-    -I$(LIB_SRC)/transportModels/twoPhaseMixture/lnInclude \
-    -I$(LIB_SRC)/transportModels/interfaceProperties/lnInclude \
-    -I$(LIB_SRC)/transportModels/immiscibleIncompressibleTwoPhaseMixture/lnInclude \
     -I$(LIB_SRC)/thermophysicalModels/basic/lnInclude \
-    -I$(LIB_SRC)/TurbulenceModels/turbulenceModels/lnInclude \
-    -I$(LIB_SRC)/TurbulenceModels/compressible/lnInclude \
-    -I$(LIB_SRC)/TurbulenceModels/incompressible/lnInclude \
+    -I$(LIB_SRC)/ThermophysicalTransportModels/lnInclude \
+    -I$(LIB_SRC)/MomentumTransportModels/momentumTransportModels/lnInclude \
+    -I$(LIB_SRC)/MomentumTransportModels/compressible/lnInclude \
+    -I$(LIB_SRC)/MomentumTransportModels/incompressible/lnInclude \
+    -I$(LIB_SRC)/transportModels/lnInclude \
     -I$(LIB_SRC)/triSurface/lnInclude \
     $(ADAPTER_PKG_CONFIG_CFLAGS) \
     -I../ \
@@ -19,8 +16,9 @@ EXE_INC = \
 LIB_LIBS = \
     -lfiniteVolume \
     -lmeshTools \
-    -lcompressibleTurbulenceModels \
-    -lincompressibleTurbulenceModels \
+    -lthermophysicalTransportModels \
+    -lfluidThermoMomentumTransportModels \
+    -lincompressibleMomentumTransportModels \
     -limmiscibleIncompressibleTwoPhaseMixture \
     $(ADAPTER_PKG_CONFIG_LIBS) \
     -lprecice


### PR DESCRIPTION
An work-in-progress attempt to port the adapter to the latest (April/May 2020) changes in OpenFOAM-dev (openfoam.org).

This is related to #129.