### PR TITLE
Re-enable multi-core builds

### DIFF
--- a/Allwmake
+++ b/Allwmake
@@ -73,7 +73,7 @@ log "  pkg-config --libs libprecice    = ${ADAPTER_PKG_CONFIG_LIBS}"
 # Run wmake (build the adapter) and check the exit code
 log ""
 log "Building with WMake (see the wmake.log log file)...\n"
-if ! wmake "${ADAPTER_WMAKE_OPTIONS}" libso 2>&1 | tee wmake.log ||
+if ! wmake ${ADAPTER_WMAKE_OPTIONS} libso 2>&1 | tee wmake.log ||
     [ "$(grep -c -E "error:" wmake.log)" -ne 0 ]; then
     log "=== ERROR: Building failed. See wmake.log for more. ==="
     log "Possible causes:"

--- a/Allwmake
+++ b/Allwmake
@@ -6,10 +6,12 @@ set -e -u
 # Optional: Preprocessor flags ("-DADAPTER_DEBUG_MODE" enables debug messages)
 ADAPTER_PREP_FLAGS=""
 
-# Optional: Flags used by wmake.
+# Build command and options
 # In order to compile with multiple threads, add e.g. "-j 4".
 # Make sure that these options are supported by your OpenFOAM version.
-ADAPTER_WMAKE_OPTIONS=""
+adapter_build_command(){
+    wmake -j 4 libso
+}
 
 # Where should the adapter be built? Default: "${FOAM_USER_LIBBIN}"
 ADAPTER_TARGET_DIR="${FOAM_USER_LIBBIN:-}"
@@ -63,7 +65,6 @@ fi
 log ""
 log "The adapter will be built into ${ADAPTER_TARGET_DIR}"
 log "Additional preprocessor/compiler options: ${ADAPTER_PREP_FLAGS}"
-log "Additional WMake options: ${ADAPTER_WMAKE_OPTIONS}"
 
 log ""
 log "If not already known by the system, preCICE may be located using:"
@@ -73,7 +74,7 @@ log "  pkg-config --libs libprecice    = ${ADAPTER_PKG_CONFIG_LIBS}"
 # Run wmake (build the adapter) and check the exit code
 log ""
 log "Building with WMake (see the wmake.log log file)...\n"
-if ! wmake ${ADAPTER_WMAKE_OPTIONS} libso 2>&1 | tee wmake.log ||
+if ! adapter_build_command 2>&1 | tee wmake.log ||
     [ "$(grep -c -E "error:" wmake.log)" -ne 0 ]; then
     log "=== ERROR: Building failed. See wmake.log for more. ==="
     log "Possible causes:"

--- a/docs/get.md
+++ b/docs/get.md
@@ -17,7 +17,7 @@ To build the adapter, you need to install a few dependencies and then execute th
 4. Execute the build script: `./Allwmake`.
     * See and adjust the configuration in the beginning of the script first, if needed.
     * Check for any error messages and suggestions at the end.
-    * Ask OpenFOAM to use more threads for compiling the code by setting, for example, `export WM_NCOMPPROCS=4`
+    * Modify the `adapter_build_command` to e.g. build using more threads, e.g. `wmake -j 4 libso`.
 
 The `-DADAPTER_DEBUG_MODE` flag inside `ADAPTER_PREP_FLAGS` activates additional debug messages. You may also change the target directory or specify the number of threads to use for the compilation. See the comments in `Allwmake` for more.
 


### PR DESCRIPTION
The problem occurred due to the double-quotes. Shellcheck will actually complain about this. This particular exception is described here: https://github.com/koalaman/shellcheck/wiki/SC2086#exceptions
We could find an alternative by restricting the script to `bash` etc. I would propose to just go this way.

Another comment. The environment variable as described in the wiki doesn't seem to work. Does it work for you?