### PR TITLE
Add a GitHub action for automated synchronization

### DIFF
--- a/.github/workflows/sync-version.yml
+++ b/.github/workflows/sync-version.yml
@@ -1,24 +1,18 @@
-name: Sync
 on:
   push:
     branches:
-      - master
+    - master
 
 jobs:
-  sync-branches:
+  pull-request:
     runs-on: ubuntu-latest
-    name: Syncing branches
     steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-      - name: Set up Node
-        uses: actions/setup-node@v1
-        with:
-          node-version: 12
-      - name: Opening pull request
-        id: pull
-        uses: tretuna/sync-branches@1.2.0
-        with:
-          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
-          FROM_BRANCH: "master"
-          TO_BRANCH: "OpenFOAM7"
+    - uses: actions/checkout@v2
+    - name: pull-request
+      uses: repo-sync/pull-request@v2
+      with:
+        source_branch: ""                                 # If blank, default: triggered branch
+        destination_branch: "OpenFOAM7"                   
+        pr_title: "Synchronize ${{ github.ref }} with OpenFOAM7" # Title of pull request
+        pr_body: "*An automated PR*: additional branches to sync: OpenFOAM4, OpenFOAM6, OpenFAOMdev"              # Full markdown support, requires pr_title to be set
+        github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/sync-version.yml
+++ b/.github/workflows/sync-version.yml
@@ -1,0 +1,24 @@
+name: Sync
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  sync-branches:
+    runs-on: ubuntu-latest
+    name: Syncing branches
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Set up Node
+        uses: actions/setup-node@v1
+        with:
+          node-version: 12
+      - name: Opening pull request
+        id: pull
+        uses: tretuna/sync-branches@1.2.0
+        with:
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+          FROM_BRANCH: "master"
+          TO_BRANCH: "OpenFOAM7"


### PR DESCRIPTION
_This is just a suggestion_.

By default, we provide the adapter for the ESI versions. However, we also offer the org versions and we frequently forget to synchronize them. This action would automatically open up a PR when we push to master in order to synchronize (this is a draft, now only OF7) all other branches. It won't work right now, since I have not yet created the access token. I would first like to hear your opinion @MakisH .