### PR TITLE
Replace non-const boundaryFieldRef wherever possible

### DIFF
--- a/CHT/HeatFlux.C
+++ b/CHT/HeatFlux.C
@@ -33,11 +33,11 @@ void preciceAdapter::CHT::HeatFlux::write(double * buffer, bool meshConnectivity
     {
         int patchID = patchIDs_.at(j);
 
-        scalarField gradientPatch
+        const scalarField & gradientPatch
         (
-            refCast<fixedValueFvPatchScalarField>
+            refCast<const fixedValueFvPatchScalarField>
             (
-                T_->boundaryFieldRef()[patchID]
+                T_->boundaryField()[patchID]
             ).snGrad()
         );
 

--- a/CHT/HeatFlux.C
+++ b/CHT/HeatFlux.C
@@ -33,9 +33,13 @@ void preciceAdapter::CHT::HeatFlux::write(double * buffer, bool meshConnectivity
     {
         int patchID = patchIDs_.at(j);
 
-        scalarField gradientPatch=refCast<fixedValueFvPatchScalarField>
-                (T_->boundaryFieldRef()[patchID]
-                 ).snGrad();
+        scalarField gradientPatch
+        (
+            refCast<fixedValueFvPatchScalarField>
+            (
+                T_->boundaryFieldRef()[patchID]
+            ).snGrad()
+        );
 
         // Extract the effective conductivity on the patch
         extractKappaEff(patchID, meshConnectivity);
@@ -94,11 +98,12 @@ void preciceAdapter::CHT::HeatFlux::read(double * buffer, const unsigned int dim
 
         // Get the temperature gradient boundary patch
         scalarField & gradientPatch
-                =
-                refCast<fixedGradientFvPatchScalarField>
-                (
-                    T_->boundaryFieldRef()[patchID]
-                    ).gradient();
+        (
+            refCast<fixedGradientFvPatchScalarField>
+            (
+                T_->boundaryFieldRef()[patchID]
+            ).gradient()
+        );
 
         // For every cell of the patch
         forAll(gradientPatch, i)

--- a/CHT/HeatFlux.C
+++ b/CHT/HeatFlux.C
@@ -33,7 +33,7 @@ void preciceAdapter::CHT::HeatFlux::write(double * buffer, bool meshConnectivity
     {
         int patchID = patchIDs_.at(j);
 
-        const scalarField & gradientPatch
+        const scalarField gradientPatch
         (
             refCast<const fixedValueFvPatchScalarField>
             (

--- a/CHT/HeatTransferCoefficient.C
+++ b/CHT/HeatTransferCoefficient.C
@@ -39,7 +39,10 @@ void preciceAdapter::CHT::HeatTransferCoefficient::write(double * buffer, bool m
         extractKappaEff(patchID, meshConnectivity);
 
         // Get the face-cell distance coefficients on the patch
-        const scalarField & delta = mesh_.boundary()[patchID].deltaCoeffs();
+        const scalarField & delta
+        (
+            mesh_.boundary()[patchID].deltaCoeffs()
+        );
 
         //If we use the mesh connectivity, we interpolate from the centres to the nodes
         if(meshConnectivity)
@@ -91,11 +94,19 @@ void preciceAdapter::CHT::HeatTransferCoefficient::read(double * buffer, const u
         extractKappaEff(patchID,/*meshConnectivity=*/false);
 
         // Get the face-cell distance coefficients on the patch
-        const scalarField & delta = mesh_.boundary()[patchID].deltaCoeffs();
+        const scalarField & delta
+        (
+            mesh_.boundary()[patchID].deltaCoeffs()
+        );
 
         // Get a reference to the temperature on the patch
-        mixedFvPatchScalarField & TPatch =
-                refCast<mixedFvPatchScalarField>(T_->boundaryFieldRef()[patchID]);
+        mixedFvPatchScalarField & TPatch
+        (
+            refCast<mixedFvPatchScalarField>
+            (
+                T_->boundaryFieldRef()[patchID]
+            )
+        );
 
         // For every cell on the patch
         forAll(TPatch, i)

--- a/CHT/KappaEffective.C
+++ b/CHT/KappaEffective.C
@@ -125,7 +125,10 @@ void preciceAdapter::CHT::KappaEff_Incompressible::extract(uint patchID, bool me
 
     // Get the laminar viscosity from the turbulence model
     // TODO: Do we really need turbulence at the end?
-    const scalarField & nu = turbulence_.nu() ().boundaryField()[patchID];
+    const scalarField & nu
+    (
+        turbulence_.nu() ().boundaryField()[patchID]
+    );
 
     // Compute the effective thermal diffusivity
     // (alphaEff = alpha + alphat = nu / Pr + nut / Prt)
@@ -135,8 +138,10 @@ void preciceAdapter::CHT::KappaEff_Incompressible::extract(uint patchID, bool me
     // Does the turbulent thermal diffusivity exist in the object registry?
     if (mesh_.foundObject<volScalarField>(nameAlphat_))
     {
-        const scalarField & alphat =
-            mesh_.lookupObject<volScalarField>(nameAlphat_).boundaryField()[patchID];
+        const scalarField & alphat
+        (
+            mesh_.lookupObject<volScalarField>(nameAlphat_).boundaryField()[patchID]
+        );
 
         alphaEff = nu / Pr_.value() + alphat;
     }
@@ -153,7 +158,10 @@ void preciceAdapter::CHT::KappaEff_Incompressible::extract(uint patchID, bool me
     }
 
     // Compute the effective thermal conductivity and store it in a temp variable
-    scalarField kappaEff_temp = alphaEff * rho_.value() * Cp_.value();
+    scalarField kappaEff_temp
+    (
+        alphaEff * rho_.value() * Cp_.value()
+    );
 
     if(meshConnectivity)
     {

--- a/CHT/SinkTemperature.C
+++ b/CHT/SinkTemperature.C
@@ -31,11 +31,13 @@ void preciceAdapter::CHT::SinkTemperature::write(double * buffer, bool meshConne
         int patchID = patchIDs_.at(j);
 
         // Get the boundary field of Temperature on the patch
-        fvPatchScalarField & TPatch =
-                refCast<fvPatchScalarField>
-                (
-                    T_->boundaryFieldRef()[patchID]
-                    );
+        fvPatchScalarField & TPatch
+        (
+            refCast<fvPatchScalarField>
+            (
+                T_->boundaryFieldRef()[patchID]
+            )
+        );
 
         // Get the internal field next to the patch // TODO: Simplify?
         tmp<scalarField> patchInternalFieldTmp = TPatch.patchInternalField();
@@ -88,11 +90,13 @@ void preciceAdapter::CHT::SinkTemperature::read(double * buffer, const unsigned 
         int patchID = patchIDs_.at(j);
 
         // Get the boundary field of the temperature on the patch
-        mixedFvPatchScalarField & TPatch =
-                refCast<mixedFvPatchScalarField>
-                (
-                    T_->boundaryFieldRef()[patchID]
-                    );
+        mixedFvPatchScalarField & TPatch
+        (
+            refCast<mixedFvPatchScalarField>
+            (
+                T_->boundaryFieldRef()[patchID]
+            )
+        );
 
         // Get a reference to the reference value on the patch
         scalarField & Tref = TPatch.refValue();

--- a/CHT/SinkTemperature.C
+++ b/CHT/SinkTemperature.C
@@ -31,11 +31,11 @@ void preciceAdapter::CHT::SinkTemperature::write(double * buffer, bool meshConne
         int patchID = patchIDs_.at(j);
 
         // Get the boundary field of Temperature on the patch
-        fvPatchScalarField & TPatch
+        const fvPatchScalarField & TPatch
         (
-            refCast<fvPatchScalarField>
+            refCast<const fvPatchScalarField>
             (
-                T_->boundaryFieldRef()[patchID]
+                T_->boundaryField()[patchID]
             )
         );
 

--- a/CHT/Temperature.C
+++ b/CHT/Temperature.C
@@ -32,7 +32,10 @@ void preciceAdapter::CHT::Temperature::write(double * buffer, bool meshConnectiv
     {
         int patchID = patchIDs_.at(j);
 
-        const scalarField& TPatch=T_->boundaryFieldRef()[patchID];
+        const scalarField& TPatch
+        (
+            T_->boundaryFieldRef()[patchID]
+        );
 
         //If we use the mesh connectivity, we interpolate from the centres to the nodes
         if(meshConnectivity)
@@ -40,10 +43,11 @@ void preciceAdapter::CHT::Temperature::write(double * buffer, bool meshConnectiv
             //Create an Interpolation object at the boundary Field
             primitivePatchInterpolation patchInterpolator(mesh_.boundaryMesh()[patchID]);
 
-            scalarField  TPoints;
-
             //Interpolate from centers to nodes
-            TPoints= patchInterpolator.faceToPointInterpolate(TPatch);
+            scalarField  TPoints
+            (
+                patchInterpolator.faceToPointInterpolate(TPatch)
+            );
 
             forAll(TPoints, i)
             {

--- a/CHT/Temperature.C
+++ b/CHT/Temperature.C
@@ -32,9 +32,9 @@ void preciceAdapter::CHT::Temperature::write(double * buffer, bool meshConnectiv
     {
         int patchID = patchIDs_.at(j);
 
-        const scalarField& TPatch
+        const scalarField & TPatch
         (
-            T_->boundaryFieldRef()[patchID]
+            T_->boundaryField()[patchID]
         );
 
         //If we use the mesh connectivity, we interpolate from the centres to the nodes
@@ -80,7 +80,7 @@ void preciceAdapter::CHT::Temperature::write(double * buffer, bool meshConnectiv
             int patchID = patchIDs_.at(j);
 
             // For every cell of the patch
-            forAll(T_->boundaryFieldRef()[patchID], i)
+            forAll(T_->boundaryField()[patchID], i)
             {
                 // Set the temperature as the buffer value
                 T_->boundaryFieldRef()[patchID][i]

--- a/FSI/Displacement.C
+++ b/FSI/Displacement.C
@@ -42,11 +42,13 @@ void preciceAdapter::FSI::Displacement::read(double * buffer, const unsigned int
         int patchID = patchIDs_.at(j);
 
         // Get the displacement on the patch
-        fixedValuePointPatchVectorField& pointDisplacementFluidPatch =
+        fixedValuePointPatchVectorField& pointDisplacementFluidPatch
+        (
             refCast<fixedValuePointPatchVectorField>
             (
                 pointDisplacement_->boundaryFieldRef()[patchID]
-            );
+            )
+        );
 
         // For every cell of the patch
         forAll(pointDisplacement_->boundaryFieldRef()[patchID], i)

--- a/FSI/Displacement.C
+++ b/FSI/Displacement.C
@@ -51,7 +51,7 @@ void preciceAdapter::FSI::Displacement::read(double * buffer, const unsigned int
         );
 
         // For every cell of the patch
-        forAll(pointDisplacement_->boundaryFieldRef()[patchID], i)
+        forAll(pointDisplacement_->boundaryField()[patchID], i)
         {
             // Set the displacement to the received one
             pointDisplacementFluidPatch[i][0] = buffer[bufferIndex++];

--- a/FSI/DisplacementDelta.C
+++ b/FSI/DisplacementDelta.C
@@ -42,11 +42,13 @@ void preciceAdapter::FSI::DisplacementDelta::read(double * buffer, const unsigne
         int patchID = patchIDs_.at(j);
 
         // Get the displacement on the patch
-        fixedValuePointPatchVectorField& pointDisplacementFluidPatch =
+        fixedValuePointPatchVectorField& pointDisplacementFluidPatch
+        (
             refCast<fixedValuePointPatchVectorField>
             (
                 pointDisplacement_->boundaryFieldRef()[patchID]
-            );
+            )
+        );
 
         // For every cell of the patch
         forAll(pointDisplacement_->boundaryFieldRef()[patchID], i)

--- a/FSI/DisplacementDelta.C
+++ b/FSI/DisplacementDelta.C
@@ -51,7 +51,7 @@ void preciceAdapter::FSI::DisplacementDelta::read(double * buffer, const unsigne
         );
 
         // For every cell of the patch
-        forAll(pointDisplacement_->boundaryFieldRef()[patchID], i)
+        forAll(pointDisplacement_->boundaryField()[patchID], i)
         {
             // Add the received delta to the actual displacement
             pointDisplacementFluidPatch[i][0] += buffer[bufferIndex++];

--- a/FSI/Force.C
+++ b/FSI/Force.C
@@ -64,24 +64,31 @@ Foam::tmp<Foam::volSymmTensorField> preciceAdapter::FSI::Force::devRhoReff() con
     typedef incompressible::turbulenceModel icoTurbModel;   
     
     if (mesh_.foundObject<cmpTurbModel>(cmpTurbModel::propertiesName))
-    {        
-        const cmpTurbModel& turb =
-            mesh_.lookupObject<cmpTurbModel>(cmpTurbModel::propertiesName);    
-        
+    {
+        const cmpTurbModel & turb
+        (
+            mesh_.lookupObject<cmpTurbModel>(cmpTurbModel::propertiesName)
+        );
+
         return turb.devRhoReff();
 
-    }    
+    }
     else if (mesh_.foundObject<icoTurbModel>(icoTurbModel::propertiesName))
-    {        
-        const incompressible::turbulenceModel& turb =
-            mesh_.lookupObject<icoTurbModel>(icoTurbModel::propertiesName);
-            
+    {
+        const incompressible::turbulenceModel& turb
+        (
+            mesh_.lookupObject<icoTurbModel>(icoTurbModel::propertiesName)
+        );
+
         return rho()*turb.devReff();        
     }
     else
     {        
         // For laminar flows get the velocity  
-        const volVectorField& U = mesh_.lookupObject<volVectorField>("U");
+        const volVectorField & U
+        (
+            mesh_.lookupObject<volVectorField>("U")
+        );
         
         return -mu()*dev(twoSymm(fvc::grad(U)));
     }
@@ -139,8 +146,10 @@ Foam::tmp<Foam::volScalarField> preciceAdapter::FSI::Force::mu() const
         typedef immiscibleIncompressibleTwoPhaseMixture iitpMixture;
         if (mesh_.foundObject<iitpMixture>("mixture"))
         {
-            const iitpMixture& mixture =
-                mesh_.lookupObject<iitpMixture>("mixture");
+            const iitpMixture& mixture
+            (
+                mesh_.lookupObject<iitpMixture>("mixture")
+            );
                 
             return mixture.mu();
         }
@@ -181,23 +190,29 @@ void preciceAdapter::FSI::Force::write(double * buffer, bool meshConnectivity, c
     // Compute forces. See the Forces function object.
 
     // Normal vectors on the boundary, multiplied with the face areas
-    const surfaceVectorField::Boundary& Sfb =
-        mesh_.Sf().boundaryField();
+    const surfaceVectorField::Boundary& Sfb
+    (
+        mesh_.Sf().boundaryField()
+    );
 
     // Stress tensor boundary field
-    tmp<volSymmTensorField> tdevRhoReff = devRhoReff();
-    const volSymmTensorField::Boundary& devRhoReffb =
-        tdevRhoReff().boundaryField();
+    tmp<volSymmTensorField> tdevRhoReff(devRhoReff());
+    const volSymmTensorField::Boundary& devRhoReffb
+    (
+        tdevRhoReff().boundaryField()
+    );
 
     // Density boundary field
-    tmp<volScalarField> trho = rho();
+    tmp<volScalarField> trho(rho());
     const volScalarField::Boundary& rhob =
         trho().boundaryField();
 
     // Pressure boundary field
     tmp<volScalarField> tp = mesh_.lookupObject<volScalarField>("p");
-    const volScalarField::Boundary& pb =
-        tp().boundaryField();        
+    const volScalarField::Boundary& pb
+    (
+        tp().boundaryField()
+    );
 
     int bufferIndex = 0;
     // For every boundary patch of the interface

--- a/FSI/Force.C
+++ b/FSI/Force.C
@@ -246,24 +246,24 @@ void preciceAdapter::FSI::Force::write(double * buffer, bool meshConnectivity, c
 
         // Write the forces to the preCICE buffer
         // For every cell of the patch
-        forAll(Force_->boundaryFieldRef()[patchID], i)
+        forAll(Force_->boundaryField()[patchID], i)
         {
             // Copy the force into the buffer
             // x-dimension
             buffer[bufferIndex++]
             = 
-            Force_->boundaryFieldRef()[patchID][i].x();
+            Force_->boundaryField()[patchID][i].x();
 
             // y-dimension
             buffer[bufferIndex++]
             =
-            Force_->boundaryFieldRef()[patchID][i].y();
+            Force_->boundaryField()[patchID][i].y();
 
             if(dim == 3)
                 // z-dimension
                 buffer[bufferIndex++]
                         =
-                        Force_->boundaryFieldRef()[patchID][i].z();
+                        Force_->boundaryField()[patchID][i].z();
         }
     }
 }

--- a/FSI/Stress.C
+++ b/FSI/Stress.C
@@ -107,24 +107,24 @@ void preciceAdapter::FSI::Stress::write(double * buffer, bool meshConnectivity, 
 
         // Write the stress to the preCICE buffer
         // For every cell of the patch
-        forAll(Stress_->boundaryFieldRef()[patchID], i)
+        forAll(Stress_->boundaryField()[patchID], i)
         {
             // Copy the stress into the buffer
             // x-dimension
             buffer[bufferIndex++]
             = 
-            Stress_->boundaryFieldRef()[patchID][i].x();
+            Stress_->boundaryField()[patchID][i].x();
 
             // y-dimension
             buffer[bufferIndex++]
             =
-            Stress_->boundaryFieldRef()[patchID][i].y();
+            Stress_->boundaryField()[patchID][i].y();
 
             if(dim == 3)
                 // z-dimension
                 buffer[bufferIndex++]
                         =
-                        Stress_->boundaryFieldRef()[patchID][i].z();
+                        Stress_->boundaryField()[patchID][i].z();
         }
     }
 }

--- a/FSI/Stress.C
+++ b/FSI/Stress.C
@@ -52,19 +52,25 @@ void preciceAdapter::FSI::Stress::write(double * buffer, bool meshConnectivity, 
     // Compute stress. See the Forces function object.
 
     // Stress tensor boundary field
-    tmp<volSymmTensorField> tdevRhoReff = this->devRhoReff();
-    const volSymmTensorField::Boundary& devRhoReffb =
-        tdevRhoReff().boundaryField();
+    tmp<volSymmTensorField> tdevRhoReff(this->devRhoReff());
+    const volSymmTensorField::Boundary& devRhoReffb
+    (
+        tdevRhoReff().boundaryField()
+    );
 
     // Density boundary field
-    tmp<volScalarField> trho = this->rho();
-    const volScalarField::Boundary& rhob =
-        trho().boundaryField();
+    tmp<volScalarField> trho(this->rho());
+    const volScalarField::Boundary& rhob
+    (
+        trho().boundaryField()
+    );
 
     // Pressure boundary field
-    tmp<volScalarField> tp = mesh_.lookupObject<volScalarField>("p");
-    const volScalarField::Boundary& pb =
-        tp().boundaryField();        
+    tmp<volScalarField> tp(mesh_.lookupObject<volScalarField>("p"));
+    const volScalarField::Boundary& pb
+    (
+        tp().boundaryField()
+    );
 
     int bufferIndex = 0;
     // For every boundary patch of the interface


### PR DESCRIPTION
OpenFOAM provides the methods boundaryField and boundaryFieldRef to return references to the boundary of a field. Their difference is that boundaryField returns a const reference, while boundaryFieldRef returns a non-const reference.
    
There are a few parts of the code where we were using the non-const versions where the const would be enough. This replaces boundaryFieldRef by boundaryField, essentially keeping only one non-const instance at the read() method of every coupling data reader.

This depends on #131.

@DavidSCN have I forgotten anything?