### PR TITLE
Add maintainers in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@
     <img src="https://travis-ci.org/precice/openfoam-adapter.svg?branch=master" alt="Build status">
 </a> -->
 
+As of April 2021, `precice/openfoam-adapter` is actively developed. Current maintainers: [@MakisH](https://github.com/MakisH/) and [@DavidSCN](https://github.com/DavidSCN). Have a look at open [good first issues](https://github.com/precice/openfoam-adapter/issues?q=is%3Aopen+is%3Aissue+label%3A%22good+first+issue%22) and [where we need help](https://github.com/precice/openfoam-adapter/issues?q=is%3Aopen+is%3Aissue+label%3A%22help+wanted%22).
+
 ## Start here
 
 See the [adapter documentation](https://precice.org/adapter-openfoam-overview.html) and related [tutorials](https://precice.org/tutorials.html).


### PR DESCRIPTION
A recurring comment by the preCICE community is that they don't know which adapters are actively developed, what we are working on, or where we need help.

This PR adds the following in `README.md`:
> As of April 2021, `precice/openfoam-adapter` is actively developed. Current maintainers: [@MakisH](https://github.com/MakisH/) and [@DavidSCN](https://github.com/DavidSCN). Have a look at open [good first issues](https://github.com/precice/openfoam-adapter/issues?q=is%3Aopen+is%3Aissue+label%3A%22good+first+issue%22) and [where we need help](https://github.com/precice/openfoam-adapter/issues?q=is%3Aopen+is%3Aissue+label%3A%22help+wanted%22).

I hope we will remember to update the date and list of maintainers with every release. I write `precice/openfoam-adapter` to prevent confusions in forks.

We could also add a [GitHub `CODEOWNERS` file](https://docs.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners) so that we automatically get assigned reviews, but I guess this project is too small for this change to have any effect, leading only to duplication.

@DavidSCN please review and merge if you would give me the honor of officially being a co-maintainer. :hugs: 