### PR TITLE
Add .clang-format and reformat the codebase

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,175 @@
+---
+Language:        Cpp
+# BasedOnStyle:  LLVM
+#
+# Proposed clang-format-11 style for OpenFOAM, trying to follow the OpenFOAM style guide:
+#   https://develop.openfoam.com/Development/openfoam/-/wikis/coding/style/style
+# Configuration developed for the OpenFOAM-preCICE adapter code:
+#   https://github.com/precice/openfoam-adapter
+# Contribute to the discussion at the respective OpenFOAM issue:
+#   https://develop.openfoam.com/Development/openfoam/-/issues/1634
+#
+# Keep `public:` at the first indentation level
+AccessModifierOffset: -4
+# Undocumented guideline: align arguments after an open bracket.
+AlignAfterOpenBracket: Align
+AlignConsecutiveMacros: false
+AlignConsecutiveAssignments: false
+AlignConsecutiveBitFields: false
+AlignConsecutiveDeclarations: false
+AlignEscapedNewlines: Right
+# Align operands after operators (+,*,<<) (see BreakBeforeBinaryOperators)
+AlignOperands: AlignAfterOperator
+AlignTrailingComments: true
+AllowAllArgumentsOnNextLine: true
+AllowAllConstructorInitializersOnNextLine: true
+AllowAllParametersOfDeclarationOnNextLine: true
+AllowShortEnumsOnASingleLine: true
+AllowShortBlocksOnASingleLine: Never
+AllowShortCaseLabelsOnASingleLine: false
+AllowShortFunctionsOnASingleLine: All
+AllowShortLambdasOnASingleLine: All
+AllowShortIfStatementsOnASingleLine: Always
+AllowShortLoopsOnASingleLine: false
+# Guideline: Splitting return type and function name
+# (this guideline is apparently not strictly followed in OpenFOAM)
+# AlwaysBreakAfterReturnType: All
+AlwaysBreakBeforeMultilineStrings: false
+AlwaysBreakTemplateDeclarations: Yes
+BinPackArguments: false
+BinPackParameters: false
+# Covered by "BreakBeforeBraces"
+BraceWrapping:
+  AfterCaseLabel:  true
+  AfterClass:      true
+  AfterControlStatement: Always
+  AfterEnum:       true
+  AfterFunction:   true
+  AfterNamespace:  true
+  AfterObjCDeclaration: true
+  AfterStruct:     true
+  AfterUnion:      true
+  AfterExternBlock: true
+  BeforeCatch:     true
+  BeforeElse:      true
+  BeforeLambdaBody: true
+  BeforeWhile:     true
+  IndentBraces:    true
+  SplitEmptyFunction: true
+  SplitEmptyRecord: true
+  SplitEmptyNamespace: true
+# Guideline (almost): Splitting long lines at an = sign. Indent after split.
+# Guideline (almost): Splitting formulae over several lines.
+BreakBeforeBinaryOperators: NonAssignment
+# Always break before braces: if, for, functions, classes, etc.
+BreakBeforeBraces: Allman
+BreakBeforeInheritanceComma: false
+BreakInheritanceList: BeforeColon
+# Guideline (almost): Splitting logical tests over several lines.
+BreakBeforeTernaryOperators: true
+BreakConstructorInitializersBeforeComma: false
+# Undocumented guideline (almost): Have the initializer : in a new line.
+BreakConstructorInitializers: BeforeColon
+BreakStringLiterals: true
+# Here we could set the 80 charactes limit, but that would lead to more aggressive changes.
+ColumnLimit:     0
+CommentPragmas:  '^ IWYU pragma:'
+CompactNamespaces: false
+ConstructorInitializerAllOnOneLineOrOnePerLine: false
+ConstructorInitializerIndentWidth: 0
+ContinuationIndentWidth: 4
+Cpp11BracedListStyle: true
+DeriveLineEnding: true
+DerivePointerAlignment: false
+DisableFormat:   false
+# Undocumented guideline: add line after "public:" etc (since clang-format 12)
+# EmptyLineAfterAccessModifier: Always
+ExperimentalAutoDetectBinPacking: false
+FixNamespaceComments: false
+# Guideline: Macro loops are like for loops, but without a space.
+ForEachMacros:
+  - forAllIters
+  - forAllConstIters
+  - forAllReverseIters
+  - forAllConstReverseIters
+  - forAll
+  - forAllReverse
+  - forAllIter
+  - forAllConstIter
+IncludeBlocks:   Preserve
+IncludeCategories:
+  - Regex:           '^"(llvm|llvm-c|clang|clang-c)/'
+    Priority:        2
+    SortPriority:    0
+  - Regex:           '^(<|"(gtest|gmock|isl|json)/)'
+    Priority:        3
+    SortPriority:    0
+  - Regex:           '.*'
+    Priority:        1
+    SortPriority:    0
+IncludeIsMainRegex: '(Test)?$'
+IncludeIsMainSourceRegex: ''
+IndentCaseLabels: false
+IndentCaseBlocks: false
+IndentGotoLabels: true
+IndentPPDirectives: None
+IndentExternBlock: AfterExternBlock
+# Guideline: The normal indentation is 4 spaces per logical level.
+IndentWidth:     4
+IndentWrappedFunctionNames: false
+InsertTrailingCommas: None
+KeepEmptyLinesAtTheStartOfBlocks: true
+MacroBlockBegin: ''
+MacroBlockEnd:   ''
+# Required to not change code following the guidelines
+# "Leave two empty lines between sections" and
+# "Use two empty lines between functions"
+MaxEmptyLinesToKeep: 2
+NamespaceIndentation: None
+PenaltyBreakAssignment: 2
+PenaltyBreakBeforeFirstCallParameter: 19
+PenaltyBreakComment: 300
+PenaltyBreakFirstLessLess: 120
+PenaltyBreakString: 1000
+PenaltyBreakTemplateDeclaration: 10
+PenaltyExcessCharacter: 1000000
+PenaltyReturnTypeOnItsOwnLine: 60
+PointerAlignment: Left
+ReflowComments:  true
+# Do not change the order of include statements (could be catastrophic for OpenFOAM)
+SortIncludes:    false
+SortUsingDeclarations: false
+SpaceAfterCStyleCast: false
+SpaceAfterLogicalNot: false
+# No "template <T>" (guideline already used, but not documented)
+SpaceAfterTemplateKeyword: false
+SpaceBeforeAssignmentOperators: true
+# No a{1} (no guideline)
+SpaceBeforeCpp11BracedList: true
+SpaceBeforeCtorInitializerColon: true
+SpaceBeforeInheritanceColon: true
+# Guideline: Spaces in "if ()", "for ()", but not "forAll ()".
+SpaceBeforeParens: ControlStatementsExceptForEachMacros
+# Guideline: Range-based for should have a space surrounding the ':'.
+SpaceBeforeRangeBasedForLoopColon: true
+SpaceInEmptyBlock: false
+SpaceInEmptyParentheses: false
+SpacesBeforeTrailingComments: 1
+SpacesInAngles:  false
+SpacesInConditionalStatement: false
+# No "arr[3] = [ 1, 2, 3 ]" (no guideline).
+SpacesInContainerLiterals: false
+SpacesInCStyleCastParentheses: false
+SpacesInParentheses: false
+SpacesInSquareBrackets: false
+SpaceBeforeSquareBrackets: false
+# Treat the code as C++11 or later
+Standard:        Latest
+StatementMacros:
+TabWidth:        4
+UseCRLF:         false
+# Guideline: No tab characters - only use spaces for indentation.
+UseTab:          Never
+WhitespaceSensitiveMacros:
+...
+

--- a/.github/workflows/check-format.yml
+++ b/.github/workflows/check-format.yml
@@ -1,0 +1,13 @@
+name: Check code formatting
+on: [push, pull_request]
+jobs:
+  formatting-check:
+    name: Check formatting (clang-format)
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Run clang-format style check for C/C++ programs.
+      uses: jidicula/clang-format-action@v3.3.0
+      with:
+        clang-format-version: '11'
+        check-path: '.'

--- a/Adapter.C
+++ b/Adapter.C
@@ -7,9 +7,8 @@
 using namespace Foam;
 
 preciceAdapter::Adapter::Adapter(const Time& runTime, const fvMesh& mesh)
-:
-runTime_(runTime),
-mesh_(mesh)
+: runTime_(runTime),
+  mesh_(mesh)
 {
     adapterInfo("The preciceAdapter was loaded.", "info");
 
@@ -22,168 +21,173 @@ bool preciceAdapter::Adapter::configFileRead()
     // We need a try-catch here, as if reading preciceDict fails,
     // the respective exception will be reduced to a warning.
     // See also comment in preciceAdapter::Adapter::configure().
-    try {
+    try
+    {
         adapterInfo("Reading preciceDict...", "info");
 
         // TODO: static is just a quick workaround to be able
         // to find the dictionary also out of scope (e.g. in KappaEffective).
         // We need a better solution.
-        static IOdictionary preciceDict
-        (
-            IOobject
-            (
+        static IOdictionary preciceDict(
+            IOobject(
                 "preciceDict",
                 runTime_.system(),
                 mesh_,
                 IOobject::MUST_READ_IF_MODIFIED,
-                IOobject::NO_WRITE
-            )
-        );
-    
-    // Read and display the preCICE configuration file name
-    // NOTE: lookupType<T>("name") is deprecated in openfoam.com since v1812,
-    // which recommends get<T>("name") instead. However, get<T>("name")
-    // is not implemented in openfoam.org at the moment.
-    preciceConfigFilename_ = preciceDict.lookupType<fileName>("preciceConfig"); // We use this deprecated lookupType<>() for backwards compatibility
-    DEBUG(adapterInfo("  precice-config-file : " + preciceConfigFilename_));
+                IOobject::NO_WRITE));
 
-    // Read and display the participant name
-    participantName_ = preciceDict.lookupType<word>("participant"); // We use this deprecated lookupType<>() for backwards compatibility
-    DEBUG(adapterInfo("  participant name    : " + participantName_));
+        // Read and display the preCICE configuration file name
+        // NOTE: lookupType<T>("name") is deprecated in openfoam.com since v1812,
+        // which recommends get<T>("name") instead. However, get<T>("name")
+        // is not implemented in openfoam.org at the moment.
+        preciceConfigFilename_ = preciceDict.lookupType<fileName>("preciceConfig"); // We use this deprecated lookupType<>() for backwards compatibility
+        DEBUG(adapterInfo("  precice-config-file : " + preciceConfigFilename_));
 
-    // Read and display the list of modules
-    DEBUG(adapterInfo("  modules requested   : "));
-    wordList modules_ = preciceDict.lookupType<wordList>("modules"); // We use this deprecated lookupType<>() for backwards compatibility
-    for (auto module : modules_)
-    {
-        DEBUG(adapterInfo("  - " + module + "\n"));
-        
-        // Set the modules switches
-        if (module == "CHT") CHTenabled_ = true;
-        if (module == "FSI") FSIenabled_ = true;
-        if (module == "FF")  FFenabled_  = true;
-    }
+        // Read and display the participant name
+        participantName_ = preciceDict.lookupType<word>("participant"); // We use this deprecated lookupType<>() for backwards compatibility
+        DEBUG(adapterInfo("  participant name    : " + participantName_));
 
-    // Every interface is a subdictionary of "interfaces",
-    // each with an arbitrary name. Read all of them and create
-    // a list (here: pointer) of dictionaries.
-    const dictionary * interfaceDictPtr = preciceDict.subDictPtr("interfaces"); // We use this deprecated subDictPtr for backwards compatibility
-    DEBUG(adapterInfo("  interfaces : "));
-
-    // Check if we found any interfaces
-    // and get the details of each interface
-    if (!interfaceDictPtr)
-    {
-        adapterInfo("  Empty list of interfaces", "warning");
-        return false;
-    }
-    else
-    {
-        for (const entry& interfaceDictEntry : *interfaceDictPtr)
+        // Read and display the list of modules
+        DEBUG(adapterInfo("  modules requested   : "));
+        wordList modules_ = preciceDict.lookupType<wordList>("modules"); // We use this deprecated lookupType<>() for backwards compatibility
+        for (auto module : modules_)
         {
-            if(interfaceDictEntry.isDict())
+            DEBUG(adapterInfo("  - " + module + "\n"));
+
+            // Set the modules switches
+            if (module == "CHT")
+                CHTenabled_ = true;
+            if (module == "FSI")
+                FSIenabled_ = true;
+            if (module == "FF")
+                FFenabled_ = true;
+        }
+
+        // Every interface is a subdictionary of "interfaces",
+        // each with an arbitrary name. Read all of them and create
+        // a list (here: pointer) of dictionaries.
+        const dictionary* interfaceDictPtr = preciceDict.subDictPtr("interfaces"); // We use this deprecated subDictPtr for backwards compatibility
+        DEBUG(adapterInfo("  interfaces : "));
+
+        // Check if we found any interfaces
+        // and get the details of each interface
+        if (!interfaceDictPtr)
+        {
+            adapterInfo("  Empty list of interfaces", "warning");
+            return false;
+        }
+        else
+        {
+            for (const entry& interfaceDictEntry : *interfaceDictPtr)
             {
-                dictionary interfaceDict = interfaceDictEntry.dict();
-                struct InterfaceConfig interfaceConfig;
-
-                interfaceConfig.meshName = interfaceDict.lookupType<word>("mesh"); // We use this deprecated lookupType<>() for backwards compatibility
-                DEBUG(adapterInfo("  - mesh         : " + interfaceConfig.meshName));
-
-                // By default, assume "faceCenters" as locationsType
-                interfaceConfig.locationsType = interfaceDict.lookupOrDefault<word>("locations", "faceCenters");
-                DEBUG(adapterInfo("    locations    : " + interfaceConfig.locationsType));
-
-                // By default, assume that no mesh connectivity is required (i.e. no nearest-projection mapping)
-                interfaceConfig.meshConnectivity = interfaceDict.lookupOrDefault<bool>("connectivity", false);
-                // Mesh connectivity only makes sense in case of faceNodes, check and raise a warning otherwise
-                if(interfaceConfig.meshConnectivity && interfaceConfig.locationsType == "faceCenters")
+                if (interfaceDictEntry.isDict())
                 {
-                    DEBUG(adapterInfo("Mesh connectivity is not supported for faceCenters. \n"
-                                      "Please configure the desired interface with the locationsType faceNodes. \n"
-                                      "Have a look in the adapter documentation for detailed information.", "warning"));
+                    dictionary interfaceDict = interfaceDictEntry.dict();
+                    struct InterfaceConfig interfaceConfig;
+
+                    interfaceConfig.meshName = interfaceDict.lookupType<word>("mesh"); // We use this deprecated lookupType<>() for backwards compatibility
+                    DEBUG(adapterInfo("  - mesh         : " + interfaceConfig.meshName));
+
+                    // By default, assume "faceCenters" as locationsType
+                    interfaceConfig.locationsType = interfaceDict.lookupOrDefault<word>("locations", "faceCenters");
+                    DEBUG(adapterInfo("    locations    : " + interfaceConfig.locationsType));
+
+                    // By default, assume that no mesh connectivity is required (i.e. no nearest-projection mapping)
+                    interfaceConfig.meshConnectivity = interfaceDict.lookupOrDefault<bool>("connectivity", false);
+                    // Mesh connectivity only makes sense in case of faceNodes, check and raise a warning otherwise
+                    if (interfaceConfig.meshConnectivity && interfaceConfig.locationsType == "faceCenters")
+                    {
+                        DEBUG(adapterInfo("Mesh connectivity is not supported for faceCenters. \n"
+                                          "Please configure the desired interface with the locationsType faceNodes. \n"
+                                          "Have a look in the adapter documentation for detailed information.",
+                                          "warning"));
+                        return false;
+                    }
+                    DEBUG(adapterInfo("    connectivity : " + std::to_string(interfaceConfig.meshConnectivity)));
+
+                    DEBUG(adapterInfo("    patches      : "));
+                    wordList patches = interfaceDict.lookupType<wordList>("patches"); // We use this deprecated lookupType<>() for backwards compatibility
+                    for (auto patch : patches)
+                    {
+                        interfaceConfig.patchNames.push_back(patch);
+                        DEBUG(adapterInfo("      - " + patch));
+                    }
+
+                    DEBUG(adapterInfo("    writeData    : "));
+                    wordList writeData = interfaceDict.lookupType<wordList>("writeData"); // We use this deprecated lookupType<>() for backwards compatibility
+                    for (auto writeDatum : writeData)
+                    {
+                        interfaceConfig.writeData.push_back(writeDatum);
+                        DEBUG(adapterInfo("      - " + writeDatum));
+                    }
+
+                    DEBUG(adapterInfo("    readData     : "));
+                    wordList readData = interfaceDict.lookupType<wordList>("readData"); // We use this deprecated lookupType<>() for backwards compatibility
+                    for (auto readDatum : readData)
+                    {
+                        interfaceConfig.readData.push_back(readDatum);
+                        DEBUG(adapterInfo("      - " + readDatum));
+                    }
+                    interfacesConfig_.push_back(interfaceConfig);
+                }
+            }
+        }
+
+        // NOTE: set the switch for your new module here
+
+        // If the CHT module is enabled, create it, read the
+        // CHT-specific options and configure it.
+        if (CHTenabled_)
+        {
+            CHT_ = new CHT::ConjugateHeatTransfer(mesh_);
+            if (!CHT_->configure(preciceDict))
+                return false;
+        }
+
+        // If the FSI module is enabled, create it, read the
+        // FSI-specific options and configure it.
+        if (FSIenabled_)
+        {
+            // Check for unsupported FSI with meshConnectivity
+            for (uint i = 0; i < interfacesConfig_.size(); i++)
+            {
+                if (interfacesConfig_.at(i).meshConnectivity == true)
+                {
+                    adapterInfo(
+                        "Mesh connectivity is not supported for FSI, as, usually, "
+                        "the Solid participant needs to provide the connectivity information. "
+                        "Therefore, set provideMeshConnectivity = false. "
+                        "Have a look in the adapter documentation for more information. ",
+                        "warning");
                     return false;
                 }
-                DEBUG(adapterInfo("    connectivity : " + std::to_string(interfaceConfig.meshConnectivity)));
-              
-                DEBUG(adapterInfo("    patches      : "));
-                wordList patches = interfaceDict.lookupType<wordList>("patches"); // We use this deprecated lookupType<>() for backwards compatibility
-                for (auto patch : patches)
-                {
-                    interfaceConfig.patchNames.push_back(patch);
-                    DEBUG(adapterInfo("      - " + patch));
-                }
-              
-                DEBUG(adapterInfo("    writeData    : "));
-                wordList writeData = interfaceDict.lookupType<wordList>("writeData"); // We use this deprecated lookupType<>() for backwards compatibility
-                for (auto writeDatum : writeData)
-                {
-                    interfaceConfig.writeData.push_back(writeDatum);
-                    DEBUG(adapterInfo("      - " + writeDatum));
-                }
-
-                DEBUG(adapterInfo("    readData     : "));
-                wordList readData = interfaceDict.lookupType<wordList>("readData");  // We use this deprecated lookupType<>() for backwards compatibility
-                for (auto readDatum : readData)
-                {
-                    interfaceConfig.readData.push_back(readDatum);
-                    DEBUG(adapterInfo("      - " + readDatum));
-                }
-                interfacesConfig_.push_back(interfaceConfig);
             }
-        }
-    }
 
-    // NOTE: set the switch for your new module here
-
-    // If the CHT module is enabled, create it, read the
-    // CHT-specific options and configure it.
-    if (CHTenabled_)
-    {
-        CHT_ = new CHT::ConjugateHeatTransfer(mesh_);
-        if (!CHT_->configure(preciceDict)) return false;
-    }
-
-    // If the FSI module is enabled, create it, read the
-    // FSI-specific options and configure it.
-    if (FSIenabled_)
-    {
-        // Check for unsupported FSI with meshConnectivity
-        for (uint i = 0; i < interfacesConfig_.size(); i++)
-        {
-            if(interfacesConfig_.at(i).meshConnectivity == true )
-            {
-                adapterInfo(
-                    "Mesh connectivity is not supported for FSI, as, usually, "
-                    "the Solid participant needs to provide the connectivity information. "
-                    "Therefore, set provideMeshConnectivity = false. "
-                    "Have a look in the adapter documentation for more information. "
-                    ,"warning");
+            FSI_ = new FSI::FluidStructureInteraction(mesh_, runTime_);
+            if (!FSI_->configure(preciceDict))
                 return false;
-            }
         }
 
-        FSI_ = new FSI::FluidStructureInteraction(mesh_, runTime_);
-        if (!FSI_->configure(preciceDict)) return false;
-    }
+        if (FFenabled_)
+        {
+            FF_ = new FF::FluidFluid(mesh_);
+            if (!FF_->configure(preciceDict))
+                return false;
+        }
 
-    if (FFenabled_)
+        // NOTE: Create your module and read any options specific to it here
+
+        if (!CHTenabled_ && !FSIenabled_ && !FFenabled_) // NOTE: Add your new switch here
+        {
+            adapterInfo("No module is enabled.", "error-deferred");
+            return false;
+        }
+
+        // TODO: Loading modules should be implemented in more general way,
+        // in order to avoid code duplication. See issue #16 on GitHub.
+    }
+    catch (const Foam::error& e)
     {
-        FF_ = new FF::FluidFluid(mesh_);
-        if (!FF_->configure(preciceDict)) return false;
-    }
-
-    // NOTE: Create your module and read any options specific to it here
-
-    if (!CHTenabled_ && !FSIenabled_ && !FFenabled_) // NOTE: Add your new switch here
-    {
-        adapterInfo("No module is enabled.", "error-deferred");
-        return false;
-    }
-
-    // TODO: Loading modules should be implemented in more general way,
-    // in order to avoid code duplication. See issue #16 on GitHub.
-
-    } catch (const Foam::error &e) {
         adapterInfo(e.message(), "error-deferred");
         return false;
     }
@@ -209,14 +213,18 @@ void preciceAdapter::Adapter::configure()
         return;
     }
 
-    try{
+    try
+    {
         // Check the timestep type (fixed vs adjustable)
         DEBUG(adapterInfo("Checking the timestep type (fixed vs adjustable)..."));
         adjustableTimestep_ = runTime_.controlDict().lookupOrDefault("adjustTimeStep", false);
 
-        if (adjustableTimestep_) {
+        if (adjustableTimestep_)
+        {
             DEBUG(adapterInfo("  Timestep type: adjustable."));
-        } else {
+        }
+        else
+        {
             DEBUG(adapterInfo("  Timestep type: fixed."));
         }
 
@@ -231,7 +239,7 @@ void preciceAdapter::Adapter::configure()
         DEBUG(adapterInfo("Creating interfaces..."));
         for (uint i = 0; i < interfacesConfig_.size(); i++)
         {
-            Interface * interface = new Interface(*precice_, mesh_, interfacesConfig_.at(i).meshName, interfacesConfig_.at(i).locationsType, interfacesConfig_.at(i).patchNames, interfacesConfig_.at(i).meshConnectivity);
+            Interface* interface = new Interface(*precice_, mesh_, interfacesConfig_.at(i).meshName, interfacesConfig_.at(i).locationsType, interfacesConfig_.at(i).patchNames, interfacesConfig_.at(i).meshConnectivity);
             interfaces_.push_back(interface);
             DEBUG(adapterInfo("Interface created on mesh " + interfacesConfig_.at(i).meshName));
 
@@ -251,7 +259,7 @@ void preciceAdapter::Adapter::configure()
                 {
                     FSI_->addWriters(dataName, interface);
                 }
-                
+
                 // Add FF-related coupling data writers
                 if (FFenabled_)
                 {
@@ -277,7 +285,7 @@ void preciceAdapter::Adapter::configure()
                 {
                     FSI_->addReaders(dataName, interface);
                 }
-                
+
                 // Add FF-related coupling data readers
                 if (FFenabled_)
                 {
@@ -328,17 +336,16 @@ void preciceAdapter::Adapter::configure()
         // This has the side-effect of not triggering the end() method
         // in any function object normally. Therefore, we trigger it
         // when preCICE dictates to stop the coupling.
-        adapterInfo
-        (
+        adapterInfo(
             "Setting the solver's endTime to infinity to prevent early exits. "
             "Only preCICE will control the simulation's endTime. "
             "Any functionObject's end() method will be triggered by the adapter. "
             "You may disable this behavior in the adapter's configuration.",
-            "info"
-        );
+            "info");
         const_cast<Time&>(runTime_).setEndTime(GREAT);
-
-    } catch (const Foam::error &e) {
+    }
+    catch (const Foam::error& e)
+    {
         adapterInfo(e.message(), "error-deferred");
         errorsInConfigure = true;
     }
@@ -352,12 +359,10 @@ void preciceAdapter::Adapter::execute()
     {
         // Handle any errors during configure().
         // See the comments in configure() for details.
-        adapterInfo
-        (
+        adapterInfo(
             "There was a problem while configuring the adapter. "
             "See the log for details.",
-            "error"
-        );
+            "error");
     }
 
     // The solver has already solved the equations for this timestep.
@@ -406,12 +411,10 @@ void preciceAdapter::Adapter::execute()
         // (i.e. the solver wrote results that need to be updated)
         if (runTime_.timePath().type() == fileName::DIRECTORY)
         {
-            adapterInfo
-            (
+            adapterInfo(
                 "The coupling timestep completed. "
                 "Writing the updated results.",
-                "info"
-            );
+                "info");
             const_cast<Time&>(runTime_).writeNow();
         }
     }
@@ -429,12 +432,10 @@ void preciceAdapter::Adapter::execute()
         // Set the solver's endTime to now. The next evaluation of
         // runTime.run() will be false and the solver will exit.
         const_cast<Time&>(runTime_).setEndTime(runTime_.value());
-        adapterInfo
-        (
+        adapterInfo(
             "The simulation was ended by preCICE. "
             "Calling the end() methods of any functionObject explicitly.",
-            "info"
-        );
+            "info");
         const_cast<Time&>(runTime_).functionObjects().end();
     }
 
@@ -549,16 +550,14 @@ void preciceAdapter::Adapter::adjustSolverTimeStep()
             // Show a warning if runTimeModifiable is set
             if (runTime_.runTimeModifiable())
             {
-                adapterInfo
-                (
+                adapterInfo(
                     "You have enabled 'runTimeModifiable' in the "
                     "controlDict. The preciceAdapter does not yet "
                     "fully support this functionality when "
                     "'adjustableTimestep' is not enabled. "
                     "If you modify the 'deltaT' in the controlDict "
                     "during the simulation, it will not be updated.",
-                    "warning"
-                );
+                    "warning");
             }
 
             // Store the value
@@ -588,34 +587,26 @@ void preciceAdapter::Adapter::adjustSolverTimeStep()
     if (timestepSolverDetermined < timestepPrecice_)
     {
         // Add a bool 'subCycling = true' which is checked in the storeMeshPoints() function.
-        adapterInfo
-        (
+        adapterInfo(
             "The solver's timestep is smaller than the "
             "coupling timestep. Subcycling...",
-            "info"
-        );
+            "info");
         timestepSolver_ = timestepSolverDetermined;
         // TODO subcycling is enabled. For FSI the oldVolumes must be written, which is normally not done.
         if (FSIenabled_)
         {
-            adapterInfo
-            (
+            adapterInfo(
                 "The adapter does not fully support subcycling for FSI and instabilities may occur.",
-                "warning"
-            );
+                "warning");
         }
     }
     else if (timestepSolverDetermined > timestepPrecice_)
     {
-        adapterInfo
-        (
+        adapterInfo(
             "The solver's timestep cannot be larger than the coupling timestep."
-            " Adjusting from " +
-            std::to_string(timestepSolverDetermined) +
-            " to " +
-            std::to_string(timestepPrecice_),
-            "warning"
-        );
+            " Adjusting from "
+                + std::to_string(timestepSolverDetermined) + " to " + std::to_string(timestepPrecice_),
+            "warning");
         timestepSolver_ = timestepPrecice_;
     }
     else
@@ -741,9 +732,9 @@ void preciceAdapter::Adapter::reloadMeshPoints()
     const_cast<fvMesh&>(mesh_).movePoints(meshPoints_);
 
     DEBUG(adapterInfo("Moved mesh points to their previous locations."));
-    
+
     // TODO The if statement can be removed in this case, but it is still included for clarity
-    if ( meshCheckPointed )
+    if (meshCheckPointed)
     {
         readMeshCheckpoint();
     }
@@ -769,21 +760,13 @@ void preciceAdapter::Adapter::setupMeshCheckpointing()
     DEBUG(adapterInfo("Creating a list of the mesh checkpointed fields..."));
 
     // Add meshPhi to the checkpointed fields
-    addMeshCheckpointField
-    (
-        const_cast<surfaceScalarField&>
-        (
-            mesh_.phi()
-        )
-    );
+    addMeshCheckpointField(
+        const_cast<surfaceScalarField&>(
+            mesh_.phi()));
 #ifdef ADAPTER_DEBUG_MODE
-    adapterInfo
-    (
-        "Added " + mesh_.phi().name() +
-        " in the list of checkpointed fields."
-    );
+    adapterInfo(
+        "Added " + mesh_.phi().name() + " in the list of checkpointed fields.");
 #endif
-    
 }
 
 void preciceAdapter::Adapter::setupMeshVolCheckpointing()
@@ -791,34 +774,20 @@ void preciceAdapter::Adapter::setupMeshVolCheckpointing()
     DEBUG(adapterInfo("Creating a list of the mesh volume checkpointed fields..."));
     // Add the V0 and the V00 to the list of checkpointed fields.
     // For V0
-    addVolCheckpointField
-    (
-        const_cast<volScalarField::Internal&>
-        (
-            mesh_.V0()
-        )
-    );
+    addVolCheckpointField(
+        const_cast<volScalarField::Internal&>(
+            mesh_.V0()));
 #ifdef ADAPTER_DEBUG_MODE
-    adapterInfo
-    (
-        "Added " + mesh_.V0().name() +
-        " in the list of checkpointed fields."
-    );
+    adapterInfo(
+        "Added " + mesh_.V0().name() + " in the list of checkpointed fields.");
 #endif
     // For V00
-    addVolCheckpointField
-    (
-        const_cast<volScalarField::Internal&>
-        (
-            mesh_.V00()
-        )
-    );
+    addVolCheckpointField(
+        const_cast<volScalarField::Internal&>(
+            mesh_.V00()));
 #ifdef ADAPTER_DEBUG_MODE
-    adapterInfo
-    (
-        "Added " + mesh_.V00().name() +
-        " in the list of checkpointed fields."
-    );
+    adapterInfo(
+        "Added " + mesh_.V00().name() + " in the list of checkpointed fields.");
 #endif
 
     // Also add the buffer fields.
@@ -831,11 +800,8 @@ void preciceAdapter::Adapter::setupMeshVolCheckpointing()
         )
     ); */
 #ifdef ADAPTER_DEBUG_MODE
-    adapterInfo
-    (
-        "Added " + mesh_.V0().name() +
-        " in the list of buffer checkpointed fields."
-    );
+    adapterInfo(
+        "Added " + mesh_.V0().name() + " in the list of buffer checkpointed fields.");
 #endif
     // TODO For V00
     /* addVolCheckpointFieldBuffer
@@ -846,11 +812,8 @@ void preciceAdapter::Adapter::setupMeshVolCheckpointing()
         )
     );*/
 #ifdef ADAPTER_DEBUG_MODE
-    adapterInfo
-    (
-        "Added " + mesh_.V00().name() +
-        " in the list of buffer checkpointed fields."
-    );
+    adapterInfo(
+        "Added " + mesh_.V00().name() + " in the list of buffer checkpointed fields.");
 #endif
 }
 
@@ -873,19 +836,13 @@ void preciceAdapter::Adapter::setupCheckpointing()
     {
         if (mesh_.foundObject<volScalarField>(objectNames_[i]))
         {
-            addCheckpointField
-            (
-                const_cast<volScalarField&>
-                (
-                    mesh_.lookupObject<volScalarField>(objectNames_[i])
-                )
-            );
+            addCheckpointField(
+                const_cast<volScalarField&>(
+                    mesh_.lookupObject<volScalarField>(objectNames_[i])));
 
 #ifdef ADAPTER_DEBUG_MODE
-            adapterInfo
-            (
-                "Will be checkpointing " + objectNames_[i]
-            );
+            adapterInfo(
+                "Will be checkpointing " + objectNames_[i]);
 #endif
         }
         else
@@ -907,19 +864,13 @@ void preciceAdapter::Adapter::setupCheckpointing()
     {
         if (mesh_.foundObject<volVectorField>(objectNames_[i]))
         {
-            addCheckpointField
-            (
-                const_cast<volVectorField&>
-                (
-                    mesh_.lookupObject<volVectorField>(objectNames_[i])
-                )
-            );
+            addCheckpointField(
+                const_cast<volVectorField&>(
+                    mesh_.lookupObject<volVectorField>(objectNames_[i])));
 
 #ifdef ADAPTER_DEBUG_MODE
-            adapterInfo
-            (
-                "Will be checkpointing " + objectNames_[i]
-            );
+            adapterInfo(
+                "Will be checkpointing " + objectNames_[i]);
 #endif
         }
         else
@@ -940,19 +891,13 @@ void preciceAdapter::Adapter::setupCheckpointing()
     {
         if (mesh_.foundObject<surfaceScalarField>(objectNames_[i]))
         {
-            addCheckpointField
-            (
-                const_cast<surfaceScalarField&>
-                (
-                    mesh_.lookupObject<surfaceScalarField>(objectNames_[i])
-                )
-            );
+            addCheckpointField(
+                const_cast<surfaceScalarField&>(
+                    mesh_.lookupObject<surfaceScalarField>(objectNames_[i])));
 
 #ifdef ADAPTER_DEBUG_MODE
-            adapterInfo
-            (
-                "Will be checkpointing " + objectNames_[i]
-            );
+            adapterInfo(
+                "Will be checkpointing " + objectNames_[i]);
 #endif
         }
         else
@@ -974,19 +919,13 @@ void preciceAdapter::Adapter::setupCheckpointing()
     {
         if (mesh_.foundObject<surfaceVectorField>(objectNames_[i]))
         {
-            addCheckpointField
-            (
-                const_cast<surfaceVectorField&>
-                (
-                    mesh_.lookupObject<surfaceVectorField>(objectNames_[i])
-                )
-            );
+            addCheckpointField(
+                const_cast<surfaceVectorField&>(
+                    mesh_.lookupObject<surfaceVectorField>(objectNames_[i])));
 
 #ifdef ADAPTER_DEBUG_MODE
-            adapterInfo
-                    (
-                        "Will be checkpointing " + objectNames_[i]
-                    );
+            adapterInfo(
+                "Will be checkpointing " + objectNames_[i]);
 #endif
         }
         else
@@ -1008,19 +947,13 @@ void preciceAdapter::Adapter::setupCheckpointing()
     {
         if (mesh_.foundObject<pointScalarField>(objectNames_[i]))
         {
-            addCheckpointField
-            (
-                const_cast<pointScalarField&>
-                (
-                    mesh_.lookupObject<pointScalarField>(objectNames_[i])
-                )
-            );
+            addCheckpointField(
+                const_cast<pointScalarField&>(
+                    mesh_.lookupObject<pointScalarField>(objectNames_[i])));
 
 #ifdef ADAPTER_DEBUG_MODE
-            adapterInfo
-            (
-                "Will be checkpointing " + objectNames_[i]
-            );
+            adapterInfo(
+                "Will be checkpointing " + objectNames_[i]);
 #endif
         }
         else
@@ -1042,19 +975,13 @@ void preciceAdapter::Adapter::setupCheckpointing()
     {
         if (mesh_.foundObject<pointVectorField>(objectNames_[i]))
         {
-            addCheckpointField
-            (
-                const_cast<pointVectorField&>
-                (
-                    mesh_.lookupObject<pointVectorField>(objectNames_[i])
-                )
-            );
+            addCheckpointField(
+                const_cast<pointVectorField&>(
+                    mesh_.lookupObject<pointVectorField>(objectNames_[i])));
 
 #ifdef ADAPTER_DEBUG_MODE
-            adapterInfo
-            (
-                "Will be checkpointing " + objectNames_[i]
-            );
+            adapterInfo(
+                "Will be checkpointing " + objectNames_[i]);
 #endif
         }
         else
@@ -1062,7 +989,6 @@ void preciceAdapter::Adapter::setupCheckpointing()
             adapterInfo("Could not checkpoint " + objectNames_[i], "warning");
         }
     }
-
 
 
     /* Find and add all the registered objects in the mesh_
@@ -1078,19 +1004,13 @@ void preciceAdapter::Adapter::setupCheckpointing()
     {
         if (mesh_.foundObject<volTensorField>(objectNames_[i]))
         {
-            addCheckpointField
-            (
-                const_cast<volTensorField&>
-                (
-                    mesh_.lookupObject<volTensorField>(objectNames_[i])
-                )
-            );
+            addCheckpointField(
+                const_cast<volTensorField&>(
+                    mesh_.lookupObject<volTensorField>(objectNames_[i])));
 
 #ifdef ADAPTER_DEBUG_MODE
-            adapterInfo
-                    (
-                        "Will be checkpointing " + objectNames_[i]
-                    );
+            adapterInfo(
+                "Will be checkpointing " + objectNames_[i]);
 #endif
         }
         else
@@ -1098,7 +1018,6 @@ void preciceAdapter::Adapter::setupCheckpointing()
             adapterInfo("Could not checkpoint " + objectNames_[i], "warning");
         }
     }
-
 
 
     /* Find and add all the registered objects in the mesh_
@@ -1113,19 +1032,13 @@ void preciceAdapter::Adapter::setupCheckpointing()
     {
         if (mesh_.foundObject<surfaceTensorField>(objectNames_[i]))
         {
-            addCheckpointField
-            (
-                const_cast<surfaceTensorField&>
-                (
-                    mesh_.lookupObject<surfaceTensorField>(objectNames_[i])
-                )
-            );
+            addCheckpointField(
+                const_cast<surfaceTensorField&>(
+                    mesh_.lookupObject<surfaceTensorField>(objectNames_[i])));
 
 #ifdef ADAPTER_DEBUG_MODE
-            adapterInfo
-            (
-                "Will be checkpointing " + objectNames_[i]
-            );
+            adapterInfo(
+                "Will be checkpointing " + objectNames_[i]);
 #endif
         }
         else
@@ -1146,19 +1059,13 @@ void preciceAdapter::Adapter::setupCheckpointing()
     {
         if (mesh_.foundObject<pointTensorField>(objectNames_[i]))
         {
-            addCheckpointField
-            (
-                const_cast<pointTensorField&>
-                (
-                    mesh_.lookupObject<pointTensorField>(objectNames_[i])
-                )
-            );
+            addCheckpointField(
+                const_cast<pointTensorField&>(
+                    mesh_.lookupObject<pointTensorField>(objectNames_[i])));
 
 #ifdef ADAPTER_DEBUG_MODE
-            adapterInfo
-            (
-                "Will be checkpointing " + objectNames_[i]
-            );
+            adapterInfo(
+                "Will be checkpointing " + objectNames_[i]);
 #endif
         }
         else
@@ -1181,19 +1088,13 @@ void preciceAdapter::Adapter::setupCheckpointing()
     {
         if (mesh_.foundObject<volSymmTensorField>(objectNames_[i]))
         {
-            addCheckpointField
-            (
-                const_cast<volSymmTensorField&>
-                (
-                    mesh_.lookupObject<volSymmTensorField>(objectNames_[i])
-                )
-            );
+            addCheckpointField(
+                const_cast<volSymmTensorField&>(
+                    mesh_.lookupObject<volSymmTensorField>(objectNames_[i])));
 
 #ifdef ADAPTER_DEBUG_MODE
-            adapterInfo
-            (
-                "Will be checkpointing " + objectNames_[i]
-            );
+            adapterInfo(
+                "Will be checkpointing " + objectNames_[i]);
 #endif
         }
         else
@@ -1206,83 +1107,83 @@ void preciceAdapter::Adapter::setupCheckpointing()
 
 
 // All mesh checkpointed fields
-void preciceAdapter::Adapter::addMeshCheckpointField(surfaceScalarField & field)
+void preciceAdapter::Adapter::addMeshCheckpointField(surfaceScalarField& field)
 {
-    surfaceScalarField * copy = new surfaceScalarField(field);
+    surfaceScalarField* copy = new surfaceScalarField(field);
     meshSurfaceScalarFields_.push_back(&field);
     meshSurfaceScalarFieldCopies_.push_back(copy);
     return;
 }
 
-void preciceAdapter::Adapter::addMeshCheckpointField(surfaceVectorField & field)
+void preciceAdapter::Adapter::addMeshCheckpointField(surfaceVectorField& field)
 {
-    surfaceVectorField * copy = new surfaceVectorField(field);
+    surfaceVectorField* copy = new surfaceVectorField(field);
     meshSurfaceVectorFields_.push_back(&field);
     meshSurfaceVectorFieldCopies_.push_back(copy);
     return;
 }
 
-void preciceAdapter::Adapter::addMeshCheckpointField(volVectorField & field)
+void preciceAdapter::Adapter::addMeshCheckpointField(volVectorField& field)
 {
-    volVectorField * copy = new volVectorField(field);
+    volVectorField* copy = new volVectorField(field);
     meshVolVectorFields_.push_back(&field);
     meshVolVectorFieldCopies_.push_back(copy);
     return;
 }
 
 // TODO Internal field for the V0 (volume old) and V00 (volume old-old) fields
-void preciceAdapter::Adapter::addVolCheckpointField(volScalarField::Internal & field)
+void preciceAdapter::Adapter::addVolCheckpointField(volScalarField::Internal& field)
 {
-    volScalarField::Internal * copy = new volScalarField::Internal(field);
+    volScalarField::Internal* copy = new volScalarField::Internal(field);
     volScalarInternalFields_.push_back(&field);
     volScalarInternalFieldCopies_.push_back(copy);
     return;
 }
 
 // All checkpointed fields
-void preciceAdapter::Adapter::addCheckpointField(volScalarField & field)
+void preciceAdapter::Adapter::addCheckpointField(volScalarField& field)
 {
-    volScalarField * copy = new volScalarField(field);
+    volScalarField* copy = new volScalarField(field);
     volScalarFields_.push_back(&field);
     volScalarFieldCopies_.push_back(copy);
     return;
 }
 
-void preciceAdapter::Adapter::addCheckpointField(volVectorField & field)
+void preciceAdapter::Adapter::addCheckpointField(volVectorField& field)
 {
-    volVectorField * copy = new volVectorField(field);
+    volVectorField* copy = new volVectorField(field);
     volVectorFields_.push_back(&field);
     volVectorFieldCopies_.push_back(copy);
     return;
 }
 
-void preciceAdapter::Adapter::addCheckpointField(surfaceScalarField & field)
+void preciceAdapter::Adapter::addCheckpointField(surfaceScalarField& field)
 {
-    surfaceScalarField * copy = new surfaceScalarField(field);
+    surfaceScalarField* copy = new surfaceScalarField(field);
     surfaceScalarFields_.push_back(&field);
     surfaceScalarFieldCopies_.push_back(copy);
     return;
 }
 
-void preciceAdapter::Adapter::addCheckpointField(surfaceVectorField & field)
+void preciceAdapter::Adapter::addCheckpointField(surfaceVectorField& field)
 {
-    surfaceVectorField * copy = new surfaceVectorField(field);
+    surfaceVectorField* copy = new surfaceVectorField(field);
     surfaceVectorFields_.push_back(&field);
     surfaceVectorFieldCopies_.push_back(copy);
     return;
 }
 
-void preciceAdapter::Adapter::addCheckpointField(pointScalarField & field)
+void preciceAdapter::Adapter::addCheckpointField(pointScalarField& field)
 {
-    pointScalarField * copy = new pointScalarField(field);
+    pointScalarField* copy = new pointScalarField(field);
     pointScalarFields_.push_back(&field);
     pointScalarFieldCopies_.push_back(copy);
     return;
 }
 
-void preciceAdapter::Adapter::addCheckpointField(pointVectorField & field)
+void preciceAdapter::Adapter::addCheckpointField(pointVectorField& field)
 {
-    pointVectorField * copy = new pointVectorField(field);
+    pointVectorField* copy = new pointVectorField(field);
     pointVectorFields_.push_back(&field);
     pointVectorFieldCopies_.push_back(copy);
     // TODO: Old time
@@ -1292,33 +1193,33 @@ void preciceAdapter::Adapter::addCheckpointField(pointVectorField & field)
     return;
 }
 
-void preciceAdapter::Adapter::addCheckpointField(volTensorField & field)
+void preciceAdapter::Adapter::addCheckpointField(volTensorField& field)
 {
-    volTensorField * copy = new volTensorField(field);
+    volTensorField* copy = new volTensorField(field);
     volTensorFields_.push_back(&field);
     volTensorFieldCopies_.push_back(copy);
     return;
 }
 
-void preciceAdapter::Adapter::addCheckpointField(surfaceTensorField & field)
+void preciceAdapter::Adapter::addCheckpointField(surfaceTensorField& field)
 {
-    surfaceTensorField * copy = new surfaceTensorField(field);
+    surfaceTensorField* copy = new surfaceTensorField(field);
     surfaceTensorFields_.push_back(&field);
     surfaceTensorFieldCopies_.push_back(copy);
     return;
 }
 
-void preciceAdapter::Adapter::addCheckpointField(pointTensorField & field)
+void preciceAdapter::Adapter::addCheckpointField(pointTensorField& field)
 {
-    pointTensorField * copy = new pointTensorField(field);
+    pointTensorField* copy = new pointTensorField(field);
     pointTensorFields_.push_back(&field);
     pointTensorFieldCopies_.push_back(copy);
     return;
 }
 
-void preciceAdapter::Adapter::addCheckpointField(volSymmTensorField & field)
+void preciceAdapter::Adapter::addCheckpointField(volSymmTensorField& field)
 {
-    volSymmTensorField * copy = new volSymmTensorField(field);
+    volSymmTensorField* copy = new volSymmTensorField(field);
     volSymmTensorFields_.push_back(&field);
     volSymmTensorFieldCopies_.push_back(copy);
     return;
@@ -1514,10 +1415,8 @@ void preciceAdapter::Adapter::readCheckpoint()
     // NOTE: Add here other field types to read, if needed.
 
 #ifdef ADAPTER_DEBUG_MODE
-    adapterInfo
-    (
-        "Checkpoint was read. Time = " + std::to_string(runTime_.value())
-    );
+    adapterInfo(
+        "Checkpoint was read. Time = " + std::to_string(runTime_.value()));
 #endif
 
     return;
@@ -1599,11 +1498,8 @@ void preciceAdapter::Adapter::writeCheckpoint()
     // NOTE: Add here other types to write, if needed.
 
 #ifdef ADAPTER_DEBUG_MODE
-    adapterInfo
-    (
-        "Checkpoint for time t = " + std::to_string(runTime_.value()) +
-        " was stored."
-    );
+    adapterInfo(
+        "Checkpoint for time t = " + std::to_string(runTime_.value()) + " was stored.");
 #endif
 
     return;
@@ -1664,12 +1560,10 @@ void preciceAdapter::Adapter::readMeshCheckpoint()
             meshVolVectorFields_.at(i)->oldTime().oldTime() == meshVolVectorFieldCopies_.at(i)->oldTime().oldTime();
         }
     }
-    
+
 #ifdef ADAPTER_DEBUG_MODE
-    adapterInfo
-    (
-        "Mesh checkpoint was read. Time = " + std::to_string(runTime_.value())
-    );
+    adapterInfo(
+        "Mesh checkpoint was read. Time = " + std::to_string(runTime_.value()));
 #endif
 
     return;
@@ -1698,17 +1592,14 @@ void preciceAdapter::Adapter::writeMeshCheckpoint()
     }
 
 #ifdef ADAPTER_DEBUG_MODE
-    adapterInfo
-    (
-        "Mesh checkpoint for time t = " + std::to_string(runTime_.value()) +
-        " was stored."
-    );
+    adapterInfo(
+        "Mesh checkpoint for time t = " + std::to_string(runTime_.value()) + " was stored.");
 #endif
 
     return;
 }
 
-// TODO for the volumes of the mesh, check this part for subcycling. 
+// TODO for the volumes of the mesh, check this part for subcycling.
 void preciceAdapter::Adapter::readVolCheckpoint()
 {
     DEBUG(adapterInfo("Reading the mesh volumes checkpoint..."));
@@ -1722,10 +1613,8 @@ void preciceAdapter::Adapter::readVolCheckpoint()
     }
 
 #ifdef ADAPTER_DEBUG_MODE
-    adapterInfo
-    (
-        "Mesh volumes were read. Time = " + std::to_string(runTime_.value())
-    );
+    adapterInfo(
+        "Mesh volumes were read. Time = " + std::to_string(runTime_.value()));
 #endif
 
     return;
@@ -1742,11 +1631,8 @@ void preciceAdapter::Adapter::writeVolCheckpoint()
     }
 
 #ifdef ADAPTER_DEBUG_MODE
-    adapterInfo
-    (
-        "Mesh volumes checkpoint for time t = " + std::to_string(runTime_.value()) +
-        " was stored."
-    );
+    adapterInfo(
+        "Mesh volumes checkpoint for time t = " + std::to_string(runTime_.value()) + " was stored.");
 #endif
 
     return;
@@ -1893,7 +1779,7 @@ void preciceAdapter::Adapter::teardown()
     }
 
     // Delete the CHT module
-    if(NULL != CHT_)
+    if (NULL != CHT_)
     {
         DEBUG(adapterInfo("Destroying the CHT module..."));
         delete CHT_;
@@ -1901,7 +1787,7 @@ void preciceAdapter::Adapter::teardown()
     }
 
     // Delete the FSI module
-    if(NULL != FSI_)
+    if (NULL != FSI_)
     {
         DEBUG(adapterInfo("Destroying the FSI module..."));
         delete FSI_;
@@ -1909,7 +1795,7 @@ void preciceAdapter::Adapter::teardown()
     }
 
     // Delete the FF module
-    if(NULL != FF_)
+    if (NULL != FF_)
     {
         DEBUG(adapterInfo("Destroying the FF module..."));
         delete FF_;

--- a/Adapter.H
+++ b/Adapter.H
@@ -31,7 +31,6 @@ class Adapter
 {
 
 private:
-
     //- Structure of the configuration of each coupling interface.
     //  Every interface needs to know the coupling mesh, the OpenFOAM
     //  patches that consist the coupling surface and the kinds
@@ -57,342 +56,340 @@ private:
 
     // Configuration parameters used in the Adapter
 
-        //- Remember if there were errors in the read() method
-        bool errorsInConfigure = false;
+    //- Remember if there were errors in the read() method
+    bool errorsInConfigure = false;
 
-        //- preCICE configuration file name
-        Foam::word preciceConfigFilename_;
+    //- preCICE configuration file name
+    Foam::word preciceConfigFilename_;
 
-        //- preCICE participant name
-        Foam::word participantName_;
+    //- preCICE participant name
+    Foam::word participantName_;
 
-        //- Switch for checkpointing
-        bool checkpointing_ = false;
+    //- Switch for checkpointing
+    bool checkpointing_ = false;
 
-        //- Type of timestep (fixed, adjustable)
-        bool adjustableTimestep_;
+    //- Type of timestep (fixed, adjustable)
+    bool adjustableTimestep_;
 
-        //- Should the (fixed) timestep be stored and used?
-        bool useStoredTimestep_ = false;
+    //- Should the (fixed) timestep be stored and used?
+    bool useStoredTimestep_ = false;
 
-        //- Switch to enable the ConjugateHeatTransfer module
-        bool CHTenabled_ = false;
+    //- Switch to enable the ConjugateHeatTransfer module
+    bool CHTenabled_ = false;
 
-        //- Switch to enable the FluidStructureInteraction module
-        bool FSIenabled_ = false;
+    //- Switch to enable the FluidStructureInteraction module
+    bool FSIenabled_ = false;
 
-        //- Switch to enable the FluidFluid module
-        bool FFenabled_ = false;
+    //- Switch to enable the FluidFluid module
+    bool FFenabled_ = false;
 
-        // NOTE: Add a switch for your new module here
+    // NOTE: Add a switch for your new module here
 
     //- Interfaces
     std::vector<Interface*> interfaces_;
 
     //- preCICE solver interface
-    precice::SolverInterface * precice_ = NULL;
+    precice::SolverInterface* precice_ = NULL;
 
     //- preCICE solver interface initialized
     bool preciceInitialized_ = false;
 
     //- Conjugate Heat Transfer module object
-    CHT::ConjugateHeatTransfer * CHT_ = NULL;
+    CHT::ConjugateHeatTransfer* CHT_ = NULL;
 
     //- Fluid-Structure Interaction module object
-    FSI::FluidStructureInteraction * FSI_ = NULL;
+    FSI::FluidStructureInteraction* FSI_ = NULL;
 
     //- Fluid-Fluid module object
-    FF::FluidFluid * FF_ = NULL;
+    FF::FluidFluid* FF_ = NULL;
 
     // NOTE: Add here a pointer for your new module object
 
     // Timesteps
 
-        //- Timestep dictated by preCICE
-        double timestepPrecice_;
+    //- Timestep dictated by preCICE
+    double timestepPrecice_;
 
-        //- Timestep used by the solver
-        double timestepSolver_;
+    //- Timestep used by the solver
+    double timestepSolver_;
 
-        //- Stored (fixed) timestep
-        double timestepStored_;
+    //- Stored (fixed) timestep
+    double timestepStored_;
 
     // Checkpointing
 
-        //- Checkpointed time (value)
-        Foam::scalar couplingIterationTimeValue_;
+    //- Checkpointed time (value)
+    Foam::scalar couplingIterationTimeValue_;
 
-        //- Checkpointed time (index)
-        Foam::label couplingIterationTimeIndex_;
+    //- Checkpointed time (index)
+    Foam::label couplingIterationTimeIndex_;
 
-        //- Checkpointed mesh points
-        Foam::pointField meshPoints_;
-        Foam::pointField oldMeshPoints_;
-        bool meshCheckPointed = false;
+    //- Checkpointed mesh points
+    Foam::pointField meshPoints_;
+    Foam::pointField oldMeshPoints_;
+    bool meshCheckPointed = false;
 
-        // TODO: Currently unused, see storeMeshPoints().
-        //- Checkpointed mesh volume
-        // bool oldVolsStored = false;
-        // Foam::volScalarField::Internal * oldVols_;
-        // Foam::volScalarField::Internal * oldOldVols_;
-        // int curTimeIndex_ = 0;
+    // TODO: Currently unused, see storeMeshPoints().
+    //- Checkpointed mesh volume
+    // bool oldVolsStored = false;
+    // Foam::volScalarField::Internal * oldVols_;
+    // Foam::volScalarField::Internal * oldOldVols_;
+    // int curTimeIndex_ = 0;
 
-        // Vectors of pointers to the checkpointed mesh fields and their copies
+    // Vectors of pointers to the checkpointed mesh fields and their copies
 
-            //- Checkpointed surfaceScalarField mesh fields
-            std::vector<Foam::surfaceScalarField*> meshSurfaceScalarFields_;
+    //- Checkpointed surfaceScalarField mesh fields
+    std::vector<Foam::surfaceScalarField*> meshSurfaceScalarFields_;
 
-            //- Checkpointed surfaceScalarField mesh fields (copies)
-            std::vector<Foam::surfaceScalarField*> meshSurfaceScalarFieldCopies_;
+    //- Checkpointed surfaceScalarField mesh fields (copies)
+    std::vector<Foam::surfaceScalarField*> meshSurfaceScalarFieldCopies_;
 
-            //- Checkpointed surfaceVectorField mesh fields
-            std::vector<Foam::surfaceVectorField*> meshSurfaceVectorFields_;
+    //- Checkpointed surfaceVectorField mesh fields
+    std::vector<Foam::surfaceVectorField*> meshSurfaceVectorFields_;
 
-            //- Checkpointed surfaceVectorField mesh fields (copies)
-            std::vector<Foam::surfaceVectorField*> meshSurfaceVectorFieldCopies_;
+    //- Checkpointed surfaceVectorField mesh fields (copies)
+    std::vector<Foam::surfaceVectorField*> meshSurfaceVectorFieldCopies_;
 
-            //- Checkpointed volVectorField mesh fields
-            std::vector<Foam::volVectorField*> meshVolVectorFields_;
+    //- Checkpointed volVectorField mesh fields
+    std::vector<Foam::volVectorField*> meshVolVectorFields_;
 
-            //- Checkpointed volVectorField mesh fields (copies)
-            std::vector<Foam::volVectorField*> meshVolVectorFieldCopies_;
+    //- Checkpointed volVectorField mesh fields (copies)
+    std::vector<Foam::volVectorField*> meshVolVectorFieldCopies_;
 
-            // TODO checkpoint for the V0 (Old volume) and V00 (Old-Old volume) fields.
-            //- Checkpointed volScalarField mesh fields
-            std::vector<Foam::volScalarField::Internal*> volScalarInternalFields_;
+    // TODO checkpoint for the V0 (Old volume) and V00 (Old-Old volume) fields.
+    //- Checkpointed volScalarField mesh fields
+    std::vector<Foam::volScalarField::Internal*> volScalarInternalFields_;
 
-            //- Checkpointed volScalarField mesh fields (copies)
-            std::vector<Foam::volScalarField::Internal*> volScalarInternalFieldCopies_;
+    //- Checkpointed volScalarField mesh fields (copies)
+    std::vector<Foam::volScalarField::Internal*> volScalarInternalFieldCopies_;
 
-        // Vectors of pointers to the checkpointed fields and their copies
+    // Vectors of pointers to the checkpointed fields and their copies
 
-            //- Checkpointed volScalarField fields
-            std::vector<Foam::volScalarField*> volScalarFields_;
+    //- Checkpointed volScalarField fields
+    std::vector<Foam::volScalarField*> volScalarFields_;
 
-            //- Checkpointed volScalarField fields (copies)
-            std::vector<Foam::volScalarField*> volScalarFieldCopies_;
+    //- Checkpointed volScalarField fields (copies)
+    std::vector<Foam::volScalarField*> volScalarFieldCopies_;
 
-            //- Checkpointed volVectorField fields
-            std::vector<Foam::volVectorField*> volVectorFields_;
+    //- Checkpointed volVectorField fields
+    std::vector<Foam::volVectorField*> volVectorFields_;
 
-            //- Checkpointed volVectorField fields (copies)
-            std::vector<Foam::volVectorField*> volVectorFieldCopies_;
+    //- Checkpointed volVectorField fields (copies)
+    std::vector<Foam::volVectorField*> volVectorFieldCopies_;
 
-            //- Checkpointed surfaceScalarField fields
-            std::vector<Foam::surfaceScalarField*> surfaceScalarFields_;
+    //- Checkpointed surfaceScalarField fields
+    std::vector<Foam::surfaceScalarField*> surfaceScalarFields_;
 
-            //- Checkpointed surfaceScalarField fields (copies)
-            std::vector<Foam::surfaceScalarField*> surfaceScalarFieldCopies_;
+    //- Checkpointed surfaceScalarField fields (copies)
+    std::vector<Foam::surfaceScalarField*> surfaceScalarFieldCopies_;
 
-            //- Checkpointed surfaceVectorField fields
-            std::vector<Foam::surfaceVectorField*> surfaceVectorFields_;
+    //- Checkpointed surfaceVectorField fields
+    std::vector<Foam::surfaceVectorField*> surfaceVectorFields_;
 
-            //- Checkpointed surfaceVectorField fields (copies)
-            std::vector<Foam::surfaceVectorField*> surfaceVectorFieldCopies_;
+    //- Checkpointed surfaceVectorField fields (copies)
+    std::vector<Foam::surfaceVectorField*> surfaceVectorFieldCopies_;
 
-            //- Checkpointed pointScalarField fields
-            std::vector<Foam::pointScalarField*> pointScalarFields_;
+    //- Checkpointed pointScalarField fields
+    std::vector<Foam::pointScalarField*> pointScalarFields_;
 
-            //- Checkpointed pointScalarField fields (copies)
-            std::vector<Foam::pointScalarField*> pointScalarFieldCopies_;
+    //- Checkpointed pointScalarField fields (copies)
+    std::vector<Foam::pointScalarField*> pointScalarFieldCopies_;
 
-            //- Checkpointed pointVectorField fields
-            std::vector<Foam::pointVectorField*> pointVectorFields_;
+    //- Checkpointed pointVectorField fields
+    std::vector<Foam::pointVectorField*> pointVectorFields_;
 
-            //- Checkpointed pointVectorField fields (copies)
-            std::vector<Foam::pointVectorField*> pointVectorFieldCopies_;
+    //- Checkpointed pointVectorField fields (copies)
+    std::vector<Foam::pointVectorField*> pointVectorFieldCopies_;
 
-            //- Checkpointed volTensorField fields
-            std::vector<Foam::volTensorField*> volTensorFields_;
+    //- Checkpointed volTensorField fields
+    std::vector<Foam::volTensorField*> volTensorFields_;
 
-            //- Checkpointed volTensorField fields (copies)
-            std::vector<Foam::volTensorField*> volTensorFieldCopies_;
+    //- Checkpointed volTensorField fields (copies)
+    std::vector<Foam::volTensorField*> volTensorFieldCopies_;
 
-            //- Checkpointed surfaceTensorField fields
-            std::vector<Foam::surfaceTensorField*> surfaceTensorFields_;
+    //- Checkpointed surfaceTensorField fields
+    std::vector<Foam::surfaceTensorField*> surfaceTensorFields_;
 
-            //- Checkpointed surfaceTensorField fields (copies)
-            std::vector<Foam::surfaceTensorField*> surfaceTensorFieldCopies_;
+    //- Checkpointed surfaceTensorField fields (copies)
+    std::vector<Foam::surfaceTensorField*> surfaceTensorFieldCopies_;
 
-            //- Checkpointed pointTensorField fields
-            std::vector<Foam::pointTensorField*> pointTensorFields_;
+    //- Checkpointed pointTensorField fields
+    std::vector<Foam::pointTensorField*> pointTensorFields_;
 
-            //- Checkpointed pointTensorField fields (copies)
-            std::vector<Foam::pointTensorField*> pointTensorFieldCopies_;
+    //- Checkpointed pointTensorField fields (copies)
+    std::vector<Foam::pointTensorField*> pointTensorFieldCopies_;
 
-            //- Checkpointed volSymmTensorField fields
-            std::vector<Foam::volSymmTensorField*> volSymmTensorFields_;
+    //- Checkpointed volSymmTensorField fields
+    std::vector<Foam::volSymmTensorField*> volSymmTensorFields_;
 
-            //- Checkpointed volSymmTensorField fields (copies)
-            std::vector<Foam::volSymmTensorField*> volSymmTensorFieldCopies_;
+    //- Checkpointed volSymmTensorField fields (copies)
+    std::vector<Foam::volSymmTensorField*> volSymmTensorFieldCopies_;
 
 
-            // NOTE: Declare additional vectors for any other types required.
+    // NOTE: Declare additional vectors for any other types required.
 
     // Configuration
 
-        //- Read the adapter's configuration file
-        bool configFileRead();
+    //- Read the adapter's configuration file
+    bool configFileRead();
 
-        //- Check the adapter's configuration file
-        bool configFileCheck(const std::string adapterConfigFileName);
+    //- Check the adapter's configuration file
+    bool configFileCheck(const std::string adapterConfigFileName);
 
     // Methods communicating with preCICE
 
-        //- Initialize preCICE and exchange the first data
-        void initialize();
+    //- Initialize preCICE and exchange the first data
+    void initialize();
 
-        //- Finalize and destroy preCICE
-        void finalize();
+    //- Finalize and destroy preCICE
+    void finalize();
 
-        //- Advance preCICE
-        void advance();
+    //- Advance preCICE
+    void advance();
 
-        //- Read the coupling data at each interface
-        void readCouplingData();
+    //- Read the coupling data at each interface
+    void readCouplingData();
 
-        //- Write the coupling data at each interface
-        void writeCouplingData();
+    //- Write the coupling data at each interface
+    void writeCouplingData();
 
-        //- Adjust the timestep of the solver according to preCICE
-        void adjustSolverTimeStep();
+    //- Adjust the timestep of the solver according to preCICE
+    void adjustSolverTimeStep();
 
-        //- Determine if the coupling is still happening
-        bool isCouplingOngoing();
+    //- Determine if the coupling is still happening
+    bool isCouplingOngoing();
 
-        //- Determine if the coupling timestep has been completed
-        bool isCouplingTimeWindowComplete();
+    //- Determine if the coupling timestep has been completed
+    bool isCouplingTimeWindowComplete();
 
-        //- Determine if a checkpoint must be read
-        bool isReadCheckpointRequired();
+    //- Determine if a checkpoint must be read
+    bool isReadCheckpointRequired();
 
-        //- Determine if a checkpoint must be written
-        bool isWriteCheckpointRequired();
+    //- Determine if a checkpoint must be written
+    bool isWriteCheckpointRequired();
 
-        //- Tell preCICE that the checkpoint has been read
-        void fulfilledReadCheckpoint();
+    //- Tell preCICE that the checkpoint has been read
+    void fulfilledReadCheckpoint();
 
-        //- Tell preCICE that the checkpoint has been written
-        void fulfilledWriteCheckpoint();
+    //- Tell preCICE that the checkpoint has been written
+    void fulfilledWriteCheckpoint();
 
     // Methods for checkpointing
 
-        //- Configure the mesh checkpointing
-        void setupMeshCheckpointing();
+    //- Configure the mesh checkpointing
+    void setupMeshCheckpointing();
 
-        //- Configure the mesh checkpointing
-        void setupMeshVolCheckpointing();
+    //- Configure the mesh checkpointing
+    void setupMeshVolCheckpointing();
 
-        //- Configure the checkpointing
-        void setupCheckpointing();
+    //- Configure the checkpointing
+    void setupCheckpointing();
 
-        //- Make a copy of the runTime object
-        void storeCheckpointTime();
+    //- Make a copy of the runTime object
+    void storeCheckpointTime();
 
-        //- Restore the copy of the runTime object
-        void reloadCheckpointTime();
+    //- Restore the copy of the runTime object
+    void reloadCheckpointTime();
 
-        //- Store the locations of the mesh points
-        void storeMeshPoints();
+    //- Store the locations of the mesh points
+    void storeMeshPoints();
 
-        //- Restore the locations of the mesh points
-        void reloadMeshPoints();
+    //- Restore the locations of the mesh points
+    void reloadMeshPoints();
 
-        // Add mesh checkpoint fields, depending on the type
-            //- Add a surfaceScalarField mesh field
-            void addMeshCheckpointField(surfaceScalarField & field);
+    // Add mesh checkpoint fields, depending on the type
+    //- Add a surfaceScalarField mesh field
+    void addMeshCheckpointField(surfaceScalarField& field);
 
-            //- Add a surfaceVectorField mesh field
-            void addMeshCheckpointField(surfaceVectorField & field);
+    //- Add a surfaceVectorField mesh field
+    void addMeshCheckpointField(surfaceVectorField& field);
 
-            //- Add a volVectorField mesh field
-            void addMeshCheckpointField(volVectorField & field);
+    //- Add a volVectorField mesh field
+    void addMeshCheckpointField(volVectorField& field);
 
-        // TODO V0 and V00 checkpointed field.
-            //- Add the V0 and V00 checkpoint fields
-            void addVolCheckpointField(volScalarField::Internal & field);
-            // void addVolCheckpointFieldBuffer(volScalarField::Internal & field);
+    // TODO V0 and V00 checkpointed field.
+    //- Add the V0 and V00 checkpoint fields
+    void addVolCheckpointField(volScalarField::Internal& field);
+    // void addVolCheckpointFieldBuffer(volScalarField::Internal & field);
 
-        // Add checkpoint fields, depending on the type
+    // Add checkpoint fields, depending on the type
 
-            //- Add a volScalarField to checkpoint
-            void addCheckpointField(volScalarField & field);
+    //- Add a volScalarField to checkpoint
+    void addCheckpointField(volScalarField& field);
 
-            //- Add a volVectorField to checkpoint
-            void addCheckpointField(volVectorField & field);
+    //- Add a volVectorField to checkpoint
+    void addCheckpointField(volVectorField& field);
 
-            //- Add a surfaceScalarField to checkpoint
-            void addCheckpointField(surfaceScalarField & field);
+    //- Add a surfaceScalarField to checkpoint
+    void addCheckpointField(surfaceScalarField& field);
 
-            //- Add a surfaceVectorField to checkpoint
-            void addCheckpointField(surfaceVectorField & field);
+    //- Add a surfaceVectorField to checkpoint
+    void addCheckpointField(surfaceVectorField& field);
 
-            //- Add a pointScalarField to checkpoint
-            void addCheckpointField(pointScalarField & field);
+    //- Add a pointScalarField to checkpoint
+    void addCheckpointField(pointScalarField& field);
 
-            //- Add a pointVectorField to checkpoint
-            void addCheckpointField(pointVectorField & field);
+    //- Add a pointVectorField to checkpoint
+    void addCheckpointField(pointVectorField& field);
 
-            // NOTE: Add here methods to add other object types to checkpoint,
-            // if needed.
+    // NOTE: Add here methods to add other object types to checkpoint,
+    // if needed.
 
-            //- Add a volTensorField to checkpoint
-            void addCheckpointField(volTensorField & field);
+    //- Add a volTensorField to checkpoint
+    void addCheckpointField(volTensorField& field);
 
-            //- Add a surfaceTensorField to checkpoint
-            void addCheckpointField(surfaceTensorField & field);
+    //- Add a surfaceTensorField to checkpoint
+    void addCheckpointField(surfaceTensorField& field);
 
-            //- Add a pointTensorField to checkpoint
-            void addCheckpointField(pointTensorField & field);
+    //- Add a pointTensorField to checkpoint
+    void addCheckpointField(pointTensorField& field);
 
-            //- Add a volSymmTensorField to checkpoint
-            void addCheckpointField(volSymmTensorField & field);
+    //- Add a volSymmTensorField to checkpoint
+    void addCheckpointField(volSymmTensorField& field);
 
-        //- Read the checkpoint - restore the mesh fields and time
-        void readMeshCheckpoint();
+    //- Read the checkpoint - restore the mesh fields and time
+    void readMeshCheckpoint();
 
-        //- Read the checkpoint - restore the fields and time
-        void readCheckpoint();
+    //- Read the checkpoint - restore the fields and time
+    void readCheckpoint();
 
-        //- Write the checkpoint - store the mesh fields and time
-        void writeMeshCheckpoint();
+    //- Write the checkpoint - store the mesh fields and time
+    void writeMeshCheckpoint();
 
-        //- Write the checkpoint - store the fields and time
-        void writeCheckpoint();
+    //- Write the checkpoint - store the fields and time
+    void writeCheckpoint();
 
-        // TODO Probably these can be included to the mesh checkpoints.
-        //- Read the volume checkpoint - restore the mesh volume fields
-        void readVolCheckpoint();
+    // TODO Probably these can be included to the mesh checkpoints.
+    //- Read the volume checkpoint - restore the mesh volume fields
+    void readVolCheckpoint();
 
-        //- Write the volume checkpoint to a buffer - restore the mesh volume fields
-        void writeVolCheckpoint();
+    //- Write the volume checkpoint to a buffer - restore the mesh volume fields
+    void writeVolCheckpoint();
 
     //- Destroy the preCICE interface and delete the allocated
     //  memory in a proper way. Called by the destructor.
     void teardown();
 
 public:
-
     // Methods called by the functionObject
 
-        //- Constructor
-        Adapter(const Foam::Time& runTime, const Foam::fvMesh& mesh);
+    //- Constructor
+    Adapter(const Foam::Time& runTime, const Foam::fvMesh& mesh);
 
-        //- Setup the adapter's configuration
-        void configure();
+    //- Setup the adapter's configuration
+    void configure();
 
-        //- Called by the functionObject's execute()
-        void execute();
+    //- Called by the functionObject's execute()
+    void execute();
 
-        //- Called by the functionObject's adjustTimeStep()
-        void adjustTimeStep();
+    //- Called by the functionObject's adjustTimeStep()
+    void adjustTimeStep();
 
-        //- Called by the functionObject's end()
-        void end();
+    //- Called by the functionObject's end()
+    void end();
 
-        //- Destructor
-        ~Adapter();
-
+    //- Destructor
+    ~Adapter();
 };
 
 }

--- a/CHT/CHT.C
+++ b/CHT/CHT.C
@@ -4,13 +4,11 @@
 
 using namespace Foam;
 
-preciceAdapter::CHT::ConjugateHeatTransfer::ConjugateHeatTransfer
-(
-    const Foam::fvMesh& mesh
-)
-:
-mesh_(mesh)
-{}
+preciceAdapter::CHT::ConjugateHeatTransfer::ConjugateHeatTransfer(
+    const Foam::fvMesh& mesh)
+: mesh_(mesh)
+{
+}
 
 bool preciceAdapter::CHT::ConjugateHeatTransfer::configure(const IOdictionary& adapterConfig)
 {
@@ -24,10 +22,7 @@ bool preciceAdapter::CHT::ConjugateHeatTransfer::configure(const IOdictionary& a
     // addWriters() and addReaders().
     // Check the solver type and determine it if needed
     if (
-        solverType_.compare("compressible") == 0 ||
-        solverType_.compare("incompressible") == 0 ||
-        solverType_.compare("basic") == 0
-    )
+        solverType_.compare("compressible") == 0 || solverType_.compare("incompressible") == 0 || solverType_.compare("basic") == 0)
     {
         DEBUG(adapterInfo("Known solver type: " + solverType_));
     }
@@ -70,7 +65,7 @@ bool preciceAdapter::CHT::ConjugateHeatTransfer::readConfig(const IOdictionary& 
     DEBUG(adapterInfo("    heat capacity name for incompressible solvers : " + nameCp_));
 
     // Read the name of the Prandtl number parameter for incompressible solvers (if different)
-    namePr_ = CHTdict.lookupOrDefault<word>("namePr","Pr");
+    namePr_ = CHTdict.lookupOrDefault<word>("namePr", "Pr");
     DEBUG(adapterInfo("    Prandtl number name for incompressible solvers : " + namePr_));
 
     // Read the name of the turbulent thermal diffusivity field for incompressible solvers (if different)
@@ -92,120 +87,104 @@ std::string preciceAdapter::CHT::ConjugateHeatTransfer::determineSolverType()
 
     if (mesh_.foundObject<volScalarField>("p"))
     {
-      volScalarField p_ = mesh_.lookupObject<volScalarField>("p");
+        volScalarField p_ = mesh_.lookupObject<volScalarField>("p");
 
-      if (p_.dimensions() == pressureDimensionsCompressible)
-        solverType = "compressible";
-      else if (p_.dimensions() == pressureDimensionsIncompressible)
-        solverType = "incompressible";
+        if (p_.dimensions() == pressureDimensionsCompressible)
+            solverType = "compressible";
+        else if (p_.dimensions() == pressureDimensionsIncompressible)
+            solverType = "incompressible";
     }
 
     if (solverType == "unknown")
-      adapterInfo("Failed to determine the solver type. "
-                  "Please specify your solver type in the CHT section of the "
-                  "preciceDict. Known solver types for CHT are: "
-                  "basic, incompressible and "
-                  "compressible",
-                  "error");
+        adapterInfo("Failed to determine the solver type. "
+                    "Please specify your solver type in the CHT section of the "
+                    "preciceDict. Known solver types for CHT are: "
+                    "basic, incompressible and "
+                    "compressible",
+                    "error");
 
     DEBUG(adapterInfo("Automatically determined solver type : " + solverType));
 
     return solverType;
 }
 
-void preciceAdapter::CHT::ConjugateHeatTransfer::addWriters(std::string dataName, Interface * interface)
+void preciceAdapter::CHT::ConjugateHeatTransfer::addWriters(std::string dataName, Interface* interface)
 {
     if (dataName.find("Sink-Temperature") == 0)
     {
-        interface->addCouplingDataWriter
-        (
+        interface->addCouplingDataWriter(
             dataName,
-            new SinkTemperature(mesh_, nameT_)
-        );
+            new SinkTemperature(mesh_, nameT_));
         DEBUG(adapterInfo("Added writer: Sink Temperature."));
     }
     else if (dataName.find("Temperature") == 0)
     {
-        interface->addCouplingDataWriter
-        (
+        interface->addCouplingDataWriter(
             dataName,
-            new Temperature(mesh_, nameT_)
-        );
+            new Temperature(mesh_, nameT_));
         DEBUG(adapterInfo("Added writer: Temperature."));
     }
     else if (dataName.find("Heat-Flux") == 0)
     {
         if (solverType_.compare("compressible") == 0)
         {
-            interface->addCouplingDataWriter
-            (
+            interface->addCouplingDataWriter(
                 dataName,
-                new HeatFlux_Compressible(mesh_, nameT_)
-            );
+                new HeatFlux_Compressible(mesh_, nameT_));
             DEBUG(adapterInfo("Added writer: Heat Flux for compressible solvers."));
         }
         else if (solverType_.compare("incompressible") == 0)
         {
-            interface->addCouplingDataWriter
-            (
+            interface->addCouplingDataWriter(
                 dataName,
-                new HeatFlux_Incompressible(mesh_, nameT_, nameRho_, nameCp_, namePr_, nameAlphat_)
-            );
+                new HeatFlux_Incompressible(mesh_, nameT_, nameRho_, nameCp_, namePr_, nameAlphat_));
             DEBUG(adapterInfo("Added writer: Heat Flux for incompressible solvers. "));
         }
         else if (solverType_.compare("basic") == 0)
         {
-            interface->addCouplingDataWriter
-            (
+            interface->addCouplingDataWriter(
                 dataName,
-                new HeatFlux_Basic(mesh_, nameT_, nameKappa_)
-            );
+                new HeatFlux_Basic(mesh_, nameT_, nameKappa_));
             DEBUG(adapterInfo("Added writer: Heat Flux for basic solvers. "));
         }
         else
         {
             adapterInfo("Unknown solver type - cannot add heat flux.",
-                "error");
+                        "error");
         }
     }
     else if (dataName.find("Heat-Transfer-Coefficient") == 0)
     {
         if (solverType_.compare("compressible") == 0)
         {
-            interface->addCouplingDataWriter
-            (
+            interface->addCouplingDataWriter(
                 dataName,
-                new HeatTransferCoefficient_Compressible(mesh_, nameT_)
-            );
+                new HeatTransferCoefficient_Compressible(mesh_, nameT_));
             DEBUG(adapterInfo("Added writer: Heat Transfer Coefficient for compressible solvers."));
         }
         else if (solverType_.compare("incompressible") == 0)
         {
-            interface->addCouplingDataWriter
-            (
+            interface->addCouplingDataWriter(
                 dataName,
-                new HeatTransferCoefficient_Incompressible(mesh_, nameT_, nameRho_, nameCp_, namePr_, nameAlphat_)
-            );
+                new HeatTransferCoefficient_Incompressible(mesh_, nameT_, nameRho_, nameCp_, namePr_, nameAlphat_));
             DEBUG(adapterInfo("Added writer: Heat Transfer Coefficient for incompressible solvers. "));
         }
         else if (solverType_.compare("basic") == 0)
         {
-            interface->addCouplingDataWriter
-            (
+            interface->addCouplingDataWriter(
                 dataName,
-                new HeatTransferCoefficient_Basic(mesh_, nameT_, nameKappa_)
-            );
+                new HeatTransferCoefficient_Basic(mesh_, nameT_, nameKappa_));
             DEBUG(adapterInfo("Added writer: Heat Transfer Coefficient for basic solvers. "));
         }
         else
         {
             adapterInfo("Unknown solver type - cannot add heat transfer coefficient.",
-                "error");
+                        "error");
         }
     }
     else
     {
-        adapterInfo("Unknown data type - cannot add " + dataName +".", "error");
+        adapterInfo("Unknown data type - cannot add " + dataName + ".", "error");
     }
 
     // NOTE: If you want to couple another variable, you need
@@ -215,99 +194,83 @@ void preciceAdapter::CHT::ConjugateHeatTransfer::addWriters(std::string dataName
     // the one provided in the adapter's configuration file.
 }
 
-void preciceAdapter::CHT::ConjugateHeatTransfer::addReaders(std::string dataName, Interface * interface)
+void preciceAdapter::CHT::ConjugateHeatTransfer::addReaders(std::string dataName, Interface* interface)
 {
     if (dataName.find("Sink-Temperature") == 0)
     {
-        interface->addCouplingDataReader
-        (
+        interface->addCouplingDataReader(
             dataName,
-            new SinkTemperature(mesh_, nameT_)
-        );
+            new SinkTemperature(mesh_, nameT_));
         DEBUG(adapterInfo("Added reader: Sink Temperature."));
     }
     else if (dataName.find("Temperature") == 0)
     {
-        interface->addCouplingDataReader
-        (
+        interface->addCouplingDataReader(
             dataName,
-            new Temperature(mesh_, nameT_)
-        );
+            new Temperature(mesh_, nameT_));
         DEBUG(adapterInfo("Added reader: Temperature."));
     }
     else if (dataName.find("Heat-Flux") == 0)
     {
         if (solverType_.compare("compressible") == 0)
         {
-            interface->addCouplingDataReader
-            (
+            interface->addCouplingDataReader(
                 dataName,
-                new HeatFlux_Compressible(mesh_, nameT_)
-            );
+                new HeatFlux_Compressible(mesh_, nameT_));
             DEBUG(adapterInfo("Added reader: Heat Flux for compressible solvers."));
         }
         else if (solverType_.compare("incompressible") == 0)
         {
-            interface->addCouplingDataReader
-            (
+            interface->addCouplingDataReader(
                 dataName,
-                new HeatFlux_Incompressible(mesh_, nameT_, nameRho_, nameCp_, namePr_, nameAlphat_)
-            );
+                new HeatFlux_Incompressible(mesh_, nameT_, nameRho_, nameCp_, namePr_, nameAlphat_));
             DEBUG(adapterInfo("Added reader: Heat Flux for incompressible solvers. "));
         }
         else if (solverType_.compare("basic") == 0)
         {
-            interface->addCouplingDataReader
-            (
+            interface->addCouplingDataReader(
                 dataName,
-                new HeatFlux_Basic(mesh_, nameT_, nameKappa_)
-            );
+                new HeatFlux_Basic(mesh_, nameT_, nameKappa_));
             DEBUG(adapterInfo("Added reader: Heat Flux for basic solvers. "));
         }
         else
         {
             adapterInfo("Unknown solver type - cannot add heat flux.",
-                "error");
+                        "error");
         }
     }
     else if (dataName.find("Heat-Transfer-Coefficient") == 0)
     {
         if (solverType_.compare("compressible") == 0)
         {
-            interface->addCouplingDataReader
-            (
+            interface->addCouplingDataReader(
                 dataName,
-                new HeatTransferCoefficient_Compressible(mesh_, nameT_)
-            );
+                new HeatTransferCoefficient_Compressible(mesh_, nameT_));
             DEBUG(adapterInfo("Added reader: Heat Transfer Coefficient for compressible solvers."));
         }
         else if (solverType_.compare("incompressible") == 0)
         {
-            interface->addCouplingDataReader
-            (
+            interface->addCouplingDataReader(
                 dataName,
-                new HeatTransferCoefficient_Incompressible(mesh_, nameT_, nameRho_, nameCp_, namePr_, nameAlphat_)
-            );
+                new HeatTransferCoefficient_Incompressible(mesh_, nameT_, nameRho_, nameCp_, namePr_, nameAlphat_));
             DEBUG(adapterInfo("Added reader: Heat Transfer Coefficient for incompressible solvers. "));
         }
         else if (solverType_.compare("basic") == 0)
         {
-            interface->addCouplingDataReader
-            (
+            interface->addCouplingDataReader(
                 dataName,
-                new HeatTransferCoefficient_Basic(mesh_, nameT_, nameKappa_)
-            );
+                new HeatTransferCoefficient_Basic(mesh_, nameT_, nameKappa_));
             DEBUG(adapterInfo("Added reader: Heat Transfer Coefficient for basic solvers. "));
         }
         else
         {
             adapterInfo("Unknown solver type - cannot add heat transfer coefficient.",
-                "error");
+                        "error");
         }
     }
     else
     {
-        adapterInfo("Unknown data type - cannot add " + dataName +".", "error");
+        adapterInfo("Unknown data type - cannot add " + dataName + ".", "error");
     }
 
     // NOTE: If you want to couple another variable, you need

--- a/CHT/CHT.H
+++ b/CHT/CHT.H
@@ -19,7 +19,6 @@ class ConjugateHeatTransfer
 {
 
 protected:
-
     //- OpenFOAM fvMesh object
     const Foam::fvMesh& mesh_;
 
@@ -47,7 +46,6 @@ protected:
     std::string nameAlphat_ = "alphat";
 
 protected:
-
     //- Determine the solver type
     std::string determineSolverType();
 
@@ -55,7 +53,6 @@ protected:
     bool readConfig(const IOdictionary& adapterConfig);
 
 public:
-
     //- Constructor
     ConjugateHeatTransfer(const Foam::fvMesh& mesh);
 
@@ -63,10 +60,10 @@ public:
     bool configure(const IOdictionary& adapterConfig);
 
     //- Add coupling data writers
-    void addWriters(std::string dataName, Interface * interface);
+    void addWriters(std::string dataName, Interface* interface);
 
     //- Add coupling data readers
-    void addReaders(std::string dataName, Interface * interface);
+    void addReaders(std::string dataName, Interface* interface);
 };
 
 }

--- a/CHT/HeatFlux.H
+++ b/CHT/HeatFlux.H
@@ -16,9 +16,8 @@ class HeatFlux : public CouplingDataUser
 {
 
 protected:
-
     //- Temperature field
-    Foam::volScalarField * T_;
+    Foam::volScalarField* T_;
 
     const Foam::fvMesh& mesh_;
 
@@ -29,21 +28,19 @@ protected:
     virtual Foam::scalar getKappaEffAt(int i) = 0;
 
 public:
-
     //- Constructor
     HeatFlux(const Foam::fvMesh& mesh, const std::string nameT);
 
     //- Compute heat flux values from the temperature field
     //  and write them into the buffer
-    virtual void write(double * buffer, bool meshConnectivity, const unsigned int dim);
+    virtual void write(double* buffer, bool meshConnectivity, const unsigned int dim);
 
     //- Read heat flux values from the buffer and assign them to
     //  the gradient of the temperature field
-    virtual void read(double * buffer, const unsigned int dim);
+    virtual void read(double* buffer, const unsigned int dim);
 
     //- Destructor
-    virtual ~HeatFlux(){};
-
+    virtual ~HeatFlux() {};
 };
 
 //- Implementation of the HeatFlux for compresible, turbulent flow solvers
@@ -52,10 +49,9 @@ class HeatFlux_Compressible : public HeatFlux
 {
 
 protected:
-
     // Object that extracts the effective conductivity
     // (for compressible turbulent flow solvers)
-    KappaEff_Compressible * Kappa_;
+    KappaEff_Compressible* Kappa_;
 
     //- Wrapper for the extract() method of the corresponding KappaEff class
     virtual void extractKappaEff(uint patchID, bool meshConnectivity);
@@ -64,17 +60,13 @@ protected:
     virtual Foam::scalar getKappaEffAt(int i);
 
 public:
-
     //- Constructor
-    HeatFlux_Compressible
-    (
+    HeatFlux_Compressible(
         const Foam::fvMesh& mesh,
-        const std::string nameT
-    );
+        const std::string nameT);
 
     //- Destructor
     virtual ~HeatFlux_Compressible();
-
 };
 
 //- Implementation of the HeatFlux for incompresible, turbulent flow solvers
@@ -83,10 +75,9 @@ class HeatFlux_Incompressible : public HeatFlux
 {
 
 protected:
-
     // Object that computes the effective conductivity
     // (for incompressible turbulent flow solvers)
-    KappaEff_Incompressible * Kappa_;
+    KappaEff_Incompressible* Kappa_;
 
     //- Wrapper for the extract() method of the corresponding KappaEff class
     virtual void extractKappaEff(uint patchID, bool meshConnectivity);
@@ -95,21 +86,17 @@ protected:
     virtual Foam::scalar getKappaEffAt(int i);
 
 public:
-
     //- Constructor
-    HeatFlux_Incompressible
-    (
+    HeatFlux_Incompressible(
         const Foam::fvMesh& mesh,
         const std::string nameT,
         const std::string nameRho,
         const std::string nameCp,
         const std::string namePr,
-        const std::string nameAlphat
-    );
+        const std::string nameAlphat);
 
     //- Destructor
     virtual ~HeatFlux_Incompressible();
-
 };
 
 //- Implementation of the HeatFlux for basic solvers
@@ -118,10 +105,9 @@ class HeatFlux_Basic : public HeatFlux
 {
 
 protected:
-
     //- Object that extracts the effective conductivity
     // (for basic solvers)
-    KappaEff_Basic * Kappa_;
+    KappaEff_Basic* Kappa_;
 
     //- Wrapper for the extract() method of the corresponding KappaEff class
     virtual void extractKappaEff(uint patchID, bool meshConnectivity);
@@ -130,18 +116,14 @@ protected:
     virtual Foam::scalar getKappaEffAt(int i);
 
 public:
-
     //- Constructor
-    HeatFlux_Basic
-    (
+    HeatFlux_Basic(
         const Foam::fvMesh& mesh,
         const std::string nameT,
-        const std::string nameKappa
-    );
+        const std::string nameKappa);
 
     //- Destructor
     virtual ~HeatFlux_Basic();
-
 };
 
 }

--- a/CHT/HeatTransferCoefficient.C
+++ b/CHT/HeatTransferCoefficient.C
@@ -8,30 +8,24 @@ using namespace Foam;
 
 //----- preciceAdapter::CHT::HeatTransferCoefficient --------------------------
 
-preciceAdapter::CHT::HeatTransferCoefficient::HeatTransferCoefficient
-(
+preciceAdapter::CHT::HeatTransferCoefficient::HeatTransferCoefficient(
     const Foam::fvMesh& mesh,
-    const std::string nameT
-)
-:
-T_(
-    const_cast<volScalarField*>
-    (
-        &mesh.lookupObject<volScalarField>(nameT)
-    )
-),
-mesh_(mesh)
+    const std::string nameT)
+: T_(
+    const_cast<volScalarField*>(
+        &mesh.lookupObject<volScalarField>(nameT))),
+  mesh_(mesh)
 {
     dataType_ = scalar;
 }
 
 
-void preciceAdapter::CHT::HeatTransferCoefficient::write(double * buffer, bool meshConnectivity, const unsigned int dim)
+void preciceAdapter::CHT::HeatTransferCoefficient::write(double* buffer, bool meshConnectivity, const unsigned int dim)
 {
     int bufferIndex = 0;
 
     // For every boundary patch of the interface
-    for (uint j = 0; j < patchIDs_.size(); j++ )
+    for (uint j = 0; j < patchIDs_.size(); j++)
     {
         int patchID = patchIDs_.at(j);
 
@@ -39,18 +33,16 @@ void preciceAdapter::CHT::HeatTransferCoefficient::write(double * buffer, bool m
         extractKappaEff(patchID, meshConnectivity);
 
         // Get the face-cell distance coefficients on the patch
-        const scalarField & delta
-        (
-            mesh_.boundary()[patchID].deltaCoeffs()
-        );
+        const scalarField& delta(
+            mesh_.boundary()[patchID].deltaCoeffs());
 
         //If we use the mesh connectivity, we interpolate from the centres to the nodes
-        if(meshConnectivity)
+        if (meshConnectivity)
         {
             //Setup Interpolation object
             primitivePatchInterpolation patchInterpolator(mesh_.boundaryMesh()[patchID]);
 
-            scalarField  deltaPoints;
+            scalarField deltaPoints;
 
             //Interpolate
             deltaPoints = patchInterpolator.faceToPointInterpolate(delta);
@@ -80,7 +72,7 @@ void preciceAdapter::CHT::HeatTransferCoefficient::write(double * buffer, bool m
 }
 
 
-void preciceAdapter::CHT::HeatTransferCoefficient::read(double * buffer, const unsigned int dim)
+void preciceAdapter::CHT::HeatTransferCoefficient::read(double* buffer, const unsigned int dim)
 {
     int bufferIndex = 0;
 
@@ -91,22 +83,16 @@ void preciceAdapter::CHT::HeatTransferCoefficient::read(double * buffer, const u
 
         // Extract the effective conductivity on the patch
         // TODO: At the moment, reading with connectivity is not supported
-        extractKappaEff(patchID,/*meshConnectivity=*/false);
+        extractKappaEff(patchID, /*meshConnectivity=*/false);
 
         // Get the face-cell distance coefficients on the patch
-        const scalarField & delta
-        (
-            mesh_.boundary()[patchID].deltaCoeffs()
-        );
+        const scalarField& delta(
+            mesh_.boundary()[patchID].deltaCoeffs());
 
         // Get a reference to the temperature on the patch
-        mixedFvPatchScalarField & TPatch
-        (
-            refCast<mixedFvPatchScalarField>
-            (
-                T_->boundaryFieldRef()[patchID]
-            )
-        );
+        mixedFvPatchScalarField& TPatch(
+            refCast<mixedFvPatchScalarField>(
+                T_->boundaryFieldRef()[patchID]));
 
         // For every cell on the patch
         forAll(TPatch, i)
@@ -124,7 +110,7 @@ void preciceAdapter::CHT::HeatTransferCoefficient::read(double * buffer, const u
 
             // Set the fraction (0-1) of value for the mixed boundary condition
             TPatch.valueFraction()[i] =
-                    neighborKappaDelta / (myKappaDelta + neighborKappaDelta);
+                neighborKappaDelta / (myKappaDelta + neighborKappaDelta);
         }
     }
 }
@@ -133,31 +119,28 @@ void preciceAdapter::CHT::HeatTransferCoefficient::read(double * buffer, const u
 //----- preciceAdapter::CHT::HeatTransferCoefficient_Compressible -------------
 
 preciceAdapter::CHT::
-HeatTransferCoefficient_Compressible::HeatTransferCoefficient_Compressible
-(
-    const Foam::fvMesh& mesh,
-    const std::string nameT
-)
-:
-HeatTransferCoefficient(mesh, nameT),
-Kappa_(new KappaEff_Compressible(mesh))
+    HeatTransferCoefficient_Compressible::HeatTransferCoefficient_Compressible(
+        const Foam::fvMesh& mesh,
+        const std::string nameT)
+: HeatTransferCoefficient(mesh, nameT),
+  Kappa_(new KappaEff_Compressible(mesh))
 {
 }
 
 preciceAdapter::CHT::HeatTransferCoefficient_Compressible::
-~HeatTransferCoefficient_Compressible()
+    ~HeatTransferCoefficient_Compressible()
 {
     delete Kappa_;
 }
 
 void preciceAdapter::CHT::HeatTransferCoefficient_Compressible::
-extractKappaEff(uint patchID, bool meshConnectivity)
+    extractKappaEff(uint patchID, bool meshConnectivity)
 {
     Kappa_->extract(patchID, meshConnectivity);
 }
 
 scalar preciceAdapter::CHT::HeatTransferCoefficient_Compressible::
-getKappaEffAt(int i)
+    getKappaEffAt(int i)
 {
     return Kappa_->getAt(i);
 }
@@ -165,35 +148,32 @@ getKappaEffAt(int i)
 //----- preciceAdapter::CHT::HeatTransferCoefficient_Incompressible -----------
 
 preciceAdapter::CHT::HeatTransferCoefficient_Incompressible::
-HeatTransferCoefficient_Incompressible
-(
-    const Foam::fvMesh& mesh,
-    const std::string nameT,
-    const std::string nameRho,
-    const std::string nameCp,
-    const std::string namePr,
-    const std::string nameAlphat
-)
-:
-HeatTransferCoefficient(mesh, nameT),
-Kappa_(new KappaEff_Incompressible(mesh, nameRho, nameCp, namePr, nameAlphat))
+    HeatTransferCoefficient_Incompressible(
+        const Foam::fvMesh& mesh,
+        const std::string nameT,
+        const std::string nameRho,
+        const std::string nameCp,
+        const std::string namePr,
+        const std::string nameAlphat)
+: HeatTransferCoefficient(mesh, nameT),
+  Kappa_(new KappaEff_Incompressible(mesh, nameRho, nameCp, namePr, nameAlphat))
 {
 }
 
 preciceAdapter::CHT::HeatTransferCoefficient_Incompressible::
-~HeatTransferCoefficient_Incompressible()
+    ~HeatTransferCoefficient_Incompressible()
 {
     delete Kappa_;
 }
 
 void preciceAdapter::CHT::HeatTransferCoefficient_Incompressible::
-extractKappaEff(uint patchID, bool meshConnectivity)
+    extractKappaEff(uint patchID, bool meshConnectivity)
 {
     Kappa_->extract(patchID, meshConnectivity);
 }
 
 scalar preciceAdapter::CHT::HeatTransferCoefficient_Incompressible::
-getKappaEffAt(int i)
+    getKappaEffAt(int i)
 {
     return Kappa_->getAt(i);
 }
@@ -201,32 +181,29 @@ getKappaEffAt(int i)
 //----- preciceAdapter::CHT::HeatTransferCoefficient_Basic -----------------------------------
 
 preciceAdapter::CHT::HeatTransferCoefficient_Basic::
-HeatTransferCoefficient_Basic
-(
-    const Foam::fvMesh& mesh,
-    const std::string nameT,
-    const std::string nameKappa
-)
-:
-HeatTransferCoefficient(mesh, nameT),
-Kappa_(new KappaEff_Basic(mesh, nameKappa))
+    HeatTransferCoefficient_Basic(
+        const Foam::fvMesh& mesh,
+        const std::string nameT,
+        const std::string nameKappa)
+: HeatTransferCoefficient(mesh, nameT),
+  Kappa_(new KappaEff_Basic(mesh, nameKappa))
 {
 }
 
 preciceAdapter::CHT::HeatTransferCoefficient_Basic::
-~HeatTransferCoefficient_Basic()
+    ~HeatTransferCoefficient_Basic()
 {
     delete Kappa_;
 }
 
 void preciceAdapter::CHT::HeatTransferCoefficient_Basic::
-extractKappaEff(uint patchID, bool meshConnectivity)
+    extractKappaEff(uint patchID, bool meshConnectivity)
 {
     Kappa_->extract(patchID, meshConnectivity);
 }
 
 scalar preciceAdapter::CHT::HeatTransferCoefficient_Basic::
-getKappaEffAt(int i)
+    getKappaEffAt(int i)
 {
     return Kappa_->getAt(i);
 }

--- a/CHT/HeatTransferCoefficient.H
+++ b/CHT/HeatTransferCoefficient.H
@@ -16,9 +16,8 @@ class HeatTransferCoefficient : public CouplingDataUser
 {
 
 protected:
-
     //- Temperature field
-    Foam::volScalarField * T_;
+    Foam::volScalarField* T_;
 
     //- OpenFOAM fvMesh object
     const Foam::fvMesh& mesh_;
@@ -30,23 +29,19 @@ protected:
     virtual Foam::scalar getKappaEffAt(int i) = 0;
 
 public:
-
     //- Constructor
-    HeatTransferCoefficient
-    (
+    HeatTransferCoefficient(
         const Foam::fvMesh& mesh,
-        const std::string nameT
-    );
+        const std::string nameT);
 
     //- Write the heat transfer coefficient values into the buffer
-    virtual void write(double * buffer, bool meshConnectivity, const unsigned int dim);
+    virtual void write(double* buffer, bool meshConnectivity, const unsigned int dim);
 
     //- Read the heat transfer coefficient values from the buffer
-    virtual void read(double * buffer, const unsigned int dim);
+    virtual void read(double* buffer, const unsigned int dim);
 
     //- Destructor
-    virtual ~HeatTransferCoefficient(){};
-
+    virtual ~HeatTransferCoefficient() {};
 };
 
 //- Implementation of the HeatTransferCoefficient for compresible, turbulent flow solvers
@@ -55,10 +50,9 @@ class HeatTransferCoefficient_Compressible : public HeatTransferCoefficient
 {
 
 protected:
-
     // Object that extracts the effective conductivity
     // (for compressible turbulent flow solvers)
-    KappaEff_Compressible * Kappa_;
+    KappaEff_Compressible* Kappa_;
 
     //- Wrapper for the extract() method of the corresponding KappaEff class
     virtual void extractKappaEff(uint patchID, bool meshConnectivity);
@@ -67,17 +61,13 @@ protected:
     virtual Foam::scalar getKappaEffAt(int i);
 
 public:
-
     //- Constructor
-    HeatTransferCoefficient_Compressible
-    (
+    HeatTransferCoefficient_Compressible(
         const Foam::fvMesh& mesh,
-        const std::string nameT
-    );
+        const std::string nameT);
 
     //- Destructor
     virtual ~HeatTransferCoefficient_Compressible();
-
 };
 
 //- Implementation of the HeatTransferCoefficient for incompresible, turbulent flow solvers
@@ -86,10 +76,9 @@ class HeatTransferCoefficient_Incompressible : public HeatTransferCoefficient
 {
 
 protected:
-
     // Object that computes the effective conductivity
     // (for incompressible turbulent flow solvers)
-    KappaEff_Incompressible * Kappa_;
+    KappaEff_Incompressible* Kappa_;
 
     //- Wrapper for the extract() method of the corresponding KappaEff class
     virtual void extractKappaEff(uint patchID, bool meshConnectivity);
@@ -98,21 +87,17 @@ protected:
     virtual Foam::scalar getKappaEffAt(int i);
 
 public:
-
     //- Constructor
-    HeatTransferCoefficient_Incompressible
-    (
+    HeatTransferCoefficient_Incompressible(
         const Foam::fvMesh& mesh,
         const std::string nameT,
         const std::string nameRho,
         const std::string nameCp,
         const std::string namePr,
-        const std::string nameAlphat
-    );
+        const std::string nameAlphat);
 
     //- Destructor
     virtual ~HeatTransferCoefficient_Incompressible();
-
 };
 
 
@@ -122,10 +107,9 @@ class HeatTransferCoefficient_Basic : public HeatTransferCoefficient
 {
 
 protected:
-
     //- Object that extracts the effective conductivity
     // (for basic solvers)
-    KappaEff_Basic * Kappa_;
+    KappaEff_Basic* Kappa_;
 
     //- Wrapper for the extract() method of the corresponding KappaEff class
     virtual void extractKappaEff(uint patchID, bool meshConnectivity);
@@ -134,18 +118,14 @@ protected:
     virtual Foam::scalar getKappaEffAt(int i);
 
 public:
-
     //- Constructor
-    HeatTransferCoefficient_Basic
-    (
+    HeatTransferCoefficient_Basic(
         const Foam::fvMesh& mesh,
         const std::string nameT,
-        const std::string nameKappa
-    );
+        const std::string nameKappa);
 
     //- Destructor
     virtual ~HeatTransferCoefficient_Basic();
-
 };
 
 }

--- a/CHT/KappaEffective.C
+++ b/CHT/KappaEffective.C
@@ -7,33 +7,29 @@ using namespace Foam;
 
 //----- preciceAdapter::CHT::KappaEff_Compressible ------------------
 
-preciceAdapter::CHT::KappaEff_Compressible::KappaEff_Compressible
-(
-    const Foam::fvMesh& mesh
-)
-:
-mesh_(mesh),
-turbulence_(
-    mesh.lookupObject<compressible::turbulenceModel>(turbulenceModel::propertiesName)
-)
+preciceAdapter::CHT::KappaEff_Compressible::KappaEff_Compressible(
+    const Foam::fvMesh& mesh)
+: mesh_(mesh),
+  turbulence_(
+      mesh.lookupObject<compressible::turbulenceModel>(turbulenceModel::propertiesName))
 {
     DEBUG(adapterInfo("Constructed KappaEff_Compressible."));
 }
 
 void preciceAdapter::CHT::KappaEff_Compressible::extract(uint patchID, bool meshConnectivity)
 {
-    if(meshConnectivity)
+    if (meshConnectivity)
     {
         //Create an Interpolation object at the boundary Field
         primitivePatchInterpolation patchInterpolator(mesh_.boundaryMesh()[patchID]);
 
         //Interpolate kappaEff_ from centers to nodes
-        kappaEff_= patchInterpolator.faceToPointInterpolate(turbulence_.kappaEff() ().boundaryField()[patchID]);
+        kappaEff_ = patchInterpolator.faceToPointInterpolate(turbulence_.kappaEff()().boundaryField()[patchID]);
     }
     else
     {
         // Extract kappaEff_ from the turbulence model
-        kappaEff_ = turbulence_.kappaEff() ().boundaryField()[patchID];
+        kappaEff_ = turbulence_.kappaEff()().boundaryField()[patchID];
     }
 }
 
@@ -45,78 +41,65 @@ scalar preciceAdapter::CHT::KappaEff_Compressible::getAt(int i)
 
 //----- preciceAdapter::CHT::KappaEff_Incompressible ------------------
 
-preciceAdapter::CHT::KappaEff_Incompressible::KappaEff_Incompressible
-(
+preciceAdapter::CHT::KappaEff_Incompressible::KappaEff_Incompressible(
     const Foam::fvMesh& mesh,
     const std::string nameRho,
     const std::string nameCp,
     const std::string namePr,
-    const std::string nameAlphat
-)
-:
-mesh_(mesh),
-turbulence_(
-    mesh.lookupObject<incompressible::turbulenceModel>(turbulenceModel::propertiesName)
-),
-nameRho_(nameRho),
-nameCp_(nameCp),
-namePr_(namePr),
-nameAlphat_(nameAlphat)
+    const std::string nameAlphat)
+: mesh_(mesh),
+  turbulence_(
+      mesh.lookupObject<incompressible::turbulenceModel>(turbulenceModel::propertiesName)),
+  nameRho_(nameRho),
+  nameCp_(nameCp),
+  namePr_(namePr),
+  nameAlphat_(nameAlphat)
 {
-        DEBUG(adapterInfo("Constructed KappaEff_Incompressible."));
-        DEBUG(adapterInfo("  Name of density: " + nameRho_));
-        DEBUG(adapterInfo("  Name of heat capacity: " + nameCp_));
-        DEBUG(adapterInfo("  Name of Prandl number: " + namePr_));
-        DEBUG(adapterInfo("  Name of turbulent thermal diffusivity: " + nameAlphat_));
+    DEBUG(adapterInfo("Constructed KappaEff_Incompressible."));
+    DEBUG(adapterInfo("  Name of density: " + nameRho_));
+    DEBUG(adapterInfo("  Name of heat capacity: " + nameCp_));
+    DEBUG(adapterInfo("  Name of Prandl number: " + namePr_));
+    DEBUG(adapterInfo("  Name of turbulent thermal diffusivity: " + nameAlphat_));
 
-        // Get the preciceDict/CHT dictionary
-        const dictionary CHTDict =
-            mesh_.lookupObject<IOdictionary>("preciceDict").subOrEmptyDict("CHT");
+    // Get the preciceDict/CHT dictionary
+    const dictionary CHTDict =
+        mesh_.lookupObject<IOdictionary>("preciceDict").subOrEmptyDict("CHT");
 
-        // Read the Prandtl number
-        if (!CHTDict.readIfPresent<dimensionedScalar>(namePr_, Pr_))
-        {
-            adapterInfo
-            (
-                "Cannot find the Prandtl number in preciceDict/CHT using the name " +
-                namePr_,
-                "error"
-            );
-        }
-        else
-        {
-            DEBUG(adapterInfo("  Pr = " + std::to_string(Pr_.value())));
-        }
+    // Read the Prandtl number
+    if (!CHTDict.readIfPresent<dimensionedScalar>(namePr_, Pr_))
+    {
+        adapterInfo(
+            "Cannot find the Prandtl number in preciceDict/CHT using the name " + namePr_,
+            "error");
+    }
+    else
+    {
+        DEBUG(adapterInfo("  Pr = " + std::to_string(Pr_.value())));
+    }
 
-        // Read the density
-        if (!CHTDict.readIfPresent<dimensionedScalar>(nameRho_, rho_))
-        {
-            adapterInfo
-            (
-                "Cannot find the density in preciceDict/CHT using the name " +
-                nameRho_,
-                "error"
-            );
-        }
-        else
-        {
-            DEBUG(adapterInfo("  rho = " + std::to_string(rho_.value())));
-        }
+    // Read the density
+    if (!CHTDict.readIfPresent<dimensionedScalar>(nameRho_, rho_))
+    {
+        adapterInfo(
+            "Cannot find the density in preciceDict/CHT using the name " + nameRho_,
+            "error");
+    }
+    else
+    {
+        DEBUG(adapterInfo("  rho = " + std::to_string(rho_.value())));
+    }
 
-        // Read the heat capacity
-        if (!CHTDict.readIfPresent<dimensionedScalar>(nameCp_, Cp_))
-        {
-            adapterInfo
-            (
-                "Cannot find the heat capacity in preciceDict/CHT using the name " +
-                nameCp_,
-                "error"
-            );
-        }
-        else
-        {
-            DEBUG(adapterInfo("  Cp = " + std::to_string(Cp_.value())));
-        }
+    // Read the heat capacity
+    if (!CHTDict.readIfPresent<dimensionedScalar>(nameCp_, Cp_))
+    {
+        adapterInfo(
+            "Cannot find the heat capacity in preciceDict/CHT using the name " + nameCp_,
+            "error");
+    }
+    else
+    {
+        DEBUG(adapterInfo("  Cp = " + std::to_string(Cp_.value())));
+    }
 }
 
 void preciceAdapter::CHT::KappaEff_Incompressible::extract(uint patchID, bool meshConnectivity)
@@ -125,10 +108,8 @@ void preciceAdapter::CHT::KappaEff_Incompressible::extract(uint patchID, bool me
 
     // Get the laminar viscosity from the turbulence model
     // TODO: Do we really need turbulence at the end?
-    const scalarField & nu
-    (
-        turbulence_.nu() ().boundaryField()[patchID]
-    );
+    const scalarField& nu(
+        turbulence_.nu()().boundaryField()[patchID]);
 
     // Compute the effective thermal diffusivity
     // (alphaEff = alpha + alphat = nu / Pr + nut / Prt)
@@ -138,10 +119,8 @@ void preciceAdapter::CHT::KappaEff_Incompressible::extract(uint patchID, bool me
     // Does the turbulent thermal diffusivity exist in the object registry?
     if (mesh_.foundObject<volScalarField>(nameAlphat_))
     {
-        const scalarField & alphat
-        (
-            mesh_.lookupObject<volScalarField>(nameAlphat_).boundaryField()[patchID]
-        );
+        const scalarField& alphat(
+            mesh_.lookupObject<volScalarField>(nameAlphat_).boundaryField()[patchID]);
 
         alphaEff = nu / Pr_.value() + alphat;
     }
@@ -158,25 +137,22 @@ void preciceAdapter::CHT::KappaEff_Incompressible::extract(uint patchID, bool me
     }
 
     // Compute the effective thermal conductivity and store it in a temp variable
-    scalarField kappaEff_temp
-    (
-        alphaEff * rho_.value() * Cp_.value()
-    );
+    scalarField kappaEff_temp(
+        alphaEff * rho_.value() * Cp_.value());
 
-    if(meshConnectivity)
+    if (meshConnectivity)
     {
         //Create an Interpolation object at the boundary Field
         primitivePatchInterpolation patchInterpolator(mesh_.boundaryMesh()[patchID]);
 
         //Interpolate kappaEff_ from centers to nodes, if desired
-        kappaEff_= patchInterpolator.faceToPointInterpolate(kappaEff_temp);
+        kappaEff_ = patchInterpolator.faceToPointInterpolate(kappaEff_temp);
     }
     else
     {
         // if no interpolation
         kappaEff_ = kappaEff_temp;
     }
-
 }
 
 scalar preciceAdapter::CHT::KappaEff_Incompressible::getAt(int i)
@@ -186,14 +162,11 @@ scalar preciceAdapter::CHT::KappaEff_Incompressible::getAt(int i)
 
 //----- preciceAdapter::CHT::KappaEff_Basic ---------------------------
 
-preciceAdapter::CHT::KappaEff_Basic::KappaEff_Basic
-(
+preciceAdapter::CHT::KappaEff_Basic::KappaEff_Basic(
     const Foam::fvMesh& mesh,
-    const std::string nameKappa
-)
-:
-mesh_(mesh),
-nameKappa_(nameKappa)
+    const std::string nameKappa)
+: mesh_(mesh),
+  nameKappa_(nameKappa)
 {
     DEBUG(adapterInfo("Constructed KappaEff_Basic."));
     DEBUG(adapterInfo("  Name of conductivity: " + nameKappa_));
@@ -205,16 +178,13 @@ nameKappa_(nameKappa)
     // Read the conductivity
     if (!CHTDict.readIfPresent<dimensionedScalar>(nameKappa_, kappaEff_))
     {
-        adapterInfo
-        (
-            "Cannot find the conductivity in preciceDict/CHT using the name " +
-            nameKappa_,
-            "error"
-        );
+        adapterInfo(
+            "Cannot find the conductivity in preciceDict/CHT using the name " + nameKappa_,
+            "error");
     }
     else
     {
-        DEBUG(adapterInfo(  "k = " + std::to_string(kappaEff_.value())));
+        DEBUG(adapterInfo("k = " + std::to_string(kappaEff_.value())));
     }
 }
 

--- a/CHT/KappaEffective.H
+++ b/CHT/KappaEffective.H
@@ -11,10 +11,10 @@ namespace CHT
 
 //- Class that extracts the effective conductivity from compressible
 //  turbulent flow solvers.
-class KappaEff_Compressible {
+class KappaEff_Compressible
+{
 
 protected:
-
     //- OpenFOAM fvMesh object
     const Foam::fvMesh& mesh_;
 
@@ -23,10 +23,9 @@ protected:
 
     //- Turbulence (and thermo/transport) model, from which
     //  kappaEff is drawn directly.
-    const Foam::compressible::turbulenceModel & turbulence_;
+    const Foam::compressible::turbulenceModel& turbulence_;
 
 public:
-
     //- Constructor
     KappaEff_Compressible(const Foam::fvMesh& mesh);
 
@@ -35,15 +34,14 @@ public:
 
     //- Get the value of kappaEff at cell i
     Foam::scalar getAt(int i);
-
 };
 
 //- Class that extracts the effective conductivity from incompressible
 //  turbulent flow solvers.
-class KappaEff_Incompressible {
+class KappaEff_Incompressible
+{
 
 protected:
-
     //- OpenFOAM fvMesh object
     const Foam::fvMesh& mesh_;
 
@@ -53,7 +51,7 @@ protected:
     //- Turbulence (and thermo/transport) model.
     //  The effective thermal diffusivity is drawn from it and
     //  used to compute the effective thermal conductivity.
-    const Foam::incompressible::turbulenceModel & turbulence_;
+    const Foam::incompressible::turbulenceModel& turbulence_;
 
     //- Name of the user-provided density (in the preciceDict)
     const std::string nameRho_;
@@ -77,32 +75,28 @@ protected:
     Foam::dimensionedScalar Pr_;
 
 public:
-
     //- Constructor
-    KappaEff_Incompressible
-    (
+    KappaEff_Incompressible(
         const Foam::fvMesh& mesh,
         const std::string nameRho,
         const std::string nameCp,
         const std::string namePr,
-        const std::string nameAlphat
-    );
+        const std::string nameAlphat);
 
     //- Extract the kappaEff on the specific patch and store it.
     void extract(uint patchID, bool meshConnectivity);
 
     //- Get the value of kappaEff at cell i
     Foam::scalar getAt(int i);
-
 };
 
 //- Class that extracts the effective conductivity from basic solvers,
 //  which do not have a turbulence/thermophysical model, but read
 //  the required parameters from the preciceDict dictionary.
-class KappaEff_Basic {
+class KappaEff_Basic
+{
 
 protected:
-
     //- OpenFOAM fvMesh object
     const Foam::fvMesh& mesh_;
 
@@ -113,20 +107,16 @@ protected:
     const std::string nameKappa_;
 
 public:
-
     //- Constructor
-    KappaEff_Basic
-    (
+    KappaEff_Basic(
         const Foam::fvMesh& mesh,
-        const std::string nameKappa
-    );
+        const std::string nameKappa);
 
     //- Extract the kappaEff on the specific patch and store it.
     void extract(uint patchID, bool meshConnectivity);
 
     //- Get the value of kappaEff at cell i (returns the same for every i)
     Foam::scalar getAt(int i);
-
 };
 
 }

--- a/CHT/SinkTemperature.C
+++ b/CHT/SinkTemperature.C
@@ -3,63 +3,52 @@
 
 using namespace Foam;
 
-preciceAdapter::CHT::SinkTemperature::SinkTemperature
-(
+preciceAdapter::CHT::SinkTemperature::SinkTemperature(
     const Foam::fvMesh& mesh,
-    const std::string nameT
-    )
-:
-T_(
-    const_cast<volScalarField*>
-    (
-        &mesh.lookupObject<volScalarField>(nameT)
-    )
-),
-mesh_(mesh)
+    const std::string nameT)
+: T_(
+    const_cast<volScalarField*>(
+        &mesh.lookupObject<volScalarField>(nameT))),
+  mesh_(mesh)
 {
     dataType_ = scalar;
 }
 
-void preciceAdapter::CHT::SinkTemperature::write(double * buffer, bool meshConnectivity, const unsigned int dim)
+void preciceAdapter::CHT::SinkTemperature::write(double* buffer, bool meshConnectivity, const unsigned int dim)
 {
     int bufferIndex = 0;
 
     // For every boundary patch of the interface
-    for (uint j = 0; j < patchIDs_.size(); j++ )
+    for (uint j = 0; j < patchIDs_.size(); j++)
     {
         int patchID = patchIDs_.at(j);
 
         // Get the boundary field of Temperature on the patch
-        const fvPatchScalarField & TPatch
-        (
-            refCast<const fvPatchScalarField>
-            (
-                T_->boundaryField()[patchID]
-            )
-        );
+        const fvPatchScalarField& TPatch(
+            refCast<const fvPatchScalarField>(
+                T_->boundaryField()[patchID]));
 
         // Get the internal field next to the patch // TODO: Simplify?
         tmp<scalarField> patchInternalFieldTmp = TPatch.patchInternalField();
-        const scalarField & patchInternalField = patchInternalFieldTmp();
+        const scalarField& patchInternalField = patchInternalFieldTmp();
 
         //If we use the mesh connectivity, we interpolate from the centres to the nodes
-        if(meshConnectivity)
+        if (meshConnectivity)
         {
             //Create an Interpolation object at the boundary Field
             primitivePatchInterpolation patchInterpolator(mesh_.boundaryMesh()[patchID]);
 
-            scalarField  patchInternalPointField;
+            scalarField patchInternalPointField;
 
             //Interpolate from centers to nodes
-            patchInternalPointField= patchInterpolator.faceToPointInterpolate(patchInternalField);
+            patchInternalPointField = patchInterpolator.faceToPointInterpolate(patchInternalField);
 
             // For every point on the patch
             forAll(patchInternalPointField, i)
             {
                 // Copy the temperature into the buffer
-                buffer[bufferIndex++]
-                =
-                patchInternalPointField[i];
+                buffer[bufferIndex++] =
+                    patchInternalPointField[i];
             }
         }
         else
@@ -68,9 +57,8 @@ void preciceAdapter::CHT::SinkTemperature::write(double * buffer, bool meshConne
             forAll(TPatch, i)
             {
                 // Copy the internal field (sink) temperature into the buffer
-                buffer[bufferIndex++]
-                =
-                patchInternalField[i];
+                buffer[bufferIndex++] =
+                    patchInternalField[i];
             }
         }
 
@@ -79,7 +67,7 @@ void preciceAdapter::CHT::SinkTemperature::write(double * buffer, bool meshConne
     }
 }
 
-void preciceAdapter::CHT::SinkTemperature::read(double * buffer, const unsigned int dim)
+void preciceAdapter::CHT::SinkTemperature::read(double* buffer, const unsigned int dim)
 {
     int bufferIndex = 0;
 
@@ -89,24 +77,19 @@ void preciceAdapter::CHT::SinkTemperature::read(double * buffer, const unsigned 
         int patchID = patchIDs_.at(j);
 
         // Get the boundary field of the temperature on the patch
-        mixedFvPatchScalarField & TPatch
-        (
-            refCast<mixedFvPatchScalarField>
-            (
-                T_->boundaryFieldRef()[patchID]
-            )
-        );
+        mixedFvPatchScalarField& TPatch(
+            refCast<mixedFvPatchScalarField>(
+                T_->boundaryFieldRef()[patchID]));
 
         // Get a reference to the reference value on the patch
-        scalarField & Tref = TPatch.refValue();
+        scalarField& Tref = TPatch.refValue();
 
         // For every cell of the patch
         forAll(TPatch, i)
         {
             // Set the reference value as the buffer value
-            Tref[i]
-            =
-            buffer[bufferIndex++];
+            Tref[i] =
+                buffer[bufferIndex++];
         }
     }
 }

--- a/CHT/SinkTemperature.H
+++ b/CHT/SinkTemperature.H
@@ -15,26 +15,21 @@ class SinkTemperature : public CouplingDataUser
 {
 
 private:
-
     //- Temperature field
-    Foam::volScalarField * T_;
+    Foam::volScalarField* T_;
     const Foam::fvMesh& mesh_;
 
 public:
-
     //- Constructor
-    SinkTemperature
-    (
+    SinkTemperature(
         const Foam::fvMesh& mesh,
-        const std::string nameT
-    );
+        const std::string nameT);
 
     //- Write the sink temperature values into the buffer
-    void write(double * buffer, bool meshConnectivity, const unsigned int dim);
+    void write(double* buffer, bool meshConnectivity, const unsigned int dim);
 
     //- Read the sink temperature values from the buffer
-    void read(double * buffer, const unsigned int dim);
-
+    void read(double* buffer, const unsigned int dim);
 };
 
 }

--- a/CHT/Temperature.C
+++ b/CHT/Temperature.C
@@ -4,55 +4,44 @@
 
 using namespace Foam;
 
-preciceAdapter::CHT::Temperature::Temperature
-(
+preciceAdapter::CHT::Temperature::Temperature(
     const Foam::fvMesh& mesh,
-    const std::string nameT
-)
-:
-T_(
-    const_cast<volScalarField*>
-    (
-        &mesh.lookupObject<volScalarField>(nameT)
-    )
-),
-mesh_(mesh)
+    const std::string nameT)
+: T_(
+    const_cast<volScalarField*>(
+        &mesh.lookupObject<volScalarField>(nameT))),
+  mesh_(mesh)
 {
     dataType_ = scalar;
 }
 
-void preciceAdapter::CHT::Temperature::write(double * buffer, bool meshConnectivity, const unsigned int dim)
+void preciceAdapter::CHT::Temperature::write(double* buffer, bool meshConnectivity, const unsigned int dim)
 {
     int bufferIndex = 0;
 
     // For every boundary patch of the interface
-    for (uint j = 0; j < patchIDs_.size(); j++ )
+    for (uint j = 0; j < patchIDs_.size(); j++)
     {
         int patchID = patchIDs_.at(j);
 
-        const scalarField & TPatch
-        (
-            T_->boundaryField()[patchID]
-        );
+        const scalarField& TPatch(
+            T_->boundaryField()[patchID]);
 
         //If we use the mesh connectivity, we interpolate from the centres to the nodes
-        if(meshConnectivity)
+        if (meshConnectivity)
         {
             //Create an Interpolation object at the boundary Field
             primitivePatchInterpolation patchInterpolator(mesh_.boundaryMesh()[patchID]);
 
             //Interpolate from centers to nodes
-            scalarField  TPoints
-            (
-                patchInterpolator.faceToPointInterpolate(TPatch)
-            );
+            scalarField TPoints(
+                patchInterpolator.faceToPointInterpolate(TPatch));
 
             forAll(TPoints, i)
             {
                 // Copy the temperature into the buffer
-                buffer[bufferIndex++]
-                =
-                TPoints[i];
+                buffer[bufferIndex++] =
+                    TPoints[i];
             }
         }
         else
@@ -60,30 +49,28 @@ void preciceAdapter::CHT::Temperature::write(double * buffer, bool meshConnectiv
             forAll(TPatch, i)
             {
                 // Copy the temperature into the buffer
-                buffer[bufferIndex++]
-                =
-                TPatch[i];
+                buffer[bufferIndex++] =
+                    TPatch[i];
             }
         }
     }
 }
 
-    void preciceAdapter::CHT::Temperature::read(double * buffer, const unsigned int dim)
+void preciceAdapter::CHT::Temperature::read(double* buffer, const unsigned int dim)
+{
+    int bufferIndex = 0;
+
+    // For every boundary patch of the interface
+    for (uint j = 0; j < patchIDs_.size(); j++)
     {
-        int bufferIndex = 0;
+        int patchID = patchIDs_.at(j);
 
-        // For every boundary patch of the interface
-        for (uint j = 0; j < patchIDs_.size(); j++)
+        // For every cell of the patch
+        forAll(T_->boundaryField()[patchID], i)
         {
-            int patchID = patchIDs_.at(j);
-
-            // For every cell of the patch
-            forAll(T_->boundaryField()[patchID], i)
-            {
-                // Set the temperature as the buffer value
-                T_->boundaryFieldRef()[patchID][i]
-                =
+            // Set the temperature as the buffer value
+            T_->boundaryFieldRef()[patchID][i] =
                 buffer[bufferIndex++];
-            }
         }
     }
+}

--- a/CHT/Temperature.H
+++ b/CHT/Temperature.H
@@ -15,26 +15,21 @@ class Temperature : public CouplingDataUser
 {
 
 private:
-
     //- Temperature field
-    Foam::volScalarField * T_;
+    Foam::volScalarField* T_;
     const Foam::fvMesh& mesh_;
 
 public:
-
     //- Constructor
-    Temperature
-    (
+    Temperature(
         const Foam::fvMesh& mesh,
-        const std::string nameT
-    );
+        const std::string nameT);
 
     //- Write the temperature values into the buffer
-    void write(double * buffer, bool meshConnectivity, const unsigned int dim);
+    void write(double* buffer, bool meshConnectivity, const unsigned int dim);
 
     //- Read the temperature values from the buffer
-    void read(double * buffer, const unsigned int dim);
-
+    void read(double* buffer, const unsigned int dim);
 };
 
 }

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,3 +9,7 @@ and watch out for more specific details in this file.
 Instead of directly editing `CHANGELOG.md`, please add a file `123.md`
 in `changelog-entries`, where `123` your pull request number. This helps reduce
 merge conflicts and we will merge these files at the time we release a new version.
+
+## Code formatting
+
+You can format all files with clang-format 11 by running `./tools/format-code.sh`.

--- a/CouplingDataUser.C
+++ b/CouplingDataUser.C
@@ -39,5 +39,5 @@ void preciceAdapter::CouplingDataUser::setLocationsType(std::string locationsTyp
 // Dummy implementation which can be overwritten in derived classes if required
 void preciceAdapter::CouplingDataUser::initialize()
 {
-  return;
+    return;
 }

--- a/CouplingDataUser.H
+++ b/CouplingDataUser.H
@@ -11,8 +11,11 @@ class CouplingDataUser
 {
 
 protected:
-
-    enum DataType {scalar, vector};
+    enum DataType
+    {
+        scalar,
+        vector
+    };
 
     //- Type of the coupling data (scalar or vector)
     DataType dataType_ = scalar;
@@ -27,7 +30,6 @@ protected:
     std::string locationsType_;
 
 public:
-
     //- Constructor
     CouplingDataUser();
 
@@ -53,14 +55,13 @@ public:
     virtual void initialize();
 
     //- Write the coupling data to the buffer
-    virtual void write(double * dataBuffer, bool meshConnectivity, const unsigned int dim) = 0;
+    virtual void write(double* dataBuffer, bool meshConnectivity, const unsigned int dim) = 0;
 
     //- Read the coupling data from the buffer
-    virtual void read(double * dataBuffer, const unsigned int dim) = 0;
+    virtual void read(double* dataBuffer, const unsigned int dim) = 0;
 
     //- Destructor
     virtual ~CouplingDataUser() {}
-
 };
 
 }

--- a/FF/FF.H
+++ b/FF/FF.H
@@ -19,7 +19,6 @@ class FluidFluid
 {
 
 protected:
-
     //- OpenFOAM fvMesh object
     const Foam::fvMesh& mesh_;
 
@@ -30,7 +29,7 @@ protected:
 
     //- Name of the velocity field
     std::string nameU_ = "U";
-    
+
     //- Name of the pressure field
     std::string nameP_ = "p";
 
@@ -41,18 +40,17 @@ protected:
     bool readConfig(const IOdictionary& adapterConfig);
 
 public:
-
     //- Constructor
     FluidFluid(const Foam::fvMesh& mesh);
 
     //- Configure
     bool configure(const IOdictionary& adapterConfig);
-    
+
     //- Add coupling data writers
-    void addWriters(std::string dataName, Interface * interface);
-    
+    void addWriters(std::string dataName, Interface* interface);
+
     //- Add coupling data readers
-    void addReaders(std::string dataName, Interface * interface);
+    void addReaders(std::string dataName, Interface* interface);
 };
 
 }

--- a/FF/Pressure.C
+++ b/FF/Pressure.C
@@ -2,23 +2,17 @@
 
 using namespace Foam;
 
-preciceAdapter::FF::Pressure::Pressure
-(
+preciceAdapter::FF::Pressure::Pressure(
     const Foam::fvMesh& mesh,
-    const std::string nameP
-)
-:
-p_(
-    const_cast<volScalarField*>
-    (
-        &mesh.lookupObject<volScalarField>(nameP)
-    )
-)
+    const std::string nameP)
+: p_(
+    const_cast<volScalarField*>(
+        &mesh.lookupObject<volScalarField>(nameP)))
 {
     dataType_ = scalar;
 }
 
-void preciceAdapter::FF::Pressure::write(double * buffer, bool meshConnectivity, const unsigned int dim)
+void preciceAdapter::FF::Pressure::write(double* buffer, bool meshConnectivity, const unsigned int dim)
 {
     int bufferIndex = 0;
 
@@ -31,14 +25,13 @@ void preciceAdapter::FF::Pressure::write(double * buffer, bool meshConnectivity,
         forAll(p_->boundaryFieldRef()[patchID], i)
         {
             // Copy the pressure into the buffer
-            buffer[bufferIndex++]
-            =
-            p_->boundaryFieldRef()[patchID][i];
+            buffer[bufferIndex++] =
+                p_->boundaryFieldRef()[patchID][i];
         }
     }
 }
 
-void preciceAdapter::FF::Pressure::read(double * buffer, const unsigned int dim)
+void preciceAdapter::FF::Pressure::read(double* buffer, const unsigned int dim)
 {
     int bufferIndex = 0;
 
@@ -51,9 +44,8 @@ void preciceAdapter::FF::Pressure::read(double * buffer, const unsigned int dim)
         forAll(p_->boundaryFieldRef()[patchID], i)
         {
             // Set the pressure as the buffer value
-            p_->boundaryFieldRef()[patchID][i]
-            =
-            buffer[bufferIndex++];
+            p_->boundaryFieldRef()[patchID][i] =
+                buffer[bufferIndex++];
         }
     }
 }

--- a/FF/Pressure.H
+++ b/FF/Pressure.H
@@ -15,24 +15,20 @@ class Pressure : public CouplingDataUser
 {
 
 private:
-
     //- Pressure field
-    Foam::volScalarField * p_;
+    Foam::volScalarField* p_;
 
 public:
-
     //- Constructor
-    Pressure
-    (
+    Pressure(
         const Foam::fvMesh& mesh,
-        const std::string nameP
-    );
+        const std::string nameP);
 
     //- Write the pressure values into the buffer
-    void write(double * buffer, bool meshConnectivity, const unsigned int dim);
+    void write(double* buffer, bool meshConnectivity, const unsigned int dim);
 
     //- Read the pressure values from the buffer
-    void read(double * buffer, const unsigned int dim);
+    void read(double* buffer, const unsigned int dim);
 };
 
 }

--- a/FF/PressureGradient.C
+++ b/FF/PressureGradient.C
@@ -2,23 +2,17 @@
 
 using namespace Foam;
 
-preciceAdapter::FF::PressureGradient::PressureGradient
-(
+preciceAdapter::FF::PressureGradient::PressureGradient(
     const Foam::fvMesh& mesh,
-    const std::string nameP
-)
-:
-p_(
-    const_cast<volScalarField*>
-    (
-        &mesh.lookupObject<volScalarField>(nameP)
-    )
-)
+    const std::string nameP)
+: p_(
+    const_cast<volScalarField*>(
+        &mesh.lookupObject<volScalarField>(nameP)))
 {
     dataType_ = scalar;
 }
 
-void preciceAdapter::FF::PressureGradient::write(double * buffer, bool meshConnectivity, const unsigned int dim)
+void preciceAdapter::FF::PressureGradient::write(double* buffer, bool meshConnectivity, const unsigned int dim)
 {
     int bufferIndex = 0;
 
@@ -28,25 +22,22 @@ void preciceAdapter::FF::PressureGradient::write(double * buffer, bool meshConne
         int patchID = patchIDs_.at(j);
 
         // Get the pressure gradient boundary patch
-        scalarField gradientPatch
-        =
-        refCast<fixedValueFvPatchScalarField>
-        (
-            p_->boundaryFieldRef()[patchID]
-        ).snGrad();
+        scalarField gradientPatch =
+            refCast<fixedValueFvPatchScalarField>(
+                p_->boundaryFieldRef()[patchID])
+                .snGrad();
 
         // For every cell of the patch
         forAll(gradientPatch, i)
         {
             // Copy the pressure gradient into the buffer
-            buffer[bufferIndex++]
-            =
-            -gradientPatch[i];
+            buffer[bufferIndex++] =
+                -gradientPatch[i];
         }
     }
 }
 
-void preciceAdapter::FF::PressureGradient::read(double * buffer, const unsigned int dim)
+void preciceAdapter::FF::PressureGradient::read(double* buffer, const unsigned int dim)
 {
     int bufferIndex = 0;
 
@@ -56,20 +47,17 @@ void preciceAdapter::FF::PressureGradient::read(double * buffer, const unsigned 
         int patchID = patchIDs_.at(j);
 
         // Get the pressure gradient boundary patch
-        scalarField & gradientPatch
-        =
-        refCast<fixedGradientFvPatchScalarField>
-        (
-            p_->boundaryFieldRef()[patchID]
-        ).gradient();
+        scalarField& gradientPatch =
+            refCast<fixedGradientFvPatchScalarField>(
+                p_->boundaryFieldRef()[patchID])
+                .gradient();
 
         // For every cell of the patch
         forAll(gradientPatch, i)
         {
             // Set the pressure gradient as the buffer value
-            gradientPatch[i]
-            =
-            buffer[bufferIndex++];
+            gradientPatch[i] =
+                buffer[bufferIndex++];
         }
     }
 }

--- a/FF/PressureGradient.H
+++ b/FF/PressureGradient.H
@@ -15,24 +15,20 @@ class PressureGradient : public CouplingDataUser
 {
 
 private:
-
     //- Pressure field
-    Foam::volScalarField * p_;
+    Foam::volScalarField* p_;
 
 public:
-
     //- Constructor
-    PressureGradient
-    (
+    PressureGradient(
         const Foam::fvMesh& mesh,
-        const std::string nameP
-    );
+        const std::string nameP);
 
     //- Write the pressure gradient values into the buffer
-    void write(double * buffer, bool meshConnectivity, const unsigned int dim);
+    void write(double* buffer, bool meshConnectivity, const unsigned int dim);
 
     //- Read the pressure gradient values from the buffer
-    void read(double * buffer, const unsigned int dim);
+    void read(double* buffer, const unsigned int dim);
 };
 
 }

--- a/FF/Velocity.C
+++ b/FF/Velocity.C
@@ -2,23 +2,17 @@
 
 using namespace Foam;
 
-preciceAdapter::FF::Velocity::Velocity
-(
+preciceAdapter::FF::Velocity::Velocity(
     const Foam::fvMesh& mesh,
-    const std::string nameU
-)
-:
-U_(
-    const_cast<volVectorField*>
-    (
-        &mesh.lookupObject<volVectorField>(nameU)
-    )
-)
+    const std::string nameU)
+: U_(
+    const_cast<volVectorField*>(
+        &mesh.lookupObject<volVectorField>(nameU)))
 {
     dataType_ = vector;
 }
 
-void preciceAdapter::FF::Velocity::write(double * buffer, bool meshConnectivity, const unsigned int dim)
+void preciceAdapter::FF::Velocity::write(double* buffer, bool meshConnectivity, const unsigned int dim)
 {
     int bufferIndex = 0;
 
@@ -32,25 +26,22 @@ void preciceAdapter::FF::Velocity::write(double * buffer, bool meshConnectivity,
         {
             // Copy the velocity into the buffer
             // x-dimension
-            buffer[bufferIndex++]
-            =
-            U_->boundaryFieldRef()[patchID][i].x();
+            buffer[bufferIndex++] =
+                U_->boundaryFieldRef()[patchID][i].x();
 
             // y-dimension
-            buffer[bufferIndex++]
-            =
-            U_->boundaryFieldRef()[patchID][i].y();
+            buffer[bufferIndex++] =
+                U_->boundaryFieldRef()[patchID][i].y();
 
-            if(dim == 3)
+            if (dim == 3)
                 // z-dimension
-                buffer[bufferIndex++]
-                =
-                U_->boundaryFieldRef()[patchID][i].z();
+                buffer[bufferIndex++] =
+                    U_->boundaryFieldRef()[patchID][i].z();
         }
     }
 }
 
-void preciceAdapter::FF::Velocity::read(double * buffer, const unsigned int dim)
+void preciceAdapter::FF::Velocity::read(double* buffer, const unsigned int dim)
 {
     int bufferIndex = 0;
 
@@ -64,20 +55,17 @@ void preciceAdapter::FF::Velocity::read(double * buffer, const unsigned int dim)
         {
             // Set the velocity as the buffer value
             // x-dimension
-            U_->boundaryFieldRef()[patchID][i].x()
-            =
-            buffer[bufferIndex++];
+            U_->boundaryFieldRef()[patchID][i].x() =
+                buffer[bufferIndex++];
 
             // y-dimension
-            U_->boundaryFieldRef()[patchID][i].y()
-            =
-            buffer[bufferIndex++];
-
-            if(dim == 3)
-                // z-dimension
-                U_->boundaryFieldRef()[patchID][i].z()
-                =
+            U_->boundaryFieldRef()[patchID][i].y() =
                 buffer[bufferIndex++];
+
+            if (dim == 3)
+                // z-dimension
+                U_->boundaryFieldRef()[patchID][i].z() =
+                    buffer[bufferIndex++];
         }
     }
 }

--- a/FF/Velocity.H
+++ b/FF/Velocity.H
@@ -15,24 +15,20 @@ class Velocity : public CouplingDataUser
 {
 
 private:
-
     //- Velocity field
-    Foam::volVectorField * U_;
+    Foam::volVectorField* U_;
 
 public:
-
     //- Constructor
-    Velocity
-    (
+    Velocity(
         const Foam::fvMesh& mesh,
-        const std::string nameU
-    );
+        const std::string nameU);
 
     //- Write the velocity values into the buffer
-    void write(double * buffer, bool meshConnectivity, const unsigned int dim);
+    void write(double* buffer, bool meshConnectivity, const unsigned int dim);
 
     //- Read the velocity values from the buffer
-    void read(double * buffer, const unsigned int dim);
+    void read(double* buffer, const unsigned int dim);
 };
 
 }

--- a/FF/VelocityGradient.C
+++ b/FF/VelocityGradient.C
@@ -2,23 +2,17 @@
 
 using namespace Foam;
 
-preciceAdapter::FF::VelocityGradient::VelocityGradient
-(
+preciceAdapter::FF::VelocityGradient::VelocityGradient(
     const Foam::fvMesh& mesh,
-    const std::string nameU
-)
-:
-U_(
-    const_cast<volVectorField*>
-    (
-        &mesh.lookupObject<volVectorField>(nameU)
-    )
-)
+    const std::string nameU)
+: U_(
+    const_cast<volVectorField*>(
+        &mesh.lookupObject<volVectorField>(nameU)))
 {
     dataType_ = vector;
 }
 
-void preciceAdapter::FF::VelocityGradient::write(double * buffer, bool meshConnectivity, const unsigned int dim)
+void preciceAdapter::FF::VelocityGradient::write(double* buffer, bool meshConnectivity, const unsigned int dim)
 {
     int bufferIndex = 0;
 
@@ -28,37 +22,32 @@ void preciceAdapter::FF::VelocityGradient::write(double * buffer, bool meshConne
         int patchID = patchIDs_.at(j);
 
         // Get the velocity gradient boundary patch
-        vectorField gradientPatch
-        =
-        refCast<fixedValueFvPatchVectorField>
-        (
-            U_->boundaryFieldRef()[patchID]
-        ).snGrad();
+        vectorField gradientPatch =
+            refCast<fixedValueFvPatchVectorField>(
+                U_->boundaryFieldRef()[patchID])
+                .snGrad();
 
         // For every cell of the patch
         forAll(gradientPatch, i)
         {
             // Copy the velocity into the buffer
             // x-dimension
-            buffer[bufferIndex++]
-            =
-            -gradientPatch[i].x();
+            buffer[bufferIndex++] =
+                -gradientPatch[i].x();
 
             // y-dimension
-            buffer[bufferIndex++]
-            =
-            -gradientPatch[i].y();
+            buffer[bufferIndex++] =
+                -gradientPatch[i].y();
 
-            if(dim == 3)
+            if (dim == 3)
                 // z-dimension
-                buffer[bufferIndex++]
-                =
-                -gradientPatch[i].z();
+                buffer[bufferIndex++] =
+                    -gradientPatch[i].z();
         }
     }
 }
 
-void preciceAdapter::FF::VelocityGradient::read(double * buffer, const unsigned int dim)
+void preciceAdapter::FF::VelocityGradient::read(double* buffer, const unsigned int dim)
 {
     int bufferIndex = 0;
 
@@ -68,32 +57,27 @@ void preciceAdapter::FF::VelocityGradient::read(double * buffer, const unsigned 
         int patchID = patchIDs_.at(j);
 
         // Get the velocity gradient boundary patch
-        vectorField & gradientPatch
-        =
-        refCast<fixedGradientFvPatchVectorField>
-        (
-            U_->boundaryFieldRef()[patchID]
-        ).gradient();
+        vectorField& gradientPatch =
+            refCast<fixedGradientFvPatchVectorField>(
+                U_->boundaryFieldRef()[patchID])
+                .gradient();
 
         // For every cell of the patch
         forAll(gradientPatch, i)
         {
             // Set the velocity as the buffer value
             // x-dimension
-            gradientPatch[i].x()
-            =
-            buffer[bufferIndex++];
+            gradientPatch[i].x() =
+                buffer[bufferIndex++];
 
             // y-dimension
-            gradientPatch[i].y()
-            =
-            buffer[bufferIndex++];
-
-            if(dim == 3)
-                // z-dimension
-                gradientPatch[i].z()
-                =
+            gradientPatch[i].y() =
                 buffer[bufferIndex++];
+
+            if (dim == 3)
+                // z-dimension
+                gradientPatch[i].z() =
+                    buffer[bufferIndex++];
         }
     }
 }

--- a/FF/VelocityGradient.H
+++ b/FF/VelocityGradient.H
@@ -15,24 +15,20 @@ class VelocityGradient : public CouplingDataUser
 {
 
 private:
-
     //- Velocity field
-    Foam::volVectorField * U_;
+    Foam::volVectorField* U_;
 
 public:
-
     //- Constructor
-    VelocityGradient
-    (
+    VelocityGradient(
         const Foam::fvMesh& mesh,
-        const std::string nameU
-    );
+        const std::string nameU);
 
     //- Write the velocity gradient values into the buffer
-    void write(double * buffer, bool meshConnectivity, const unsigned int dim);
+    void write(double* buffer, bool meshConnectivity, const unsigned int dim);
 
     //- Read the velocity gradient values from the buffer
-    void read(double * buffer, const unsigned int dim);
+    void read(double* buffer, const unsigned int dim);
 };
 
 }

--- a/FSI/Displacement.C
+++ b/FSI/Displacement.C
@@ -3,16 +3,16 @@
 using namespace Foam;
 
 preciceAdapter::FSI::Displacement::Displacement(
-    const Foam::fvMesh &mesh,
-    const std::string   namePointDisplacement,
-    const std::string   nameCellDisplacement)
-    : pointDisplacement_(
-          const_cast<pointVectorField *>(
-              &mesh.lookupObject<pointVectorField>(namePointDisplacement))),
-      cellDisplacement_(
-          const_cast<volVectorField *>(
-              &mesh.lookupObject<volVectorField>(nameCellDisplacement))),
-      mesh_(mesh)
+    const Foam::fvMesh& mesh,
+    const std::string namePointDisplacement,
+    const std::string nameCellDisplacement)
+: pointDisplacement_(
+    const_cast<pointVectorField*>(
+        &mesh.lookupObject<pointVectorField>(namePointDisplacement))),
+  cellDisplacement_(
+      const_cast<volVectorField*>(
+          &mesh.lookupObject<volVectorField>(nameCellDisplacement))),
+  mesh_(mesh)
 {
     dataType_ = vector;
 }
@@ -21,18 +21,18 @@ preciceAdapter::FSI::Displacement::Displacement(
 // defined later. Hence, we call this method after the CouplingDaaUser has been configured
 void preciceAdapter::FSI::Displacement::initialize()
 {
-  // Initialize appropriate objects for each interface patch, namely the volField and the interpolation object
-  // this is only necessary for face based FSI
-  if (this->locationsType_ == "faceCenters" || this->locationsType_ == "faceCentres")
-    for (unsigned int j = 0; j < patchIDs_.size(); ++j) {
-      const unsigned int patchID = patchIDs_.at(j);
-      interpolationObjects_.emplace_back(new primitivePatchInterpolation(mesh_.boundaryMesh()[patchID]));
-    }
+    // Initialize appropriate objects for each interface patch, namely the volField and the interpolation object
+    // this is only necessary for face based FSI
+    if (this->locationsType_ == "faceCenters" || this->locationsType_ == "faceCentres")
+        for (unsigned int j = 0; j < patchIDs_.size(); ++j)
+        {
+            const unsigned int patchID = patchIDs_.at(j);
+            interpolationObjects_.emplace_back(new primitivePatchInterpolation(mesh_.boundaryMesh()[patchID]));
+        }
 }
 
 
-
-void preciceAdapter::FSI::Displacement::write(double * buffer, bool meshConnectivity, const unsigned int dim)
+void preciceAdapter::FSI::Displacement::write(double* buffer, bool meshConnectivity, const unsigned int dim)
 {
     /* TODO: Implement
     * We need two nested for-loops for each patch,
@@ -46,43 +46,47 @@ void preciceAdapter::FSI::Displacement::write(double * buffer, bool meshConnecti
 
 
 // return the displacement to use later in the velocity?
-void preciceAdapter::FSI::Displacement::read(double * buffer, const unsigned int dim)
+void preciceAdapter::FSI::Displacement::read(double* buffer, const unsigned int dim)
 {
     for (unsigned int j = 0; j < patchIDs_.size(); j++)
     {
         // Get the ID of the current patch
         const unsigned int patchID = patchIDs_.at(j);
 
-        if (this->locationsType_ == "faceCenters" || this->locationsType_ == "faceCentres") {
+        if (this->locationsType_ == "faceCenters" || this->locationsType_ == "faceCentres")
+        {
 
-          // the boundaryCellDisplacement is a vector and ordered according to the iterator j
-          // and not according to the patchID
-          // First, copy the buffer data into the center based vectorFields on each interface patch
-          forAll (cellDisplacement_->boundaryField()[patchID], i) {
-            for (unsigned int d = 0; d < dim; ++d)
-              cellDisplacement_->boundaryFieldRef()[patchID][i][d] = buffer[i * dim + d];
-          }
-          // Get a reference to the displacement on the point patch in order to overwrite it
-          vectorField &pointDisplacementFluidPatch(
-              refCast<vectorField>(
-                  pointDisplacement_->boundaryFieldRef()[patchID]));
+            // the boundaryCellDisplacement is a vector and ordered according to the iterator j
+            // and not according to the patchID
+            // First, copy the buffer data into the center based vectorFields on each interface patch
+            forAll(cellDisplacement_->boundaryField()[patchID], i)
+            {
+                for (unsigned int d = 0; d < dim; ++d)
+                    cellDisplacement_->boundaryFieldRef()[patchID][i][d] = buffer[i * dim + d];
+            }
+            // Get a reference to the displacement on the point patch in order to overwrite it
+            vectorField& pointDisplacementFluidPatch(
+                refCast<vectorField>(
+                    pointDisplacement_->boundaryFieldRef()[patchID]));
 
-          // Overwrite the node based patch using the interpolation objects and the cell based vector field
-          // Afterwards, continue as usual
-          pointDisplacementFluidPatch = interpolationObjects_[j]->faceToPointInterpolate(cellDisplacement_->boundaryField()[patchID]);
+            // Overwrite the node based patch using the interpolation objects and the cell based vector field
+            // Afterwards, continue as usual
+            pointDisplacementFluidPatch = interpolationObjects_[j]->faceToPointInterpolate(cellDisplacement_->boundaryField()[patchID]);
+        }
+        else if (this->locationsType_ == "faceNodes")
+        {
 
-        } else if (this->locationsType_ == "faceNodes") {
+            // Get the displacement on the patch
+            fixedValuePointPatchVectorField& pointDisplacementFluidPatch(
+                refCast<fixedValuePointPatchVectorField>(
+                    pointDisplacement_->boundaryFieldRef()[patchID]));
 
-          // Get the displacement on the patch
-          fixedValuePointPatchVectorField &pointDisplacementFluidPatch(
-              refCast<fixedValuePointPatchVectorField>(
-                  pointDisplacement_->boundaryFieldRef()[patchID]));
-
-          // Overwrite the nodes on the interface directly
-          forAll (pointDisplacement_->boundaryFieldRef()[patchID], i) {
-            for (unsigned int d = 0; d < dim; ++d)
-              pointDisplacementFluidPatch[i][d] = buffer[i * dim + d];
-          }
+            // Overwrite the nodes on the interface directly
+            forAll(pointDisplacement_->boundaryFieldRef()[patchID], i)
+            {
+                for (unsigned int d = 0; d < dim; ++d)
+                    pointDisplacementFluidPatch[i][d] = buffer[i * dim + d];
+            }
         }
     }
 }

--- a/FSI/Displacement.H
+++ b/FSI/Displacement.H
@@ -17,33 +17,29 @@ class Displacement : public CouplingDataUser
 {
 
 private:
-
     // Displacement pointVectorField
-    Foam::pointVectorField * pointDisplacement_;
+    Foam::pointVectorField* pointDisplacement_;
 
     // cellDisplacement field
-    Foam::volVectorField *cellDisplacement_;
+    Foam::volVectorField* cellDisplacement_;
 
     const Foam::fvMesh& mesh_;
     // NOTE: this allocation could be avoided in case we directly write to the
     // Needs to be a pointer since the class disables assignment and copy constructors
-    std::vector<const Foam::primitivePatchInterpolation *> interpolationObjects_;
+    std::vector<const Foam::primitivePatchInterpolation*> interpolationObjects_;
 
-  public:
-
+public:
     //- Constructor
-    Displacement
-    (
+    Displacement(
         const Foam::fvMesh& mesh,
         const std::string namePointDisplacement,
-        const std::string nameCellDisplacement
-    );
+        const std::string nameCellDisplacement);
 
     //- Write the displacement values into the buffer
-    void write(double * buffer, bool meshConnectivity, const unsigned int dim);
+    void write(double* buffer, bool meshConnectivity, const unsigned int dim);
 
     //- Read the displacement values from the buffer
-    void read(double * buffer, const unsigned int dim);
+    void read(double* buffer, const unsigned int dim);
 
     //- We need to initialize the cell-based vector and the interpolation object
     // in case we want to use the faceCenter location for the coupling

--- a/FSI/DisplacementDelta.C
+++ b/FSI/DisplacementDelta.C
@@ -3,16 +3,16 @@
 using namespace Foam;
 
 preciceAdapter::FSI::DisplacementDelta::DisplacementDelta(
-    const Foam::fvMesh &mesh,
-    const std::string   namePointDisplacement,
-    const std::string   nameCellDisplacement)
-    : pointDisplacement_(
-          const_cast<pointVectorField *>(
-              &mesh.lookupObject<pointVectorField>(namePointDisplacement))),
-      cellDisplacement_(
-          const_cast<volVectorField *>(
-              &mesh.lookupObject<volVectorField>(nameCellDisplacement))),
-      mesh_(mesh)
+    const Foam::fvMesh& mesh,
+    const std::string namePointDisplacement,
+    const std::string nameCellDisplacement)
+: pointDisplacement_(
+    const_cast<pointVectorField*>(
+        &mesh.lookupObject<pointVectorField>(namePointDisplacement))),
+  cellDisplacement_(
+      const_cast<volVectorField*>(
+          &mesh.lookupObject<volVectorField>(nameCellDisplacement))),
+  mesh_(mesh)
 {
     dataType_ = vector;
 }
@@ -21,18 +21,18 @@ preciceAdapter::FSI::DisplacementDelta::DisplacementDelta(
 // defined later. Hence, we call this method after the CouplingDaaUser has been configured
 void preciceAdapter::FSI::DisplacementDelta::initialize()
 {
-  // Initialize appropriate objects for each interface patch, namely the volField and the interpolation object
-  // this is only necessary for face based FSI
-  if (this->locationsType_ == "faceCenters" || this->locationsType_ == "faceCentres")
-    for (unsigned int j = 0; j < patchIDs_.size(); ++j) {
-      const unsigned int patchID = patchIDs_.at(j);
-      interpolationObjects_.emplace_back(new primitivePatchInterpolation(mesh_.boundaryMesh()[patchID]));
-    }
+    // Initialize appropriate objects for each interface patch, namely the volField and the interpolation object
+    // this is only necessary for face based FSI
+    if (this->locationsType_ == "faceCenters" || this->locationsType_ == "faceCentres")
+        for (unsigned int j = 0; j < patchIDs_.size(); ++j)
+        {
+            const unsigned int patchID = patchIDs_.at(j);
+            interpolationObjects_.emplace_back(new primitivePatchInterpolation(mesh_.boundaryMesh()[patchID]));
+        }
 }
 
 
-
-void preciceAdapter::FSI::DisplacementDelta::write(double * buffer, bool meshConnectivity, const unsigned int dim)
+void preciceAdapter::FSI::DisplacementDelta::write(double* buffer, bool meshConnectivity, const unsigned int dim)
 {
     /* TODO: Implement
     * We need two nested for-loops for each patch,
@@ -45,45 +45,49 @@ void preciceAdapter::FSI::DisplacementDelta::write(double * buffer, bool meshCon
 }
 
 // return the displacement to use later in the velocity?
-void preciceAdapter::FSI::DisplacementDelta::read(double * buffer, const unsigned int dim)
+void preciceAdapter::FSI::DisplacementDelta::read(double* buffer, const unsigned int dim)
 {
     for (unsigned int j = 0; j < patchIDs_.size(); j++)
     {
         // Get the ID of the current patch
         const unsigned int patchID = patchIDs_.at(j);
 
-        if (this->locationsType_ == "faceCenters" || this->locationsType_ == "faceCentres") {
+        if (this->locationsType_ == "faceCenters" || this->locationsType_ == "faceCentres")
+        {
 
-          // the boundaryCellDisplacement is a vector and ordered according to the iterator j
-          // and not according to the patchID
-          // First, copy the buffer data into the center based vectorFields on each interface patch
-          // For DisplacementDelta, set absolute values here and sum the interpolated values up to the point field
-          // since the temporary field in this class is not reloaded in the implicit coupling
-          forAll (cellDisplacement_->boundaryField()[patchID], i) {
-            for (unsigned int d = 0; d < dim; ++d)
-              cellDisplacement_->boundaryFieldRef()[patchID][i][d] = buffer[i * dim + d];
-          }
-          // Get a reference to the displacement on the point patch in order to overwrite it
-          vectorField &pointDisplacementFluidPatch(
-              refCast<vectorField>(
-                  pointDisplacement_->boundaryFieldRef()[patchID]));
+            // the boundaryCellDisplacement is a vector and ordered according to the iterator j
+            // and not according to the patchID
+            // First, copy the buffer data into the center based vectorFields on each interface patch
+            // For DisplacementDelta, set absolute values here and sum the interpolated values up to the point field
+            // since the temporary field in this class is not reloaded in the implicit coupling
+            forAll(cellDisplacement_->boundaryField()[patchID], i)
+            {
+                for (unsigned int d = 0; d < dim; ++d)
+                    cellDisplacement_->boundaryFieldRef()[patchID][i][d] = buffer[i * dim + d];
+            }
+            // Get a reference to the displacement on the point patch in order to overwrite it
+            vectorField& pointDisplacementFluidPatch(
+                refCast<vectorField>(
+                    pointDisplacement_->boundaryFieldRef()[patchID]));
 
-          // Overwrite the node based patch using the interpolation objects and the cell based vector field
-          // Afterwards, continue as usual
-          pointDisplacementFluidPatch += interpolationObjects_[j]->faceToPointInterpolate(cellDisplacement_->boundaryField()[patchID]);
+            // Overwrite the node based patch using the interpolation objects and the cell based vector field
+            // Afterwards, continue as usual
+            pointDisplacementFluidPatch += interpolationObjects_[j]->faceToPointInterpolate(cellDisplacement_->boundaryField()[patchID]);
+        }
+        else if (this->locationsType_ == "faceNodes")
+        {
 
-        } else if (this->locationsType_ == "faceNodes") {
+            // Get the displacement on the patch
+            fixedValuePointPatchVectorField& pointDisplacementFluidPatch(
+                refCast<fixedValuePointPatchVectorField>(
+                    pointDisplacement_->boundaryFieldRef()[patchID]));
 
-          // Get the displacement on the patch
-          fixedValuePointPatchVectorField &pointDisplacementFluidPatch(
-              refCast<fixedValuePointPatchVectorField>(
-                  pointDisplacement_->boundaryFieldRef()[patchID]));
-
-          // Overwrite the nodes on the interface directly
-          forAll (pointDisplacement_->boundaryFieldRef()[patchID], i) {
-            for (unsigned int d = 0; d < dim; ++d)
-              pointDisplacementFluidPatch[i][d] += buffer[i * dim + d];
-          }
+            // Overwrite the nodes on the interface directly
+            forAll(pointDisplacement_->boundaryFieldRef()[patchID], i)
+            {
+                for (unsigned int d = 0; d < dim; ++d)
+                    pointDisplacementFluidPatch[i][d] += buffer[i * dim + d];
+            }
         }
     }
 }

--- a/FSI/DisplacementDelta.H
+++ b/FSI/DisplacementDelta.H
@@ -17,33 +17,29 @@ class DisplacementDelta : public CouplingDataUser
 {
 
 private:
-
     // Displacement pointVectorField
-    Foam::pointVectorField * pointDisplacement_;
+    Foam::pointVectorField* pointDisplacement_;
 
     // cellDisplacement field
-    Foam::volVectorField *cellDisplacement_;
+    Foam::volVectorField* cellDisplacement_;
 
     const Foam::fvMesh& mesh_;
     // NOTE: this allocation could be avoided in case we directly write to the
     // Needs to be a pointer since the class disables assignment and copy constructors
-    std::vector<const Foam::primitivePatchInterpolation *> interpolationObjects_;
+    std::vector<const Foam::primitivePatchInterpolation*> interpolationObjects_;
 
-  public:
-
+public:
     //- Constructor
-    DisplacementDelta
-    (
+    DisplacementDelta(
         const Foam::fvMesh& mesh,
         const std::string namePointDisplacement,
-        const std::string nameCellDisplacement
-    );
+        const std::string nameCellDisplacement);
 
     //- Write the displacementDelta values into the buffer
-    void write(double * buffer, bool meshConnectivity, const unsigned int dim);
+    void write(double* buffer, bool meshConnectivity, const unsigned int dim);
 
     //- Read the displacementDelta values from the buffer
-    void read(double * buffer, const unsigned int dim);
+    void read(double* buffer, const unsigned int dim);
 
     //- We need to initialize the cell-based vector and the interpolation object
     // in case we want to use the faceCenter location for the coupling

--- a/FSI/FSI.C
+++ b/FSI/FSI.C
@@ -4,15 +4,13 @@
 
 using namespace Foam;
 
-preciceAdapter::FSI::FluidStructureInteraction::FluidStructureInteraction
-(
+preciceAdapter::FSI::FluidStructureInteraction::FluidStructureInteraction(
     const Foam::fvMesh& mesh,
-    const Foam::Time& runTime
-)
-:
-mesh_(mesh),
-runTime_(runTime)
-{}
+    const Foam::Time& runTime)
+: mesh_(mesh),
+  runTime_(runTime)
+{
+}
 
 bool preciceAdapter::FSI::FluidStructureInteraction::configure(const IOdictionary& adapterConfig)
 {
@@ -26,9 +24,7 @@ bool preciceAdapter::FSI::FluidStructureInteraction::configure(const IOdictionar
     // addWriters() and addReaders().
     // Check the solver type and determine it if needed
     if (
-        solverType_.compare("compressible") == 0 ||
-        solverType_.compare("incompressible") == 0
-    )
+        solverType_.compare("compressible") == 0 || solverType_.compare("incompressible") == 0)
     {
         DEBUG(adapterInfo("Known solver type: " + solverType_));
     }
@@ -49,7 +45,7 @@ bool preciceAdapter::FSI::FluidStructureInteraction::configure(const IOdictionar
 bool preciceAdapter::FSI::FluidStructureInteraction::readConfig(const IOdictionary& adapterConfig)
 {
     const dictionary FSIdict = adapterConfig.subOrEmptyDict("FSI");
-  
+
     // Read the solver type (if not specified, it is determined automatically)
     solverType_ = FSIdict.lookupOrDefault<word>("solverType", "");
     DEBUG(adapterInfo("    user-defined solver type : " + solverType_));
@@ -82,21 +78,21 @@ std::string preciceAdapter::FSI::FluidStructureInteraction::determineSolverType(
 
     if (mesh_.foundObject<volScalarField>("p"))
     {
-      volScalarField p_ = mesh_.lookupObject<volScalarField>("p");
+        volScalarField p_ = mesh_.lookupObject<volScalarField>("p");
 
-      if (p_.dimensions() == pressureDimensionsCompressible)
-        solverType = "compressible";
-      else if (p_.dimensions() == pressureDimensionsIncompressible)
-        solverType = "incompressible";
+        if (p_.dimensions() == pressureDimensionsCompressible)
+            solverType = "compressible";
+        else if (p_.dimensions() == pressureDimensionsIncompressible)
+            solverType = "incompressible";
     }
 
     if (solverType == "unknown")
-      adapterInfo("Failed to determine the solver type. "
-                  "Please specify your solver type in the FSI section of the "
-                  "preciceDict. Known solver types for FSI are: "
-                  "incompressible and "
-                  "compressible",
-                  "error");
+        adapterInfo("Failed to determine the solver type. "
+                    "Please specify your solver type in the FSI section of the "
+                    "preciceDict. Known solver types for FSI are: "
+                    "incompressible and "
+                    "compressible",
+                    "error");
 
     DEBUG(adapterInfo("Automatically determined solver type : " + solverType));
 
@@ -104,43 +100,37 @@ std::string preciceAdapter::FSI::FluidStructureInteraction::determineSolverType(
 }
 
 
-void preciceAdapter::FSI::FluidStructureInteraction::addWriters(std::string dataName, Interface * interface)
+void preciceAdapter::FSI::FluidStructureInteraction::addWriters(std::string dataName, Interface* interface)
 {
     if (dataName.find("Force") == 0)
-    {        
-            interface->addCouplingDataWriter
-            (
-                dataName,
-                new Force(mesh_, solverType_) /* TODO: Add any other arguments here */
-            );
-            DEBUG(adapterInfo("Added writer: Force."));        
-    }    
+    {
+        interface->addCouplingDataWriter(
+            dataName,
+            new Force(mesh_, solverType_) /* TODO: Add any other arguments here */
+        );
+        DEBUG(adapterInfo("Added writer: Force."));
+    }
     else if (dataName.find("DisplacementDelta") == 0)
     {
-        interface->addCouplingDataWriter
-        (
+        interface->addCouplingDataWriter(
             dataName,
-            new DisplacementDelta(mesh_, namePointDisplacement_, nameCellDisplacement_)
-        );
+            new DisplacementDelta(mesh_, namePointDisplacement_, nameCellDisplacement_));
         DEBUG(adapterInfo("Added writer: DisplacementDelta."));
     }
     else if (dataName.find("Displacement") == 0)
     {
-        interface->addCouplingDataWriter
-        (
+        interface->addCouplingDataWriter(
             dataName,
-            new Displacement(mesh_, namePointDisplacement_, nameCellDisplacement_)
-        );
+            new Displacement(mesh_, namePointDisplacement_, nameCellDisplacement_));
         DEBUG(adapterInfo("Added writer: Displacement."));
     }
-    else if(dataName.find("Stress") == 0)
+    else if (dataName.find("Stress") == 0)
     {
-      interface->addCouplingDataWriter
-          (
-              dataName,
-              new Stress(mesh_, solverType_) /* TODO: Add any other arguments here */
-              );
-      DEBUG(adapterInfo("Added writer: Stress."));
+        interface->addCouplingDataWriter(
+            dataName,
+            new Stress(mesh_, solverType_) /* TODO: Add any other arguments here */
+        );
+        DEBUG(adapterInfo("Added writer: Stress."));
     }
 
     // NOTE: If you want to couple another variable, you need
@@ -150,12 +140,11 @@ void preciceAdapter::FSI::FluidStructureInteraction::addWriters(std::string data
     // the one provided in the adapter's configuration file.
 }
 
-void preciceAdapter::FSI::FluidStructureInteraction::addReaders(std::string dataName, Interface * interface)
+void preciceAdapter::FSI::FluidStructureInteraction::addReaders(std::string dataName, Interface* interface)
 {
     if (dataName.find("Force") == 0)
     {
-        interface->addCouplingDataReader
-        (
+        interface->addCouplingDataReader(
             dataName,
             new Force(mesh_, solverType_) /* TODO: Add any other arguments here */
         );
@@ -163,30 +152,25 @@ void preciceAdapter::FSI::FluidStructureInteraction::addReaders(std::string data
     }
     else if (dataName.find("DisplacementDelta") == 0)
     {
-        interface->addCouplingDataReader
-        (
+        interface->addCouplingDataReader(
             dataName,
-            new DisplacementDelta(mesh_, namePointDisplacement_, nameCellDisplacement_)
-        );
+            new DisplacementDelta(mesh_, namePointDisplacement_, nameCellDisplacement_));
         DEBUG(adapterInfo("Added reader: DisplacementDelta."));
     }
     else if (dataName.find("Displacement") == 0)
     {
-        interface->addCouplingDataReader
-        (
+        interface->addCouplingDataReader(
             dataName,
-            new Displacement(mesh_, namePointDisplacement_, nameCellDisplacement_)
-        );
+            new Displacement(mesh_, namePointDisplacement_, nameCellDisplacement_));
         DEBUG(adapterInfo("Added reader: Displacement."));
     }
-    else if(dataName.find("Stress") == 0)
+    else if (dataName.find("Stress") == 0)
     {
-      interface->addCouplingDataReader
-          (
-              dataName,
-              new Stress(mesh_, solverType_) /* TODO: Add any other arguments here */
-              );
-      DEBUG(adapterInfo("Added reader: Stress."));
+        interface->addCouplingDataReader(
+            dataName,
+            new Stress(mesh_, solverType_) /* TODO: Add any other arguments here */
+        );
+        DEBUG(adapterInfo("Added reader: Stress."));
     }
 
     // NOTE: If you want to couple another variable, you need

--- a/FSI/FSI.H
+++ b/FSI/FSI.H
@@ -19,16 +19,15 @@ class FluidStructureInteraction
 {
 
 protected:
-
     //- OpenFOAM fvMesh object
     const Foam::fvMesh& mesh_;
 
     //- OpenFOAM Time object (we need to access the timestep to compute the pointMotionU)
     const Foam::Time& runTime_;
-    
+
     //- Solver type
     std::string solverType_ = "none";
-    
+
     //- Name of the pointDisplacement field
     std::string namePointDisplacement_ = "pointDisplacement";
 
@@ -42,7 +41,6 @@ protected:
     */
 
 protected:
-    
     //- Determine the solver type
     std::string determineSolverType();
 
@@ -50,7 +48,6 @@ protected:
     bool readConfig(const IOdictionary& adapterConfig);
 
 public:
-
     //- Constructor
     //  We need also the runTime to access the timeName and the deltaT
     FluidStructureInteraction(const Foam::fvMesh& mesh, const Foam::Time& runTime);
@@ -59,10 +56,10 @@ public:
     bool configure(const IOdictionary& adapterConfig);
 
     //- Add coupling data writers
-    void addWriters(std::string dataName, Interface * interface);
+    void addWriters(std::string dataName, Interface* interface);
 
     //- Add coupling data readers
-    void addReaders(std::string dataName, Interface * interface);
+    void addReaders(std::string dataName, Interface* interface);
 };
 
 }

--- a/FSI/Force.C
+++ b/FSI/Force.C
@@ -2,48 +2,39 @@
 
 using namespace Foam;
 
-preciceAdapter::FSI::Force::Force
-(
+preciceAdapter::FSI::Force::Force(
     const Foam::fvMesh& mesh,
-    const std::string solverType
-)
-:
-ForceBase(mesh,solverType)
+    const std::string solverType)
+: ForceBase(mesh, solverType)
 {
-    Force_ = new volVectorField
-    (
-        IOobject
-        (
+    Force_ = new volVectorField(
+        IOobject(
             "Force",
             mesh_.time().timeName(),
             mesh,
             IOobject::NO_READ,
-            IOobject::AUTO_WRITE
-        ),
+            IOobject::AUTO_WRITE),
         mesh,
-        dimensionedVector
-        (
+        dimensionedVector(
             "fdim",
-            dimensionSet(1,1,-2,0,0,0,0),
-            Foam::vector::zero
-        )
-    );
+            dimensionSet(1, 1, -2, 0, 0, 0, 0),
+            Foam::vector::zero));
 }
 
-void preciceAdapter::FSI::Force::write(double * buffer, bool meshConnectivity, const unsigned int dim)
+void preciceAdapter::FSI::Force::write(double* buffer, bool meshConnectivity, const unsigned int dim)
 {
-  this->writeToBuffer(buffer, *Force_, dim);
+    this->writeToBuffer(buffer, *Force_, dim);
 }
 
-void preciceAdapter::FSI::Force::read(double * buffer, const unsigned int dim)
+void preciceAdapter::FSI::Force::read(double* buffer, const unsigned int dim)
 {
     this->readFromBuffer(buffer);
 }
 
 vectorField preciceAdapter::FSI::Force::getFaceVectors(const unsigned int patchID) const
 {
-  // Normal vectors multiplied by face area
-  return mesh_.boundary()[patchID].Sf();
+    // Normal vectors multiplied by face area
+    return mesh_.boundary()[patchID].Sf();
 }
 
 preciceAdapter::FSI::Force::~Force()

--- a/FSI/Force.H
+++ b/FSI/Force.H
@@ -12,24 +12,20 @@ namespace FSI
 class Force : public ForceBase
 {
 private:
-
     //- Force field
-    Foam::volVectorField * Force_;
+    Foam::volVectorField* Force_;
 
 public:
-
     //- Constructor
-    Force
-    (
+    Force(
         const Foam::fvMesh& mesh,
-        const std::string solverType
-    );
+        const std::string solverType);
 
     //- Write the forces values into the buffer
-    void write(double * buffer, bool meshConnectivity, const unsigned int dim);
+    void write(double* buffer, bool meshConnectivity, const unsigned int dim);
 
     //- Read the forces values from the buffer
-    void read(double * buffer, const unsigned int dim);
+    void read(double* buffer, const unsigned int dim);
 
     //- Returns the normal vectors multiplied by the face area
     Foam::vectorField getFaceVectors(const unsigned int patchID) const override;

--- a/FSI/ForceBase.H
+++ b/FSI/ForceBase.H
@@ -34,19 +34,16 @@ protected:
     const std::string solverType_;
 
 public:
-
     //- Constructor
-    ForceBase
-    (
+    ForceBase(
         const Foam::fvMesh& mesh,
-        const std::string solverType
-    );
+        const std::string solverType);
 
-    void writeToBuffer(double *                                  buffer,
-                       Foam::volVectorField &                    forceField,
-                       const unsigned int                        dim) const;
+    void writeToBuffer(double* buffer,
+                       Foam::volVectorField& forceField,
+                       const unsigned int dim) const;
 
-    void readFromBuffer(double *buffer) const;
+    void readFromBuffer(double* buffer) const;
 
     virtual Foam::vectorField getFaceVectors(const unsigned int patchID) const = 0;
 };

--- a/FSI/Stress.C
+++ b/FSI/Stress.C
@@ -2,40 +2,31 @@
 
 using namespace Foam;
 
-preciceAdapter::FSI::Stress::Stress
-(
+preciceAdapter::FSI::Stress::Stress(
     const Foam::fvMesh& mesh,
-    const std::string solverType
-)
-:
-ForceBase(mesh,solverType)
+    const std::string solverType)
+: ForceBase(mesh, solverType)
 {
-    Stress_ = new volVectorField
-    (
-        IOobject
-        (
+    Stress_ = new volVectorField(
+        IOobject(
             "Stress",
             mesh_.time().timeName(),
             mesh,
             IOobject::NO_READ,
-            IOobject::AUTO_WRITE
-        ),
+            IOobject::AUTO_WRITE),
         mesh,
-        dimensionedVector
-        (
+        dimensionedVector(
             "pdim",
-            dimensionSet(1,-1,-2,0,0,0,0),
-            Foam::vector::zero
-        )
-    );
+            dimensionSet(1, -1, -2, 0, 0, 0, 0),
+            Foam::vector::zero));
 }
 
-void preciceAdapter::FSI::Stress::write(double * buffer, bool meshConnectivity, const unsigned int dim)
+void preciceAdapter::FSI::Stress::write(double* buffer, bool meshConnectivity, const unsigned int dim)
 {
-  this->writeToBuffer(buffer, *Stress_, dim);
+    this->writeToBuffer(buffer, *Stress_, dim);
 }
 
-void preciceAdapter::FSI::Stress::read(double * buffer, const unsigned int dim)
+void preciceAdapter::FSI::Stress::read(double* buffer, const unsigned int dim)
 {
     this->readFromBuffer(buffer);
 }

--- a/FSI/Stress.H
+++ b/FSI/Stress.H
@@ -13,26 +13,24 @@ namespace FSI
 // cell face. Thus, a consistent quantity. Calculation concept has been copied
 // from the force module, but the scaled version here is commonly used in FEM
 // applications.
-class Stress : public ForceBase {
+class Stress : public ForceBase
+{
 
 private:
     //- Stress field
-    Foam::volVectorField * Stress_;
+    Foam::volVectorField* Stress_;
 
 public:
-
     //- Constructor
-    Stress
-    (
-     const Foam::fvMesh& mesh,
-     const std::string solverType
-    );
+    Stress(
+        const Foam::fvMesh& mesh,
+        const std::string solverType);
 
     //- Write the stress values into the buffer
-    void write(double * buffer, bool meshConnectivity, const unsigned int dim);
+    void write(double* buffer, bool meshConnectivity, const unsigned int dim);
 
     //- Read the stress values from the buffer
-    void read(double * buffer, const unsigned int dim);
+    void read(double* buffer, const unsigned int dim);
 
     //- Returns the face normal vectors (no multiplication by area)
     Foam::vectorField getFaceVectors(const unsigned int patchID) const override;

--- a/Interface.H
+++ b/Interface.H
@@ -14,9 +14,8 @@ namespace preciceAdapter
 class Interface
 {
 protected:
-
     //- preCICE solver interface
-    precice::SolverInterface & precice_;
+    precice::SolverInterface& precice_;
 
     //- Mesh name used in the preCICE configuration
     std::string meshName_;
@@ -37,10 +36,10 @@ protected:
     int numDataLocations_ = 0;
 
     //- Vertex IDs assigned by preCICE
-    int * vertexIDs_;
+    int* vertexIDs_;
 
     //- Buffer for the coupling data
-    double * dataBuffer_;
+    double* dataBuffer_;
 
     //- Vector of CouplingDataReaders
     std::vector<CouplingDataUser*> couplingDataReaders_;
@@ -59,32 +58,25 @@ protected:
     void configureMesh(const Foam::fvMesh& mesh);
 
 public:
-
     //- Constructor
-    Interface
-    (
-        precice::SolverInterface & precice,
+    Interface(
+        precice::SolverInterface& precice,
         const Foam::fvMesh& mesh,
         std::string meshName,
         std::string locationsType,
         std::vector<std::string> patchNames,
-        bool meshConnectivity
-    );
+        bool meshConnectivity);
 
     //- Add a CouplingDataUser to read data from the interface
-    void addCouplingDataReader
-    (
+    void addCouplingDataReader(
         std::string dataName,
-        CouplingDataUser * couplingDataReader
-    );
+        CouplingDataUser* couplingDataReader);
 
 
     //- Add a CouplingDataUser to write data on the interface
-    void addCouplingDataWriter
-    (
+    void addCouplingDataWriter(
         std::string dataName,
-        CouplingDataUser * couplingDataWriter
-    );
+        CouplingDataUser* couplingDataWriter);
 
     //- Allocate an appropriate buffer for scalar or vector data.
     //  If at least one couplingDataUser has vector data, then
@@ -101,7 +93,6 @@ public:
 
     //- Destructor
     ~Interface();
-
 };
 
 }

--- a/Utilities.C
+++ b/Utilities.C
@@ -15,13 +15,13 @@ void adapterInfo(const std::string message, const std::string level)
     {
         // Produce a warning message with cyan header
         WarningInFunction
-             << "\033[36m" // cyan color
-             << "Warning in the preCICE adapter: "
-             << "\033[0m" // restore color
-             << nl
-             << message.c_str()
-             << nl
-             << nl;
+            << "\033[36m" // cyan color
+            << "Warning in the preCICE adapter: "
+            << "\033[0m" // restore color
+            << nl
+            << message.c_str()
+            << nl
+            << nl;
     }
     else if (level.compare("error") == 0)
     {
@@ -30,13 +30,13 @@ void adapterInfo(const std::string message, const std::string level)
         // It will also exit the simulation, unless it
         // is called inside the functionObject's read().
         FatalErrorInFunction
-             << "\033[31m" // red color
-             << "Error in the preCICE adapter: "
-             << "\033[0m" // restore color
-             << nl
-             << message.c_str()
-             << nl
-             << exit(FatalError);
+            << "\033[31m" // red color
+            << "Error in the preCICE adapter: "
+            << "\033[0m" // restore color
+            << nl
+            << message.c_str()
+            << nl
+            << exit(FatalError);
     }
     else if (level.compare("error-deferred") == 0)
     {
@@ -48,13 +48,13 @@ void adapterInfo(const std::string message, const std::string level)
         // but the user still sees that this is the actual
         // problem. We catch these errors and exit later.
         WarningInFunction
-             << "\033[31m" // red color
-             << "Error (deferred - will exit later) in the preCICE adapter: "
-             << "\033[0m" // restore color
-             << nl
-             << message.c_str()
-             << nl
-             << nl;
+            << "\033[31m" // red color
+            << "Error (deferred - will exit later) in the preCICE adapter: "
+            << "\033[0m" // restore color
+            << nl
+            << message.c_str()
+            << nl
+            << nl;
     }
     else if (level.compare("debug") == 0)
     {

--- a/changelog-entries/173.md
+++ b/changelog-entries/173.md
@@ -1,0 +1,1 @@
+Added a clang-format file, a formatting GitHub action, and formatted the codebase. [#173](https://github.com/precice/openfoam-adapter/pull/173)

--- a/preciceAdapterFunctionObject.C
+++ b/preciceAdapterFunctionObject.C
@@ -35,30 +35,27 @@ namespace Foam
 {
 namespace functionObjects
 {
-    defineTypeNameAndDebug(preciceAdapterFunctionObject, 0);
-    addToRunTimeSelectionTable(functionObject, preciceAdapterFunctionObject, dictionary);
+defineTypeNameAndDebug(preciceAdapterFunctionObject, 0);
+addToRunTimeSelectionTable(functionObject, preciceAdapterFunctionObject, dictionary);
 }
 }
 
 
 // * * * * * * * * * * * * * * * * Constructors  * * * * * * * * * * * * * * //
 
-Foam::functionObjects::preciceAdapterFunctionObject::preciceAdapterFunctionObject
-(
+Foam::functionObjects::preciceAdapterFunctionObject::preciceAdapterFunctionObject(
     const word& name,
     const Time& runTime,
-    const dictionary& dict
-)
-:
-    fvMeshFunctionObject(name, runTime, dict),
-    adapter_(runTime, mesh_)
+    const dictionary& dict)
+: fvMeshFunctionObject(name, runTime, dict),
+  adapter_(runTime, mesh_)
 {
-    #if (defined OPENFOAM_PLUS && (OPENFOAM_PLUS >= 1712) ) || (defined OPENFOAM && (OPENFOAM >= 1806))
-        // Patch for issue #27: warning "MPI was already finalized" while
-        // running in serial. This only affects openfoam.com, while initNull()
-        // does not exist in openfoam.org.
-        UPstream::initNull();
-    #endif
+#if (defined OPENFOAM_PLUS && (OPENFOAM_PLUS >= 1712)) || (defined OPENFOAM && (OPENFOAM >= 1806))
+    // Patch for issue #27: warning "MPI was already finalized" while
+    // running in serial. This only affects openfoam.com, while initNull()
+    // does not exist in openfoam.org.
+    UPstream::initNull();
+#endif
 
     read(dict);
 }

--- a/preciceAdapterFunctionObject.H
+++ b/preciceAdapterFunctionObject.H
@@ -75,38 +75,34 @@ namespace functionObjects
 \*---------------------------------------------------------------------------*/
 
 class preciceAdapterFunctionObject
-:
-    public fvMeshFunctionObject
+: public fvMeshFunctionObject
 {
     // Private data
 
-        //- Adapter's main class instance
-        preciceAdapter::Adapter adapter_;
+    //- Adapter's main class instance
+    preciceAdapter::Adapter adapter_;
 
     // Private Member Functions
 
-        //- Disallow default bitwise copy construct
-        preciceAdapterFunctionObject(const preciceAdapterFunctionObject&);
+    //- Disallow default bitwise copy construct
+    preciceAdapterFunctionObject(const preciceAdapterFunctionObject&);
 
-        //- Disallow default bitwise assignment
-        void operator=(const preciceAdapterFunctionObject&);
+    //- Disallow default bitwise assignment
+    void operator=(const preciceAdapterFunctionObject&);
 
 
 public:
-
     //- Runtime type information
     TypeName("preciceAdapterFunctionObject");
 
 
     // Constructors
 
-        //- Construct from Time and dictionary
-        preciceAdapterFunctionObject
-        (
-            const word& name,
-            const Time& runTime,
-            const dictionary& dict
-        );
+    //- Construct from Time and dictionary
+    preciceAdapterFunctionObject(
+        const word& name,
+        const Time& runTime,
+        const dictionary& dict);
 
 
     //- Destructor
@@ -115,20 +111,20 @@ public:
 
     // Member Functions
 
-        //- Read the preciceAdapterFunctionObject data
-        virtual bool read(const dictionary&);
+    //- Read the preciceAdapterFunctionObject data
+    virtual bool read(const dictionary&);
 
-        //- Execute in the beginning of each time-loop, after the first one
-        virtual bool execute();
+    //- Execute in the beginning of each time-loop, after the first one
+    virtual bool execute();
 
-        //- Execute at the final time-loop, after execute()
-        virtual bool end();
+    //- Execute at the final time-loop, after execute()
+    virtual bool end();
 
-        //- Write the preciceAdapterFunctionObject
-        virtual bool write();
+    //- Write the preciceAdapterFunctionObject
+    virtual bool write();
 
-        //- Called at the end of Time::adjustDeltaT() if adjustTime is true
-        virtual bool adjustTimeStep();
+    //- Called at the end of Time::adjustDeltaT() if adjustTime is true
+    virtual bool adjustTimeStep();
 
     /*
         // NOTE: If you add a new module that needs to execute methods

--- a/tools/format-code.sh
+++ b/tools/format-code.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+# Format all C++ files with clang-format
+find . \( -iname "*.H" -o -iname "*.C" \) -exec clang-format -i {} \;


### PR DESCRIPTION
This pull request:
- adds a configuration file for clang-format 11, with some commented-out options for clang-format 12. Since the OpenFOAM style is quite unique, I wanted to have as many options available as possible. Closes #126.
- reformats the codebase with the included `.clang-format`.
- adds the GitHub action [clang-format-check](https://github.com/marketplace/actions/clang-format-check).

@DavidSCN could you please have a look into the formatted code and write if you feel comfortable with this style? If you have any ideas on the remaining issues, they would be very welcome!

For anyone from OpenFOAM reading this: we know we have some technical debt here, please don't look too closely into the code. :see_no_evil: We are in the process of fixing many of the open issues, but more feedback is always welcome! :smile: 

While these steps are rather straight-forward, the complicated part is to configure clang-format so that it applies the [OpenFOAM style guide](https://develop.openfoam.com/Development/openfoam/-/wikis/coding/style/style) as closely as possible. The result is not perfect, but I think that it is good enough for us and that it reaches the current limits of [clang-format style options](https://clang.llvm.org/docs/ClangFormatStyleOptions.html) (here [v11](https://releases.llvm.org/11.0.0/tools/clang/docs/ClangFormatStyleOptions.html), [upcoming v13 release notes](https://clang.llvm.org/docs/ReleaseNotes.html#clang-format)).

A very large part of the code stays the same (good!). The following are a few unresolved issues I identified from formatting [this arbitrary sample OpenFOAM file](https://develop.openfoam.com/Development/openfoam/-/blob/master/src/OpenFOAM/algorithms/dynamicIndexedOctree/dynamicIndexedOctree.C):

## Issue 1: Round braces in dedicated lines

Cannot tell clang-format that parentheses should open and close in dedicated lines. If you know any way, please [answer my StackOverflow question 1](https://stackoverflow.com/questions/67244540/can-i-tell-clang-format-to-open-and-close-round-braces-in-new-lines).

```diff
- contents_.append
- (
-     autoPtr<DynamicList<label>>
-     (
-         new DynamicList<label>()
-     )
- );
---
+ contents_.append(
+     autoPtr<DynamicList<label>>(
+         new DynamicList<label>()));
```

**Upside:** IDEs understand that e.g. `append` is a function and colorize it properly.

## Issue 2: Spaces around arithmetic operators.

Cannot tell clang-format that it should not add spaces around arithmetic operators. See also my [StackOverflow question 2](https://stackoverflow.com/questions/67245250/can-i-tell-clang-format-to-not-add-space-around-arithmetic-operators). Both spaces and no-spaces are actually allowed by the guidelines (and I prefer spaces).

```diff
- const point mid(0.5*(min+max));
---
+ const point mid(0.5 * (min + max));
```

**Upside:** Consistent formatting (single rule instead of either), more easily identifiable operands.

## Issue 3: Aligning operations

Blocks with multiple operations are still aligned, but not exactly in the same way:
```diff
-    if
-    (
-        bb.min()[0] >= bb.max()[0]
-     || bb.min()[1] >= bb.max()[1]
-     || bb.min()[2] >= bb.max()[2]
-    )
---
+    if (
+        bb.min()[0] >= bb.max()[0]
+        || bb.min()[1] >= bb.max()[1]
+        || bb.min()[2] >= bb.max()[2])
```

Maybe there is a way to fix the alignment, but I could not succeed. The opening/closing braces in the same lines is again issue 1.

## Issue 4: Space in streams

OpenFOAM always starts `<<` in the fourth column after the start of the indentation level, often leaving no space between the target stream and the operator.

```diff
- Pout<< "    iter:" << i
-     << " hit face:" << faceString(hitFaceID)
---
+ Pout << "    iter:" << i
+      << " hit face:" << faceString(hitFaceID)
```

**Upside:** The added space could make this more readable. It also looks less like fortran fixed format.

## Issue 5: Columns limit

I had to set `ColumnLimit: 0`. If I set it to `80`,  clang-format was formatting things that it shouldn't. I tried tuning the penalties, but I could not succeed. This leads to situations such as the following:

```diff
- nodes_[parentNodeIndex].subNodes_[octantToBeDivided]
-    = nodePlusOctant(sz, octantToBeDivided);
---
+ nodes_[parentNodeIndex].subNodes_[octantToBeDivided] = nodePlusOctant(sz, octantToBeDivided);
```

## Issue 6: Indentation in initializer list

Similarly to issue 1, no dedicated line for `:`:

```diff
- :
-    shapes_(shapes),
-    bb_(bb), 
---
+ : shapes_(shapes),
+   bb_(bb),
```
At least the `:` remains not indented.

## See also

Related upstream issue: https://develop.openfoam.com/Development/openfoam/-/issues/1634.

In the `.clang-format` itself, I include comments on how this relates to the style guide. I can provide more details in the upstream issue.

I started from the default LLVM style and changed each setting manually (they are not so many). The `.clang-format` of [mdolab/dafoam](https://github.com/mdolab/dafoam/blob/master/.clang-format) helped me guess how to fix some issues (especially the `ColumnLimit: 0`, I would never guess that).