### PR TITLE
Turn off debug messages by default

### DIFF
--- a/Allwmake
+++ b/Allwmake
@@ -17,7 +17,7 @@ ADAPTER_PRECICE_ROOT="${PRECICE_ROOT}"
 # ADAPTER_PRECICE_DEP="${ADAPTER_PRECICE_DEP} -lpython2.7"
 
 # Optional: Preprocessor flags ("-DADAPTER_DEBUG_MODE" enables debug messages)
-ADAPTER_PREP_FLAGS="-DADAPTER_DEBUG_MODE"
+ADAPTER_PREP_FLAGS=""
 
 # Optional: Flags used by wmake.
 # In order to compile with multiple threads, add e.g. "-j 4".

--- a/Interface.C
+++ b/Interface.C
@@ -96,7 +96,6 @@ void preciceAdapter::Interface::configureMesh(const fvMesh& mesh)
               for (unsigned int d = 0; d < dim_; ++d)
                 vertices[verticesIndex++] = faceCenters[i][d];
 
-#ifdef ADAPTER_DEBUG_MODE
             // Check if we are in the right layer in case of preCICE dimension 2
             // If there is at least one node with a different z-coordinate, then the (2D) geometry is not on the xy-plane, as required.
             if (dim_ == 2) {
@@ -131,7 +130,6 @@ void preciceAdapter::Interface::configureMesh(const fvMesh& mesh)
                          "Please rotate your geometry so that the geometry is located in the xy-plane."
                       << exit(FatalError);
             }
-#endif
         }
 
         // Pass the mesh vertices information to preCICE


### PR DESCRIPTION
Until now, we always had debug messages turned on by default, which maybe was a bit too much for the user. Similarly, this makes log files unnecessarily longer/noisier and potentially everything slower.

I have the impression that for a while these additional messages have not really helped us discover new problems in user-submitted log files and they can always very easily be turned on again, if needed. I suggest that we change this default.

Now it would also be a good time since we anyway massively update the tutorials and the user will notice related changes.

This does not change the compilation mode, which is the OpenFOAM default, or as set by the user on the OpenFOAM side.

Partially related to #89.

@DavidSCN please merge if you aggree.