### PR TITLE
Enable `faceCenters` for Displacement based reading

### DIFF
--- a/CouplingDataUser.C
+++ b/CouplingDataUser.C
@@ -35,3 +35,9 @@ void preciceAdapter::CouplingDataUser::setLocationsType(std::string locationsTyp
 {
     locationsType_ = locationsType;
 }
+
+// Dummy implementation which can be overwritten in derived classes if required
+void preciceAdapter::CouplingDataUser::initialize()
+{
+  return;
+}

--- a/CouplingDataUser.C
+++ b/CouplingDataUser.C
@@ -30,3 +30,8 @@ void preciceAdapter::CouplingDataUser::setPatchIDs(std::vector<int> patchIDs)
 {
     patchIDs_ = patchIDs;
 }
+
+void preciceAdapter::CouplingDataUser::setLocationsType(std::string locationsType)
+{
+    locationsType_ = locationsType;
+}

--- a/CouplingDataUser.H
+++ b/CouplingDataUser.H
@@ -2,6 +2,7 @@
 #define COUPLINGDATAUSER_H
 
 #include <vector>
+#include <string>
 
 namespace preciceAdapter
 {
@@ -22,6 +23,9 @@ protected:
     //- preCICE data ID
     int dataID_;
 
+    //- preCICE data ID
+    std::string locationsType_;
+
 public:
 
     //- Constructor
@@ -41,6 +45,9 @@ public:
 
     //- Set the patch IDs that form the interface
     void setPatchIDs(std::vector<int> patchIDs);
+
+    //- Set the locations type of the interface
+    void setLocationsType(std::string locationsType);
 
     //- Write the coupling data to the buffer
     virtual void write(double * dataBuffer, bool meshConnectivity, const unsigned int dim) = 0;

--- a/CouplingDataUser.H
+++ b/CouplingDataUser.H
@@ -49,6 +49,9 @@ public:
     //- Set the locations type of the interface
     void setLocationsType(std::string locationsType);
 
+    //- option to initialize data in derived data classes
+    virtual void initialize();
+
     //- Write the coupling data to the buffer
     virtual void write(double * dataBuffer, bool meshConnectivity, const unsigned int dim) = 0;
 

--- a/CouplingDataUser.H
+++ b/CouplingDataUser.H
@@ -23,7 +23,7 @@ protected:
     //- preCICE data ID
     int dataID_;
 
-    //- preCICE data ID
+    //- location type of the interface
     std::string locationsType_;
 
 public:

--- a/FSI/Displacement.C
+++ b/FSI/Displacement.C
@@ -16,7 +16,7 @@ preciceAdapter::FSI::Displacement::Displacement(
     dataType_ = vector;
 }
 
-// We cannot do this steps in the constructor by design of the adapter since the information of the CouplingDataUser is
+// We cannot do this step in the constructor by design of the adapter since the information of the CouplingDataUser is
 // defined later. Hence, we call this method after the CouplingDaaUser has been configured
 void preciceAdapter::FSI::Displacement::initialize()
 {

--- a/FSI/Displacement.C
+++ b/FSI/Displacement.C
@@ -57,7 +57,7 @@ void preciceAdapter::FSI::Displacement::read(double * buffer, const unsigned int
           // the boundaryCellDisplacement is a vector and ordered according to the iterator j
           // and not according to the patchID
           // First, copy the buffer data into the center based vectorFields on each interface patch
-          for (int i = 0; i < cellDisplacement_->boundaryField()[patchID].size(); ++i) {
+          forAll (cellDisplacement_->boundaryField()[patchID], i) {
             for (unsigned int d = 0; d < dim; ++d)
               cellDisplacement_->boundaryFieldRef()[patchID][i][d] = buffer[i * dim + d];
           }
@@ -78,7 +78,7 @@ void preciceAdapter::FSI::Displacement::read(double * buffer, const unsigned int
                   pointDisplacement_->boundaryFieldRef()[patchID]));
 
           // Overwrite the nodes on the interface directly
-          for (int i = 0; i < pointDisplacement_->boundaryFieldRef()[patchID].size(); ++i) {
+          forAll (pointDisplacement_->boundaryFieldRef()[patchID], i) {
             for (unsigned int d = 0; d < dim; ++d)
               pointDisplacementFluidPatch[i][d] = buffer[i * dim + d];
           }

--- a/FSI/Displacement.C
+++ b/FSI/Displacement.C
@@ -53,30 +53,18 @@ void preciceAdapter::FSI::Displacement::read(double * buffer, const unsigned int
                 cellDisplacement[i][2] = buffer[bufferIndex++];
         }
 
-        //Interpolate from centers to nodes
-        primitivePatchInterpolation patchInterpolator(mesh_.boundaryMesh()[patchID]);
-        vectorField pointDisplacement
-        (
-            patchInterpolator.faceToPointInterpolate(cellDisplacement)
-        );
-
         // Get the displacement on the patch
-        fixedValuePointPatchVectorField& pointDisplacementFluidPatch
+        vectorField& pointDisplacementFluidPatch
         (
-            refCast<fixedValuePointPatchVectorField>
+            refCast<vectorField>
             (
                 pointDisplacement_->boundaryFieldRef()[patchID]
             )
         );
 
-        // For every cell of the patch
-        forAll(pointDisplacement_->boundaryFieldRef()[patchID], i)
-        {
-            // Set the displacement to the received one
-            pointDisplacementFluidPatch[i][0] = pointDisplacement[i][0];
-            pointDisplacementFluidPatch[i][1] = pointDisplacement[i][1];
-            if(dim ==3)
-                pointDisplacementFluidPatch[i][2] = pointDisplacement[i][2];
-        }
+        //Interpolate from centers to nodes
+        primitivePatchInterpolation patchInterpolator(mesh_.boundaryMesh()[patchID]);
+        pointDisplacementFluidPatch =
+             patchInterpolator.faceToPointInterpolate(cellDisplacement);
     }
 }

--- a/FSI/Displacement.C
+++ b/FSI/Displacement.C
@@ -19,6 +19,26 @@ mesh_(mesh)
     dataType_ = vector;
 }
 
+// We cannot do this steps in the constructor by design of the adapter since the information of the CouplingDataUser is
+// defined later. Hence, we call this method after the CouplingDaaUser has been configured
+void preciceAdapter::FSI::Displacement::initialize()
+{
+  // We use the cellDisplacement in order to copy the interface boundary fields
+  const volVectorField &cellDisplacement_ =
+      mesh_.lookupObject<volVectorField>("cellDisplacement");
+
+  // Initialize appropriate objects for each interface patch, namely the volField and the interpolation object
+  // this is only necessary for face based FSI
+  if (this->locationsType_ == "faceCenters" || this->locationsType_ == "faceCentres")
+    for (unsigned int j = 0; j < patchIDs_.size(); j++) {
+      const unsigned int patchID = patchIDs_.at(j);
+      boundaryCellDisplacement_.emplace_back(cellDisplacement_.boundaryField()[patchID]);
+      interpolationObjects_.emplace_back(new primitivePatchInterpolation(mesh_.boundaryMesh()[patchID]));
+    }
+}
+
+
+
 void preciceAdapter::FSI::Displacement::write(double * buffer, bool meshConnectivity, const unsigned int dim)
 {
     /* TODO: Implement
@@ -31,40 +51,45 @@ void preciceAdapter::FSI::Displacement::write(double * buffer, bool meshConnecti
         << exit(FatalError);
 }
 
+
 // return the displacement to use later in the velocity?
 void preciceAdapter::FSI::Displacement::read(double * buffer, const unsigned int dim)
 {
-    // For every element in the buffer
-    int bufferIndex = 0;
-
-    // For every boundary patch of the interface
-    for (uint j = 0; j < patchIDs_.size(); j++)
+    for (unsigned int j = 0; j < patchIDs_.size(); j++)
     {
-        int patchID = patchIDs_.at(j);
+        // Get the ID of the current patch
+        const unsigned int patchID = patchIDs_.at(j);
 
-        const volVectorField &tmp_field = mesh_.lookupObject<volVectorField>("cellDisplacement");
-        vectorField           cellDisplacement(tmp_field.boundaryField()[patchID]);
-        forAll(cellDisplacement, i)
-        {
-            // Set the displacement to the received one
-            cellDisplacement[i][0] = buffer[bufferIndex++];
-            cellDisplacement[i][1] = buffer[bufferIndex++];
-            if(dim ==3)
-                cellDisplacement[i][2] = buffer[bufferIndex++];
+        if (this->locationsType_ == "faceCenters" || this->locationsType_ == "faceCentres") {
+
+          // the boundaryCellDisplacement is a vector and ordered according to the iterator j
+          // and not according to the patchID
+          // First, copy the buffer data into the center based vectorFields on each interface patch
+          for (int i = 0; i < boundaryCellDisplacement_[j].size(); ++i) {
+            for (unsigned int d = 0; d < dim; ++d)
+              boundaryCellDisplacement_[j][i][d] = buffer[i * dim + d];
+          }
+          // Get a reference to the displacement on the point patch in order to overwrite it
+          vectorField &pointDisplacementFluidPatch(
+              refCast<vectorField>(
+                  pointDisplacement_->boundaryFieldRef()[patchID]));
+
+          // Overwrite the node based patch using the interpolation objects and the cell based vector field
+          // Afterwards, continue as usual
+          pointDisplacementFluidPatch = interpolationObjects_[j]->faceToPointInterpolate(boundaryCellDisplacement_[j]);
+
+        } else if (this->locationsType_ == "faceNodes") {
+
+          // Get the displacement on the patch
+          fixedValuePointPatchVectorField &pointDisplacementFluidPatch(
+              refCast<fixedValuePointPatchVectorField>(
+                  pointDisplacement_->boundaryFieldRef()[patchID]));
+
+          // Overwrite the nodes on the interface directly
+          for (int i = 0; i < pointDisplacement_->boundaryFieldRef()[patchID].size(); ++i) {
+            for (unsigned int d = 0; d < dim; ++d)
+              pointDisplacementFluidPatch[i][d] = buffer[i * dim + d];
+          }
         }
-
-        // Get the displacement on the patch
-        vectorField& pointDisplacementFluidPatch
-        (
-            refCast<vectorField>
-            (
-                pointDisplacement_->boundaryFieldRef()[patchID]
-            )
-        );
-
-        //Interpolate from centers to nodes
-        primitivePatchInterpolation patchInterpolator(mesh_.boundaryMesh()[patchID]);
-        pointDisplacementFluidPatch =
-             patchInterpolator.faceToPointInterpolate(cellDisplacement);
     }
 }

--- a/FSI/Displacement.C
+++ b/FSI/Displacement.C
@@ -4,13 +4,14 @@ using namespace Foam;
 
 preciceAdapter::FSI::Displacement::Displacement(
     const Foam::fvMesh &mesh,
-    const std::string   namePointDisplacement)
+    const std::string   namePointDisplacement,
+    const std::string   nameCellDisplacement)
     : pointDisplacement_(
           const_cast<pointVectorField *>(
               &mesh.lookupObject<pointVectorField>(namePointDisplacement))),
       cellDisplacement_(
           const_cast<volVectorField *>(
-              &mesh.lookupObject<volVectorField>("cellDisplacement"))),
+              &mesh.lookupObject<volVectorField>(nameCellDisplacement))),
       mesh_(mesh)
 {
     dataType_ = vector;

--- a/FSI/Displacement.H
+++ b/FSI/Displacement.H
@@ -27,7 +27,7 @@ private:
     const Foam::fvMesh& mesh_;
     // NOTE: this allocation could be avoided in case we directly write to the
     // Needs to be a pointer since the class disables assignment and copy constructors
-    std::vector<Foam::primitivePatchInterpolation *> interpolationObjects_;
+    std::vector<const Foam::primitivePatchInterpolation *> interpolationObjects_;
 
   public:
 

--- a/FSI/Displacement.H
+++ b/FSI/Displacement.H
@@ -21,12 +21,11 @@ private:
     // Displacement pointVectorField
     Foam::pointVectorField * pointDisplacement_;
 
-    const Foam::fvMesh& mesh_;
-
-    // vector field for cell displacement on each interface patch
-    // NOTE: both allocation could be avoided in case we directly write to the
     // cellDisplacement field
-    std::vector<Foam::vectorField> boundaryCellDisplacement_;
+    Foam::volVectorField *cellDisplacement_;
+
+    const Foam::fvMesh& mesh_;
+    // NOTE: this allocation could be avoided in case we directly write to the
     // Needs to be a pointer since the class disables assignment and copy constructors
     std::vector<Foam::primitivePatchInterpolation *> interpolationObjects_;
 

--- a/FSI/Displacement.H
+++ b/FSI/Displacement.H
@@ -49,6 +49,7 @@ private:
     // in case we want to use the faceCenter location for the coupling
     void initialize() override;
 };
+
 }
 }
 

--- a/FSI/Displacement.H
+++ b/FSI/Displacement.H
@@ -23,6 +23,13 @@ private:
 
     const Foam::fvMesh& mesh_;
 
+    // vector field for cell displacement on each interface patch
+    // NOTE: both allocation could be avoided in case we directly write to the
+    // cellDisplacement field
+    std::vector<Foam::vectorField> boundaryCellDisplacement_;
+    // Needs to be a pointer since the class disables assignment and copy constructors
+    std::vector<Foam::primitivePatchInterpolation *> interpolationObjects_;
+
   public:
 
     //- Constructor
@@ -37,8 +44,11 @@ private:
 
     //- Read the displacement values from the buffer
     void read(double * buffer, const unsigned int dim);
-};
 
+    //- We need to initialize the cell-based vector and the interpolation object
+    // in case we want to use the faceCenter location for the coupling
+    void initialize() override;
+};
 }
 }
 

--- a/FSI/Displacement.H
+++ b/FSI/Displacement.H
@@ -35,7 +35,8 @@ private:
     Displacement
     (
         const Foam::fvMesh& mesh,
-        const std::string namePointDisplacement
+        const std::string namePointDisplacement,
+        const std::string nameCellDisplacement
     );
 
     //- Write the displacement values into the buffer

--- a/FSI/Displacement.H
+++ b/FSI/Displacement.H
@@ -5,6 +5,7 @@
 
 #include "fvCFD.H"
 #include "fixedValuePointPatchFields.H"
+#include "primitivePatchInterpolation.H"
 
 namespace preciceAdapter
 {
@@ -20,7 +21,9 @@ private:
     // Displacement pointVectorField
     Foam::pointVectorField * pointDisplacement_;
 
-public:
+    const Foam::fvMesh& mesh_;
+
+  public:
 
     //- Constructor
     Displacement

--- a/FSI/DisplacementDelta.C
+++ b/FSI/DisplacementDelta.C
@@ -4,13 +4,14 @@ using namespace Foam;
 
 preciceAdapter::FSI::DisplacementDelta::DisplacementDelta(
     const Foam::fvMesh &mesh,
-    const std::string   namePointDisplacement)
+    const std::string   namePointDisplacement,
+    const std::string   nameCellDisplacement)
     : pointDisplacement_(
           const_cast<pointVectorField *>(
               &mesh.lookupObject<pointVectorField>(namePointDisplacement))),
       cellDisplacement_(
           const_cast<volVectorField *>(
-              &mesh.lookupObject<volVectorField>("cellDisplacement"))),
+              &mesh.lookupObject<volVectorField>(nameCellDisplacement))),
       mesh_(mesh)
 {
     dataType_ = vector;

--- a/FSI/DisplacementDelta.C
+++ b/FSI/DisplacementDelta.C
@@ -47,10 +47,10 @@ void preciceAdapter::FSI::DisplacementDelta::read(double * buffer, const unsigne
         forAll(cellDisplacement, i)
         {
             // Set the displacement to the received one
-            cellDisplacement[i][0] = buffer[bufferIndex++];
-            cellDisplacement[i][1] = buffer[bufferIndex++];
+            cellDisplacement[i][0] += buffer[bufferIndex++];
+            cellDisplacement[i][1] += buffer[bufferIndex++];
             if(dim ==3)
-                cellDisplacement[i][2] = buffer[bufferIndex++];
+                cellDisplacement[i][2] += buffer[bufferIndex++];
         }
 
         // Get the displacement on the patch

--- a/FSI/DisplacementDelta.C
+++ b/FSI/DisplacementDelta.C
@@ -2,19 +2,16 @@
 
 using namespace Foam;
 
-preciceAdapter::FSI::DisplacementDelta::DisplacementDelta
-(
-    const Foam::fvMesh& mesh,
-    const std::string namePointDisplacement
-)
-:
-pointDisplacement_(
-    const_cast<pointVectorField*>
-    (
-        &mesh.lookupObject<pointVectorField>(namePointDisplacement)
-    )
-),
-mesh_(mesh)
+preciceAdapter::FSI::DisplacementDelta::DisplacementDelta(
+    const Foam::fvMesh &mesh,
+    const std::string   namePointDisplacement)
+    : pointDisplacement_(
+          const_cast<pointVectorField *>(
+              &mesh.lookupObject<pointVectorField>(namePointDisplacement))),
+      cellDisplacement_(
+          const_cast<volVectorField *>(
+              &mesh.lookupObject<volVectorField>("cellDisplacement"))),
+      mesh_(mesh)
 {
     dataType_ = vector;
 }
@@ -23,16 +20,11 @@ mesh_(mesh)
 // defined later. Hence, we call this method after the CouplingDaaUser has been configured
 void preciceAdapter::FSI::DisplacementDelta::initialize()
 {
-  // We use the cellDisplacement in order to copy the interface boundary fields
-  const volVectorField &cellDisplacement_ =
-      mesh_.lookupObject<volVectorField>("cellDisplacement");
-
   // Initialize appropriate objects for each interface patch, namely the volField and the interpolation object
   // this is only necessary for face based FSI
   if (this->locationsType_ == "faceCenters" || this->locationsType_ == "faceCentres")
-    for (unsigned int j = 0; j < patchIDs_.size(); j++) {
+    for (unsigned int j = 0; j < patchIDs_.size(); ++j) {
       const unsigned int patchID = patchIDs_.at(j);
-      boundaryCellDisplacement_.emplace_back(cellDisplacement_.boundaryField()[patchID]);
       interpolationObjects_.emplace_back(new primitivePatchInterpolation(mesh_.boundaryMesh()[patchID]));
     }
 }
@@ -66,9 +58,9 @@ void preciceAdapter::FSI::DisplacementDelta::read(double * buffer, const unsigne
           // First, copy the buffer data into the center based vectorFields on each interface patch
           // For DisplacementDelta, set absolute values here and sum the interpolated values up to the point field
           // since the temporary field in this class is not reloaded in the implicit coupling
-          for (int i = 0; i < boundaryCellDisplacement_[j].size(); ++i) {
+          for (int i = 0; i < cellDisplacement_->boundaryField()[patchID].size(); ++i) {
             for (unsigned int d = 0; d < dim; ++d)
-              boundaryCellDisplacement_[j][i][d] = buffer[i * dim + d];
+              cellDisplacement_->boundaryFieldRef()[patchID][i][d] = buffer[i * dim + d];
           }
           // Get a reference to the displacement on the point patch in order to overwrite it
           vectorField &pointDisplacementFluidPatch(
@@ -77,7 +69,7 @@ void preciceAdapter::FSI::DisplacementDelta::read(double * buffer, const unsigne
 
           // Overwrite the node based patch using the interpolation objects and the cell based vector field
           // Afterwards, continue as usual
-          pointDisplacementFluidPatch += interpolationObjects_[j]->faceToPointInterpolate(boundaryCellDisplacement_[j]);
+          pointDisplacementFluidPatch += interpolationObjects_[j]->faceToPointInterpolate(cellDisplacement_->boundaryField()[patchID]);
 
         } else if (this->locationsType_ == "faceNodes") {
 

--- a/FSI/DisplacementDelta.C
+++ b/FSI/DisplacementDelta.C
@@ -58,7 +58,7 @@ void preciceAdapter::FSI::DisplacementDelta::read(double * buffer, const unsigne
           // First, copy the buffer data into the center based vectorFields on each interface patch
           // For DisplacementDelta, set absolute values here and sum the interpolated values up to the point field
           // since the temporary field in this class is not reloaded in the implicit coupling
-          for (int i = 0; i < cellDisplacement_->boundaryField()[patchID].size(); ++i) {
+          forAll (cellDisplacement_->boundaryField()[patchID], i) {
             for (unsigned int d = 0; d < dim; ++d)
               cellDisplacement_->boundaryFieldRef()[patchID][i][d] = buffer[i * dim + d];
           }
@@ -79,7 +79,7 @@ void preciceAdapter::FSI::DisplacementDelta::read(double * buffer, const unsigne
                   pointDisplacement_->boundaryFieldRef()[patchID]));
 
           // Overwrite the nodes on the interface directly
-          for (int i = 0; i < pointDisplacement_->boundaryFieldRef()[patchID].size(); ++i) {
+          forAll (pointDisplacement_->boundaryFieldRef()[patchID], i) {
             for (unsigned int d = 0; d < dim; ++d)
               pointDisplacementFluidPatch[i][d] += buffer[i * dim + d];
           }

--- a/FSI/DisplacementDelta.C
+++ b/FSI/DisplacementDelta.C
@@ -19,6 +19,26 @@ mesh_(mesh)
     dataType_ = vector;
 }
 
+// We cannot do this steps in the constructor by design of the adapter since the information of the CouplingDataUser is
+// defined later. Hence, we call this method after the CouplingDaaUser has been configured
+void preciceAdapter::FSI::DisplacementDelta::initialize()
+{
+  // We use the cellDisplacement in order to copy the interface boundary fields
+  const volVectorField &cellDisplacement_ =
+      mesh_.lookupObject<volVectorField>("cellDisplacement");
+
+  // Initialize appropriate objects for each interface patch, namely the volField and the interpolation object
+  // this is only necessary for face based FSI
+  if (this->locationsType_ == "faceCenters" || this->locationsType_ == "faceCentres")
+    for (unsigned int j = 0; j < patchIDs_.size(); j++) {
+      const unsigned int patchID = patchIDs_.at(j);
+      boundaryCellDisplacement_.emplace_back(cellDisplacement_.boundaryField()[patchID]);
+      interpolationObjects_.emplace_back(new primitivePatchInterpolation(mesh_.boundaryMesh()[patchID]));
+    }
+}
+
+
+
 void preciceAdapter::FSI::DisplacementDelta::write(double * buffer, bool meshConnectivity, const unsigned int dim)
 {
     /* TODO: Implement
@@ -34,37 +54,43 @@ void preciceAdapter::FSI::DisplacementDelta::write(double * buffer, bool meshCon
 // return the displacement to use later in the velocity?
 void preciceAdapter::FSI::DisplacementDelta::read(double * buffer, const unsigned int dim)
 {
-    // For every element in the buffer
-    int bufferIndex = 0;
-
-    // For every boundary patch of the interface
-    for (uint j = 0; j < patchIDs_.size(); j++)
+    for (unsigned int j = 0; j < patchIDs_.size(); j++)
     {
-        int patchID = patchIDs_.at(j);
+        // Get the ID of the current patch
+        const unsigned int patchID = patchIDs_.at(j);
 
-        const volVectorField &tmp_field = mesh_.lookupObject<volVectorField>("cellDisplacement");
-        vectorField           cellDisplacement(tmp_field.boundaryField()[patchID]);
-        forAll(cellDisplacement, i)
-        {
-            // Set the displacement to the received one
-            cellDisplacement[i][0] += buffer[bufferIndex++];
-            cellDisplacement[i][1] += buffer[bufferIndex++];
-            if(dim ==3)
-                cellDisplacement[i][2] += buffer[bufferIndex++];
+        if (this->locationsType_ == "faceCenters" || this->locationsType_ == "faceCentres") {
+
+          // the boundaryCellDisplacement is a vector and ordered according to the iterator j
+          // and not according to the patchID
+          // First, copy the buffer data into the center based vectorFields on each interface patch
+          // For DisplacementDelta, set absolute values here and sum the interpolated values up to the point field
+          // since the temporary field in this class is not reloaded in the implicit coupling
+          for (int i = 0; i < boundaryCellDisplacement_[j].size(); ++i) {
+            for (unsigned int d = 0; d < dim; ++d)
+              boundaryCellDisplacement_[j][i][d] = buffer[i * dim + d];
+          }
+          // Get a reference to the displacement on the point patch in order to overwrite it
+          vectorField &pointDisplacementFluidPatch(
+              refCast<vectorField>(
+                  pointDisplacement_->boundaryFieldRef()[patchID]));
+
+          // Overwrite the node based patch using the interpolation objects and the cell based vector field
+          // Afterwards, continue as usual
+          pointDisplacementFluidPatch += interpolationObjects_[j]->faceToPointInterpolate(boundaryCellDisplacement_[j]);
+
+        } else if (this->locationsType_ == "faceNodes") {
+
+          // Get the displacement on the patch
+          fixedValuePointPatchVectorField &pointDisplacementFluidPatch(
+              refCast<fixedValuePointPatchVectorField>(
+                  pointDisplacement_->boundaryFieldRef()[patchID]));
+
+          // Overwrite the nodes on the interface directly
+          for (int i = 0; i < pointDisplacement_->boundaryFieldRef()[patchID].size(); ++i) {
+            for (unsigned int d = 0; d < dim; ++d)
+              pointDisplacementFluidPatch[i][d] += buffer[i * dim + d];
+          }
         }
-
-        // Get the displacement on the patch
-        vectorField& pointDisplacementFluidPatch
-        (
-            refCast<vectorField>
-            (
-                pointDisplacement_->boundaryFieldRef()[patchID]
-            )
-        );
-
-        //Interpolate from centers to nodes
-        primitivePatchInterpolation patchInterpolator(mesh_.boundaryMesh()[patchID]);
-        pointDisplacementFluidPatch =
-             patchInterpolator.faceToPointInterpolate(cellDisplacement);
     }
 }

--- a/FSI/DisplacementDelta.C
+++ b/FSI/DisplacementDelta.C
@@ -16,7 +16,7 @@ preciceAdapter::FSI::DisplacementDelta::DisplacementDelta(
     dataType_ = vector;
 }
 
-// We cannot do this steps in the constructor by design of the adapter since the information of the CouplingDataUser is
+// We cannot do this step in the constructor by design of the adapter since the information of the CouplingDataUser is
 // defined later. Hence, we call this method after the CouplingDaaUser has been configured
 void preciceAdapter::FSI::DisplacementDelta::initialize()
 {

--- a/FSI/DisplacementDelta.H
+++ b/FSI/DisplacementDelta.H
@@ -25,8 +25,7 @@ private:
     Foam::volVectorField *cellDisplacement_;
 
     const Foam::fvMesh& mesh_;
-
-    // NOTE: both allocation could be avoided in case we directly write to the
+    // NOTE: this allocation could be avoided in case we directly write to the
     // Needs to be a pointer since the class disables assignment and copy constructors
     std::vector<const Foam::primitivePatchInterpolation *> interpolationObjects_;
 

--- a/FSI/DisplacementDelta.H
+++ b/FSI/DisplacementDelta.H
@@ -35,7 +35,8 @@ private:
     DisplacementDelta
     (
         const Foam::fvMesh& mesh,
-        const std::string namePointDisplacement
+        const std::string namePointDisplacement,
+        const std::string nameCellDisplacement
     );
 
     //- Write the displacementDelta values into the buffer

--- a/FSI/DisplacementDelta.H
+++ b/FSI/DisplacementDelta.H
@@ -5,6 +5,7 @@
 
 #include "fvCFD.H"
 #include "fixedValuePointPatchFields.H"
+#include "primitivePatchInterpolation.H"
 
 namespace preciceAdapter
 {
@@ -20,7 +21,9 @@ private:
     // Displacement pointVectorField
     Foam::pointVectorField * pointDisplacement_;
 
-public:
+    const Foam::fvMesh& mesh_;
+
+  public:
 
     //- Constructor
     DisplacementDelta
@@ -34,7 +37,6 @@ public:
 
     //- Read the displacementDelta values from the buffer
     void read(double * buffer, const unsigned int dim);
-
 };
 
 }

--- a/FSI/DisplacementDelta.H
+++ b/FSI/DisplacementDelta.H
@@ -23,6 +23,13 @@ private:
 
     const Foam::fvMesh& mesh_;
 
+    // vector field for cell displacement on each interface patch
+    // NOTE: both allocation could be avoided in case we directly write to the
+    // cellDisplacement field
+    std::vector<Foam::vectorField> boundaryCellDisplacement_;
+    // Needs to be a pointer since the class disables assignment and copy constructors
+    std::vector<Foam::primitivePatchInterpolation *> interpolationObjects_;
+
   public:
 
     //- Constructor
@@ -37,6 +44,10 @@ private:
 
     //- Read the displacementDelta values from the buffer
     void read(double * buffer, const unsigned int dim);
+
+    //- We need to initialize the cell-based vector and the interpolation object
+    // in case we want to use the faceCenter location for the coupling
+    void initialize() override;
 };
 
 }

--- a/FSI/DisplacementDelta.H
+++ b/FSI/DisplacementDelta.H
@@ -26,12 +26,9 @@ private:
 
     const Foam::fvMesh& mesh_;
 
-    // vector field for cell displacement on each interface patch
     // NOTE: both allocation could be avoided in case we directly write to the
-    // cellDisplacement field
-    std::vector<Foam::vectorField> boundaryCellDisplacement_;
     // Needs to be a pointer since the class disables assignment and copy constructors
-    std::vector<Foam::primitivePatchInterpolation *> interpolationObjects_;
+    std::vector<const Foam::primitivePatchInterpolation *> interpolationObjects_;
 
   public:
 

--- a/FSI/DisplacementDelta.H
+++ b/FSI/DisplacementDelta.H
@@ -21,6 +21,9 @@ private:
     // Displacement pointVectorField
     Foam::pointVectorField * pointDisplacement_;
 
+    // cellDisplacement field
+    Foam::volVectorField *cellDisplacement_;
+
     const Foam::fvMesh& mesh_;
 
     // vector field for cell displacement on each interface patch

--- a/FSI/FSI.C
+++ b/FSI/FSI.C
@@ -62,6 +62,10 @@ bool preciceAdapter::FSI::FluidStructureInteraction::readConfig(const IOdictiona
     namePointDisplacement_ = FSIdict.lookupOrDefault<word>("namePointDisplacement", "pointDisplacement");
     DEBUG(adapterInfo("    pointDisplacement field name : " + namePointDisplacement_));
 
+    // Read the name of the pointDisplacement field (if different)
+    nameCellDisplacement_ = FSIdict.lookupOrDefault<word>("nameCellDisplacement", "cellDisplacement");
+    DEBUG(adapterInfo("    cellDisplacement field name : " + nameCellDisplacement_));
+
     return true;
 }
 
@@ -116,7 +120,7 @@ void preciceAdapter::FSI::FluidStructureInteraction::addWriters(std::string data
         interface->addCouplingDataWriter
         (
             dataName,
-            new DisplacementDelta(mesh_, namePointDisplacement_)
+            new DisplacementDelta(mesh_, namePointDisplacement_, nameCellDisplacement_)
         );
         DEBUG(adapterInfo("Added writer: DisplacementDelta."));
     }
@@ -125,7 +129,7 @@ void preciceAdapter::FSI::FluidStructureInteraction::addWriters(std::string data
         interface->addCouplingDataWriter
         (
             dataName,
-            new Displacement(mesh_, namePointDisplacement_)
+            new Displacement(mesh_, namePointDisplacement_, nameCellDisplacement_)
         );
         DEBUG(adapterInfo("Added writer: Displacement."));
     }
@@ -162,7 +166,7 @@ void preciceAdapter::FSI::FluidStructureInteraction::addReaders(std::string data
         interface->addCouplingDataReader
         (
             dataName,
-            new DisplacementDelta(mesh_, namePointDisplacement_)
+            new DisplacementDelta(mesh_, namePointDisplacement_, nameCellDisplacement_)
         );
         DEBUG(adapterInfo("Added reader: DisplacementDelta."));
     }
@@ -171,7 +175,7 @@ void preciceAdapter::FSI::FluidStructureInteraction::addReaders(std::string data
         interface->addCouplingDataReader
         (
             dataName,
-            new Displacement(mesh_, namePointDisplacement_)
+            new Displacement(mesh_, namePointDisplacement_, nameCellDisplacement_)
         );
         DEBUG(adapterInfo("Added reader: Displacement."));
     }

--- a/FSI/FSI.H
+++ b/FSI/FSI.H
@@ -32,6 +32,9 @@ protected:
     //- Name of the pointDisplacement field
     std::string namePointDisplacement_ = "pointDisplacement";
 
+    //- Name of the pointDisplacement field
+    std::string nameCellDisplacement_ = "cellDisplacement";
+
     /* TODO: Declare here any parameters that should be read from
     /  the configuration file. See CHT/CHT.H for reference.
     /  We want to support in-house solvers with different field names,

--- a/Interface.C
+++ b/Interface.C
@@ -237,6 +237,9 @@ void preciceAdapter::Interface::addCouplingDataWriter
     // Set the patchIDs of the patches that form the interface
     couplingDataWriter->setPatchIDs(patchIDs_);
 
+    // Set the location type in the CouplingDataUser class
+    couplingDataWriter->setLocationsType(locationsType_);
+
     // Add the CouplingDataUser to the list of writers
     couplingDataWriters_.push_back(couplingDataWriter);
 }
@@ -253,6 +256,10 @@ void preciceAdapter::Interface::addCouplingDataReader
 
     // Add the CouplingDataUser to the list of readers
     couplingDataReader->setPatchIDs(patchIDs_);
+
+    // Set the location type in the CouplingDataUser class
+    couplingDataReader->setLocationsType(locationsType_);
+
     couplingDataReaders_.push_back(couplingDataReader);
 }
 

--- a/Interface.C
+++ b/Interface.C
@@ -240,6 +240,9 @@ void preciceAdapter::Interface::addCouplingDataWriter
     // Set the location type in the CouplingDataUser class
     couplingDataWriter->setLocationsType(locationsType_);
 
+    // Initilaize class specific data
+    couplingDataWriter->initialize();
+
     // Add the CouplingDataUser to the list of writers
     couplingDataWriters_.push_back(couplingDataWriter);
 }
@@ -259,6 +262,9 @@ void preciceAdapter::Interface::addCouplingDataReader
 
     // Set the location type in the CouplingDataUser class
     couplingDataReader->setLocationsType(locationsType_);
+
+    // Initilaize class specific data
+    couplingDataReader->initialize();
 
     couplingDataReaders_.push_back(couplingDataReader);
 }

--- a/Interface.C
+++ b/Interface.C
@@ -266,6 +266,7 @@ void preciceAdapter::Interface::addCouplingDataReader
     // Initilaize class specific data
     couplingDataReader->initialize();
 
+    // Add the CouplingDataUser to the list of readers
     couplingDataReaders_.push_back(couplingDataReader);
 }
 


### PR DESCRIPTION
Resolves #146 
However, it comes at the price of a repeated memory allocation for the intermediate 'center based' field in order to transform the buffer into an OpenFOAM suitable format. A variant similar to https://github.com/DavidSCN/openfoam-adapter/pull/1 would be much better.

Open question: how should we proceed in 3D? Should we stick to this variant or should be fall back to the `faceNodes`? Also, I'm still not sure about the formatting, but afaik we don't have standard yet.