### PR TITLE
Refactor Force based data sets

### DIFF
--- a/FSI/FSI.C
+++ b/FSI/FSI.C
@@ -111,7 +111,7 @@ void preciceAdapter::FSI::FluidStructureInteraction::addWriters(std::string data
             interface->addCouplingDataWriter
             (
                 dataName,
-                new Force(mesh_, runTime_.timeName(), solverType_) /* TODO: Add any other arguments here */
+                new Force(mesh_, solverType_) /* TODO: Add any other arguments here */
             );
             DEBUG(adapterInfo("Added writer: Force."));        
     }    
@@ -138,7 +138,7 @@ void preciceAdapter::FSI::FluidStructureInteraction::addWriters(std::string data
       interface->addCouplingDataWriter
           (
               dataName,
-              new Stress(mesh_, runTime_.timeName(), solverType_) /* TODO: Add any other arguments here */
+              new Stress(mesh_, solverType_) /* TODO: Add any other arguments here */
               );
       DEBUG(adapterInfo("Added writer: Stress."));
     }
@@ -157,7 +157,7 @@ void preciceAdapter::FSI::FluidStructureInteraction::addReaders(std::string data
         interface->addCouplingDataReader
         (
             dataName,
-            new Force(mesh_, runTime_.timeName(), solverType_) /* TODO: Add any other arguments here */
+            new Force(mesh_, solverType_) /* TODO: Add any other arguments here */
         );
         DEBUG(adapterInfo("Added reader: Force."));
     }
@@ -184,7 +184,7 @@ void preciceAdapter::FSI::FluidStructureInteraction::addReaders(std::string data
       interface->addCouplingDataReader
           (
               dataName,
-              new Stress(mesh_, runTime_.timeName(), solverType_) /* TODO: Add any other arguments here */
+              new Stress(mesh_, solverType_) /* TODO: Add any other arguments here */
               );
       DEBUG(adapterInfo("Added reader: Stress."));
     }

--- a/FSI/Force.C
+++ b/FSI/Force.C
@@ -4,48 +4,18 @@ using namespace Foam;
 
 preciceAdapter::FSI::Force::Force
 (
-        const Foam::fvMesh& mesh,
-        const std::string solverType
-)
-:
-mesh_(mesh),
-solverType_(solverType),
-force_field_created(false)
-{}
-
-
-preciceAdapter::FSI::Force::Force
-(
     const Foam::fvMesh& mesh,
-    const fileName& timeName,
     const std::string solverType
-    /* TODO: We should add any required field names here.
-    /  They would need to be vector fields.
-    /  See FSI/Temperature.C for details.
-    */
 )
 :
-mesh_(mesh),
-solverType_(solverType),
-force_field_created(true)
+ForceBase(mesh,solverType)
 {
-    //What about type "basic"?
-    if (solverType_.compare("incompressible") != 0 && solverType_.compare("compressible") != 0) 
-    {
-        FatalErrorInFunction
-            << "Forces calculation does only support "
-            << "compressible or incompressible solver type."
-            << exit(FatalError);
-    }
-    
-    dataType_ = vector;
-
     Force_ = new volVectorField
     (
         IOobject
         (
             "Force",
-            timeName,
+            mesh_.time().timeName(),
             mesh,
             IOobject::NO_READ,
             IOobject::AUTO_WRITE
@@ -60,232 +30,23 @@ force_field_created(true)
     );
 }
 
-//Calculate viscous force
-Foam::tmp<Foam::volSymmTensorField> preciceAdapter::FSI::Force::devRhoReff() const
-{
-    //For turbulent flows 
-    typedef compressible::turbulenceModel cmpTurbModel;
-    typedef incompressible::turbulenceModel icoTurbModel;   
-    
-    if (mesh_.foundObject<cmpTurbModel>(cmpTurbModel::propertiesName))
-    {
-        const cmpTurbModel & turb
-        (
-            mesh_.lookupObject<cmpTurbModel>(cmpTurbModel::propertiesName)
-        );
-
-        return turb.devRhoReff();
-
-    }
-    else if (mesh_.foundObject<icoTurbModel>(icoTurbModel::propertiesName))
-    {
-        const incompressible::turbulenceModel& turb
-        (
-            mesh_.lookupObject<icoTurbModel>(icoTurbModel::propertiesName)
-        );
-
-        return rho()*turb.devReff();        
-    }
-    else
-    {        
-        // For laminar flows get the velocity  
-        const volVectorField & U
-        (
-            mesh_.lookupObject<volVectorField>("U")
-        );
-        
-        return -mu()*dev(twoSymm(fvc::grad(U)));
-    }
-}
-
-//lookup correct rho
-Foam::tmp<Foam::volScalarField> preciceAdapter::FSI::Force::rho() const
-{
-    // If volScalarField exists, read it from registry (for compressible cases)
-    // interFoam is incompressible but has volScalarField rho
-
-    if (mesh_.foundObject<volScalarField>("rho"))
-    {        
-        return mesh_.lookupObject<volScalarField>("rho");            
-    }
-    else if (solverType_.compare("incompressible") == 0)
-    {        
-        const dictionary& FSIDict =
-            mesh_.lookupObject<IOdictionary>("preciceDict").subOrEmptyDict("FSI");
-            
-        return tmp<volScalarField>
-        (
-            new volScalarField
-            (
-                IOobject
-                (
-                    "rho",
-                    mesh_.time().timeName(),
-                    mesh_,
-                    IOobject::NO_READ,
-                    IOobject::NO_WRITE
-                ),
-                mesh_,
-                dimensionedScalar(FSIDict.lookup("rho"))
-            )
-        );
-        
-    } 
-    else
-    {
-        FatalErrorInFunction
-            << "Did not find the correct rho."
-            << exit(FatalError);
-            
-        return volScalarField::null();
-    }
-}
-
-//lookup correct mu
-Foam::tmp<Foam::volScalarField> preciceAdapter::FSI::Force::mu() const
-{ 
-
-    if (solverType_.compare("incompressible") == 0)
-    {
-        typedef immiscibleIncompressibleTwoPhaseMixture iitpMixture;
-        if (mesh_.foundObject<iitpMixture>("mixture"))
-        {
-            const iitpMixture& mixture
-            (
-                mesh_.lookupObject<iitpMixture>("mixture")
-            );
-                
-            return mixture.mu();
-        }
-        else
-        {        
-        
-            const dictionary& FSIDict =
-                mesh_.lookupObject<IOdictionary>("preciceDict").subOrEmptyDict("FSI");
-                
-            dimensionedScalar nu(FSIDict.lookup("nu"));       
-            
-            return tmp<volScalarField>
-            (
-                new volScalarField
-                (  
-                    nu*rho()
-                )
-            );
-        }
-
-    }
-    else if (solverType_.compare("compressible") == 0)
-    {
-        return mesh_.lookupObject<volScalarField>("thermo:mu");
-    }
-    else
-    {
-        FatalErrorInFunction
-            << "Did not find the correct mu."
-            << exit(FatalError);
-            
-        return volScalarField::null();
-    }
-}
-
 void preciceAdapter::FSI::Force::write(double * buffer, bool meshConnectivity, const unsigned int dim)
 {
-    // Compute forces. See the Forces function object.
-
-    // Normal vectors on the boundary, multiplied with the face areas
-    const surfaceVectorField::Boundary& Sfb
-    (
-        mesh_.Sf().boundaryField()
-    );
-
-    // Stress tensor boundary field
-    tmp<volSymmTensorField> tdevRhoReff(devRhoReff());
-    const volSymmTensorField::Boundary& devRhoReffb
-    (
-        tdevRhoReff().boundaryField()
-    );
-
-    // Density boundary field
-    tmp<volScalarField> trho(rho());
-    const volScalarField::Boundary& rhob =
-        trho().boundaryField();
-
-    // Pressure boundary field
-    tmp<volScalarField> tp = mesh_.lookupObject<volScalarField>("p");
-    const volScalarField::Boundary& pb
-    (
-        tp().boundaryField()
-    );
-
-    int bufferIndex = 0;
-    // For every boundary patch of the interface
-    for (uint j = 0; j < patchIDs_.size(); j++)
-    {
-
-        int patchID = patchIDs_.at(j);
-
-        // Pressure forces
-        if (solverType_.compare("incompressible") == 0)
-        {
-            Force_->boundaryFieldRef()[patchID] =
-                Sfb[patchID] * pb[patchID] * rhob[patchID];
-        }
-        else if (solverType_.compare("compressible") == 0)
-        {
-            Force_->boundaryFieldRef()[patchID] =
-                Sfb[patchID] * pb[patchID];
-        }
-        else
-        {
-            FatalErrorInFunction
-                << "Forces calculation does only support "
-                << "compressible or incompressible solver type."
-                << exit(FatalError);
-        }
-
-        // Viscous forces
-        Force_->boundaryFieldRef()[patchID] +=
-            Sfb[patchID] & devRhoReffb[patchID];
-
-        // Write the forces to the preCICE buffer
-        // For every cell of the patch
-        forAll(Force_->boundaryField()[patchID], i)
-        {
-            // Copy the force into the buffer
-            // x-dimension
-            buffer[bufferIndex++]
-            = 
-            Force_->boundaryField()[patchID][i].x();
-
-            // y-dimension
-            buffer[bufferIndex++]
-            =
-            Force_->boundaryField()[patchID][i].y();
-
-            if(dim == 3)
-                // z-dimension
-                buffer[bufferIndex++]
-                        =
-                        Force_->boundaryField()[patchID][i].z();
-        }
-    }
+  this->writeToBuffer(buffer, *Force_, dim);
 }
 
 void preciceAdapter::FSI::Force::read(double * buffer, const unsigned int dim)
 {
-    /* TODO: Implement
-    * We need two nested for-loops for each patch,
-    * the outer for the locations and the inner for the dimensions.
-    * See the preCICE readBlockVectorData() implementation.
-    */
-    FatalErrorInFunction
-        << "Reading forces is not supported."
-        << exit(FatalError);
+    this->readFromBuffer(buffer);
+}
+
+vectorField preciceAdapter::FSI::Force::getFaceVectors(const unsigned int patchID) const
+{
+  // Normal vectors multiplied by face area
+  return mesh_.boundary()[patchID].Sf();
 }
 
 preciceAdapter::FSI::Force::~Force()
 {
-  if(force_field_created)
     delete Force_;
 }

--- a/FSI/Force.H
+++ b/FSI/Force.H
@@ -31,6 +31,7 @@ public:
     //- Read the forces values from the buffer
     void read(double * buffer, const unsigned int dim);
 
+    //- Returns the normal vectors multiplied by the face area
     Foam::vectorField getFaceVectors(const unsigned int patchID) const override;
 
     //- Destructor

--- a/FSI/Force.H
+++ b/FSI/Force.H
@@ -1,15 +1,7 @@
 #ifndef FSI_FORCE_H
 #define FSI_FORCE_H
 
-#include "CouplingDataUser.H"
-
-#include "fvCFD.H"
-
-#include "pointFields.H"
-#include "vectorField.H"
-#include "immiscibleIncompressibleTwoPhaseMixture.H"
-#include "turbulentFluidThermoModel.H"
-#include "turbulentTransportModel.H"
+#include "ForceBase.H"
 
 namespace preciceAdapter
 {
@@ -17,47 +9,14 @@ namespace FSI
 {
 
 //- Class that writes and reads force
-class Force : public CouplingDataUser
+class Force : public ForceBase
 {
-
 private:
-
-    //- OpenFOAM fvMesh object (we need to access the objects' registry multiple times)
-    const Foam::fvMesh& mesh_;
-    
-    const std::string solverType_;
 
     //- Force field
     Foam::volVectorField * Force_;
 
-    // Needed for inheritance to the Stress data field to avoid creating the Force
-    // field in case it is not required
-    const bool force_field_created;
-
-protected:
-    //- Stress tensor (see the OpenFOAM "Forces" function object)
-    Foam::tmp<Foam::volSymmTensorField> devRhoReff() const;
-    
-    Foam::tmp<Foam::volScalarField> rho() const;
-    
-    Foam::tmp<Foam::volScalarField> mu() const;
-
-
 public:
-
-    //- Constructor
-    Force
-    (
-        const Foam::fvMesh& mesh,
-        const fileName& timeName,
-        const std::string solverType
-        // We create an IOobject and we need the time directory
-        /* TODO: We should add any required field names here.
-        /  They would need to be vector fields.
-        /  See CHT/Temperature.H for details.
-        /  Apply any changes also to Force.C.
-        */
-    );
 
     //- Constructor
     Force
@@ -72,9 +31,10 @@ public:
     //- Read the forces values from the buffer
     void read(double * buffer, const unsigned int dim);
 
+    Foam::vectorField getFaceVectors(const unsigned int patchID) const override;
+
     //- Destructor
     ~Force();
-
 };
 
 }

--- a/FSI/ForceBase.C
+++ b/FSI/ForceBase.C
@@ -1,0 +1,221 @@
+#include "ForceBase.H"
+
+using namespace Foam;
+
+
+preciceAdapter::FSI::ForceBase::ForceBase
+(
+    const Foam::fvMesh& mesh,
+    const std::string solverType
+)
+:
+mesh_(mesh),
+solverType_(solverType)
+{
+    //What about type "basic"?
+    if (solverType_.compare("incompressible") != 0 && solverType_.compare("compressible") != 0)
+    {
+        FatalErrorInFunction
+            << "Force based calculations only support "
+            << "compressible or incompressible solver types."
+            << exit(FatalError);
+    }
+
+    dataType_ = vector;
+}
+
+//Calculate viscous force
+Foam::tmp<Foam::volSymmTensorField> preciceAdapter::FSI::ForceBase::devRhoReff() const
+{
+    //For turbulent flows
+    typedef compressible::turbulenceModel cmpTurbModel;
+    typedef incompressible::turbulenceModel icoTurbModel;
+
+    if (mesh_.foundObject<cmpTurbModel>(cmpTurbModel::propertiesName))
+    {
+        const cmpTurbModel & turb
+        (
+            mesh_.lookupObject<cmpTurbModel>(cmpTurbModel::propertiesName)
+        );
+
+        return turb.devRhoReff();
+
+    }
+    else if (mesh_.foundObject<icoTurbModel>(icoTurbModel::propertiesName))
+    {
+        const incompressible::turbulenceModel& turb
+        (
+            mesh_.lookupObject<icoTurbModel>(icoTurbModel::propertiesName)
+        );
+
+        return rho()*turb.devReff();
+    }
+    else
+    {
+        // For laminar flows get the velocity
+        const volVectorField & U
+        (
+            mesh_.lookupObject<volVectorField>("U")
+        );
+
+        return -mu()*dev(twoSymm(fvc::grad(U)));
+    }
+}
+
+//lookup correct rho
+Foam::tmp<Foam::volScalarField> preciceAdapter::FSI::ForceBase::rho() const
+{
+    // If volScalarField exists, read it from registry (for compressible cases)
+    // interFoam is incompressible but has volScalarField rho
+
+    if (mesh_.foundObject<volScalarField>("rho"))
+    {
+        return mesh_.lookupObject<volScalarField>("rho");
+    }
+    else if (solverType_.compare("incompressible") == 0)
+    {
+        const dictionary& FSIDict =
+            mesh_.lookupObject<IOdictionary>("preciceDict").subOrEmptyDict("FSI");
+
+        return tmp<volScalarField>
+        (
+            new volScalarField
+            (
+                IOobject
+                (
+                    "rho",
+                    mesh_.time().timeName(),
+                    mesh_,
+                    IOobject::NO_READ,
+                    IOobject::NO_WRITE
+                ),
+                mesh_,
+                dimensionedScalar(FSIDict.lookup("rho"))
+            )
+        );
+
+    }
+    else
+    {
+        FatalErrorInFunction
+            << "Did not find the correct rho."
+            << exit(FatalError);
+
+        return volScalarField::null();
+    }
+}
+
+//lookup correct mu
+Foam::tmp<Foam::volScalarField> preciceAdapter::FSI::ForceBase::mu() const
+{
+
+    if (solverType_.compare("incompressible") == 0)
+    {
+        typedef immiscibleIncompressibleTwoPhaseMixture iitpMixture;
+        if (mesh_.foundObject<iitpMixture>("mixture"))
+        {
+            const iitpMixture& mixture
+            (
+                mesh_.lookupObject<iitpMixture>("mixture")
+            );
+
+            return mixture.mu();
+        }
+        else
+        {
+
+            const dictionary& FSIDict =
+                mesh_.lookupObject<IOdictionary>("preciceDict").subOrEmptyDict("FSI");
+
+            dimensionedScalar nu(FSIDict.lookup("nu"));
+
+            return tmp<volScalarField>
+            (
+                new volScalarField
+                (
+                    nu * rho()
+                )
+            );
+        }
+
+    }
+    else if (solverType_.compare("compressible") == 0)
+    {
+        return mesh_.lookupObject<volScalarField>("thermo:mu");
+    }
+    else
+    {
+        FatalErrorInFunction
+            << "Did not find the correct mu."
+            << exit(FatalError);
+
+        return volScalarField::null();
+    }
+}
+
+void preciceAdapter::FSI::ForceBase::writeToBuffer(double *                            buffer,
+                                                   volVectorField &                    forceField,
+                                                   const unsigned int dim) const
+{
+  // Compute forces. See the Forces function object.
+  // Stress tensor boundary field
+  tmp<volSymmTensorField> tdevRhoReff(devRhoReff());
+  const volSymmTensorField::Boundary &devRhoReffb(
+      tdevRhoReff().boundaryField());
+
+  // Density boundary field
+  tmp<volScalarField>             trho(rho());
+  const volScalarField::Boundary &rhob =
+      trho().boundaryField();
+
+  // Pressure boundary field
+  tmp<volScalarField>             tp = mesh_.lookupObject<volScalarField>("p");
+  const volScalarField::Boundary &pb(
+      tp().boundaryField());
+
+  // For every boundary patch of the interface
+  for (const label patchID : patchIDs_) {
+
+    const auto &surface = getFaceVectors(patchID);
+
+    // Pressure forces
+    // FIXME: We need to substract the reference pressure for incompressible calculations
+    if (solverType_.compare("incompressible") == 0) {
+      forceField.boundaryFieldRef()[patchID] =
+          surface * pb[patchID] * rhob[patchID];
+    } else if (solverType_.compare("compressible") == 0) {
+      forceField.boundaryFieldRef()[patchID] =
+          surface * pb[patchID];
+    } else {
+      FatalErrorInFunction
+          << "Forces calculation does only support "
+          << "compressible or incompressible solver type."
+          << exit(FatalError);
+    }
+
+    // Viscous forces
+    forceField.boundaryFieldRef()[patchID] +=
+        surface & devRhoReffb[patchID];
+
+    // Write the forces to the preCICE buffer
+    // For every cell of the patch
+    forAll(forceField.boundaryField()[patchID], i)
+    {
+      for (unsigned int d = 0; d < dim; ++d)
+        buffer[i * dim + d] =
+            forceField.boundaryField()[patchID][i][d];
+    }
+  }
+}
+
+void preciceAdapter::FSI::ForceBase::readFromBuffer(double *buffer) const
+{
+  /* TODO: Implement
+    * We need two nested for-loops for each patch,
+    * the outer for the locations and the inner for the dimensions.
+    * See the preCICE readBlockVectorData() implementation.
+    */
+  FatalErrorInFunction
+      << "Reading forces is not supported."
+      << exit(FatalError);
+}

--- a/FSI/ForceBase.H
+++ b/FSI/ForceBase.H
@@ -1,0 +1,56 @@
+#ifndef FORCEBASE_H
+#define FORCEBASE_H
+
+
+#include "CouplingDataUser.H"
+
+#include "fvCFD.H"
+
+#include "pointFields.H"
+#include "vectorField.H"
+#include "immiscibleIncompressibleTwoPhaseMixture.H"
+#include "turbulentFluidThermoModel.H"
+#include "turbulentTransportModel.H"
+
+namespace preciceAdapter
+{
+namespace FSI
+{
+
+//- Class that writes and reads force
+class ForceBase : public CouplingDataUser
+{
+protected:
+    //- Stress tensor (see the OpenFOAM "Forces" function object)
+    Foam::tmp<Foam::volSymmTensorField> devRhoReff() const;
+
+    Foam::tmp<Foam::volScalarField> rho() const;
+
+    Foam::tmp<Foam::volScalarField> mu() const;
+
+    //- OpenFOAM fvMesh object (we need to access the objects' registry multiple times)
+    const Foam::fvMesh& mesh_;
+
+    const std::string solverType_;
+
+public:
+
+    //- Constructor
+    ForceBase
+    (
+        const Foam::fvMesh& mesh,
+        const std::string solverType
+    );
+
+    void writeToBuffer(double *                                  buffer,
+                       Foam::volVectorField &                    forceField,
+                       const unsigned int                        dim) const;
+
+    void readFromBuffer(double *buffer) const;
+
+    virtual Foam::vectorField getFaceVectors(const unsigned int patchID) const = 0;
+};
+}
+}
+
+#endif // FORCEBASE_H

--- a/FSI/Stress.C
+++ b/FSI/Stress.C
@@ -42,7 +42,8 @@ void preciceAdapter::FSI::Stress::read(double * buffer, const unsigned int dim)
 
 vectorField preciceAdapter::FSI::Stress::getFaceVectors(const unsigned int patchID) const
 {
-  return mesh_.boundary()[patchID].nf();
+    // face normal vectors
+    return mesh_.boundary()[patchID].nf();
 }
 
 preciceAdapter::FSI::Stress::~Stress()

--- a/FSI/Stress.C
+++ b/FSI/Stress.C
@@ -5,34 +5,17 @@ using namespace Foam;
 preciceAdapter::FSI::Stress::Stress
 (
     const Foam::fvMesh& mesh,
-    const fileName& timeName,
     const std::string solverType
-    /* TODO: We should add any required field names here.
-    /  They would need to be vector fields.
-    /  See FSI/Temperature.C for details.
-    */
 )
 :
-Force(mesh,solverType),
-mesh_(mesh),
-solverType_(solverType)
+ForceBase(mesh,solverType)
 {
-    if (solverType_.compare("incompressible") != 0 && solverType_.compare("compressible") != 0)
-    {
-        FatalErrorInFunction
-            << "Stresses calculation only supports "
-            << "compressible or incompressible solver type."
-            << exit(FatalError);
-    }
-    
-    dataType_ = vector;
-
     Stress_ = new volVectorField
     (
         IOobject
         (
             "Stress",
-            timeName,
+            mesh_.time().timeName(),
             mesh,
             IOobject::NO_READ,
             IOobject::AUTO_WRITE
@@ -49,96 +32,17 @@ solverType_(solverType)
 
 void preciceAdapter::FSI::Stress::write(double * buffer, bool meshConnectivity, const unsigned int dim)
 {
-    // Compute stress. See the Forces function object.
-
-    // Stress tensor boundary field
-    tmp<volSymmTensorField> tdevRhoReff(this->devRhoReff());
-    const volSymmTensorField::Boundary& devRhoReffb
-    (
-        tdevRhoReff().boundaryField()
-    );
-
-    // Density boundary field
-    tmp<volScalarField> trho(this->rho());
-    const volScalarField::Boundary& rhob
-    (
-        trho().boundaryField()
-    );
-
-    // Pressure boundary field
-    tmp<volScalarField> tp(mesh_.lookupObject<volScalarField>("p"));
-    const volScalarField::Boundary& pb
-    (
-        tp().boundaryField()
-    );
-
-    int bufferIndex = 0;
-    // For every boundary patch of the interface
-    for (uint j = 0; j < patchIDs_.size(); j++)
-    {
-
-        int patchID = patchIDs_.at(j);
-
-        // Compute normal vectors on each patch
-        const vectorField nV = mesh_.boundary()[patchID].nf();
-
-        // Pressure constribution
-        if (solverType_.compare("incompressible") == 0)
-        {
-            Stress_->boundaryFieldRef()[patchID] =
-                nV * pb[patchID] * rhob[patchID];
-        }
-        else if (solverType_.compare("compressible") == 0)
-        {
-            Stress_->boundaryFieldRef()[patchID] =
-                nV * pb[patchID];
-        }
-        else
-        {
-            FatalErrorInFunction
-                << "Stress calculation does only support "
-                << "compressible or incompressible solver type."
-                << exit(FatalError);
-        }
-
-        // Viscous contribution
-        Stress_->boundaryFieldRef()[patchID] +=
-            nV & devRhoReffb[patchID];
-
-        // Write the stress to the preCICE buffer
-        // For every cell of the patch
-        forAll(Stress_->boundaryField()[patchID], i)
-        {
-            // Copy the stress into the buffer
-            // x-dimension
-            buffer[bufferIndex++]
-            = 
-            Stress_->boundaryField()[patchID][i].x();
-
-            // y-dimension
-            buffer[bufferIndex++]
-            =
-            Stress_->boundaryField()[patchID][i].y();
-
-            if(dim == 3)
-                // z-dimension
-                buffer[bufferIndex++]
-                        =
-                        Stress_->boundaryField()[patchID][i].z();
-        }
-    }
+  this->writeToBuffer(buffer, *Stress_, dim);
 }
 
 void preciceAdapter::FSI::Stress::read(double * buffer, const unsigned int dim)
 {
-    /* TODO: Implement
-    * We need two nested for-loops for each patch,
-    * the outer for the locations and the inner for the dimensions.
-    * See the preCICE readBlockVectorData() implementation.
-    */
-    FatalErrorInFunction
-        << "Reading stresses is not supported."
-        << exit(FatalError);
+    this->readFromBuffer(buffer);
+}
+
+vectorField preciceAdapter::FSI::Stress::getFaceVectors(const unsigned int patchID) const
+{
+  return mesh_.boundary()[patchID].nf();
 }
 
 preciceAdapter::FSI::Stress::~Stress()

--- a/FSI/Stress.H
+++ b/FSI/Stress.H
@@ -1,16 +1,7 @@
 #ifndef FSI_STRESS_H
 #define FSI_STRESS_H
 
-#include "CouplingDataUser.H"
-#include "Force.H"
-
-#include "fvCFD.H"
-
-#include "pointFields.H"
-#include "vectorField.H"
-#include "immiscibleIncompressibleTwoPhaseMixture.H"
-#include "turbulentFluidThermoModel.H"
-#include "turbulentTransportModel.H"
+#include "ForceBase.H"
 
 namespace preciceAdapter
 {
@@ -22,30 +13,19 @@ namespace FSI
 // cell face. Thus, a consistent quantity. Calculation concept has been copied
 // from the force module, but the scaled version here is commonly used in FEM
 // applications.
-class Stress : public Force {
+class Stress : public ForceBase {
 
 private:
-
-    //- OpenFOAM fvMesh object (we need to access the objects' registry multiple times)
-    const Foam::fvMesh& mesh_;
-    
-    const std::string solverType_;
-
     //- Stress field
     Foam::volVectorField * Stress_;
-
 
 public:
 
     //- Constructor
     Stress
     (
-        const Foam::fvMesh& mesh,
-        const fileName& timeName,
-        const std::string solverType
-        // We create an IOobject and we need the time directory
-        /* TODO: We should add any required field names here.
-        */
+     const Foam::fvMesh& mesh,
+     const std::string solverType
     );
 
     //- Write the stress values into the buffer
@@ -53,6 +33,8 @@ public:
 
     //- Read the stress values from the buffer
     void read(double * buffer, const unsigned int dim);
+
+    Foam::vectorField getFaceVectors(const unsigned int patchID) const override;
 
     //- Destructor
     ~Stress();

--- a/FSI/Stress.H
+++ b/FSI/Stress.H
@@ -34,6 +34,7 @@ public:
     //- Read the stress values from the buffer
     void read(double * buffer, const unsigned int dim);
 
+    //- Returns the face normal vectors (no multiplication by area)
     Foam::vectorField getFaceVectors(const unsigned int patchID) const override;
 
     //- Destructor

--- a/Make/files
+++ b/Make/files
@@ -13,6 +13,7 @@ CHT/SinkTemperature.C
 CHT/CHT.C
 
 FSI/FSI.C
+FSI/ForceBase.C
 FSI/Force.C
 FSI/Stress.C
 FSI/Displacement.C


### PR DESCRIPTION
I took the opportunity to clean-up the Force based data classes and split the common functionality in a base class. The PR reverts a crime introduced in #134 and partially #125, reduces code duplication and makes the whole data set much easier to maintain. Closes #139.

I hope we can run the tests on this PR.