### PR TITLE
Replace deprecated lookupType and subDictPtr with get and findDict

### DIFF
--- a/Adapter.C
+++ b/Adapter.C
@@ -37,19 +37,16 @@ bool preciceAdapter::Adapter::configFileRead()
                 IOobject::NO_WRITE));
 
         // Read and display the preCICE configuration file name
-        // NOTE: lookupType<T>("name") is deprecated in openfoam.com since v1812,
-        // which recommends get<T>("name") instead. However, get<T>("name")
-        // is not implemented in openfoam.org at the moment.
-        preciceConfigFilename_ = preciceDict.lookupType<fileName>("preciceConfig"); // We use this deprecated lookupType<>() for backwards compatibility
+        preciceConfigFilename_ = preciceDict.get<fileName>("preciceConfig");
         DEBUG(adapterInfo("  precice-config-file : " + preciceConfigFilename_));
 
         // Read and display the participant name
-        participantName_ = preciceDict.lookupType<word>("participant"); // We use this deprecated lookupType<>() for backwards compatibility
+        participantName_ = preciceDict.get<word>("participant");
         DEBUG(adapterInfo("  participant name    : " + participantName_));
 
         // Read and display the list of modules
         DEBUG(adapterInfo("  modules requested   : "));
-        wordList modules_ = preciceDict.lookupType<wordList>("modules"); // We use this deprecated lookupType<>() for backwards compatibility
+        auto modules_ = preciceDict.get<wordList>("modules");
         for (auto module : modules_)
         {
             DEBUG(adapterInfo("  - " + module + "\n"));
@@ -66,7 +63,7 @@ bool preciceAdapter::Adapter::configFileRead()
         // Every interface is a subdictionary of "interfaces",
         // each with an arbitrary name. Read all of them and create
         // a list (here: pointer) of dictionaries.
-        const dictionary* interfaceDictPtr = preciceDict.subDictPtr("interfaces"); // We use this deprecated subDictPtr for backwards compatibility
+        const auto interfaceDictPtr = preciceDict.findDict("interfaces");
         DEBUG(adapterInfo("  interfaces : "));
 
         // Check if we found any interfaces
@@ -85,7 +82,7 @@ bool preciceAdapter::Adapter::configFileRead()
                     dictionary interfaceDict = interfaceDictEntry.dict();
                     struct InterfaceConfig interfaceConfig;
 
-                    interfaceConfig.meshName = interfaceDict.lookupType<word>("mesh"); // We use this deprecated lookupType<>() for backwards compatibility
+                    interfaceConfig.meshName = interfaceDict.get<word>("mesh");
                     DEBUG(adapterInfo("  - mesh         : " + interfaceConfig.meshName));
 
                     // By default, assume "faceCenters" as locationsType
@@ -106,7 +103,7 @@ bool preciceAdapter::Adapter::configFileRead()
                     DEBUG(adapterInfo("    connectivity : " + std::to_string(interfaceConfig.meshConnectivity)));
 
                     DEBUG(adapterInfo("    patches      : "));
-                    wordList patches = interfaceDict.lookupType<wordList>("patches"); // We use this deprecated lookupType<>() for backwards compatibility
+                    auto patches = interfaceDict.get<wordList>("patches");
                     for (auto patch : patches)
                     {
                         interfaceConfig.patchNames.push_back(patch);
@@ -114,7 +111,7 @@ bool preciceAdapter::Adapter::configFileRead()
                     }
 
                     DEBUG(adapterInfo("    writeData    : "));
-                    wordList writeData = interfaceDict.lookupType<wordList>("writeData"); // We use this deprecated lookupType<>() for backwards compatibility
+                    auto writeData = interfaceDict.get<wordList>("writeData");
                     for (auto writeDatum : writeData)
                     {
                         interfaceConfig.writeData.push_back(writeDatum);
@@ -122,7 +119,7 @@ bool preciceAdapter::Adapter::configFileRead()
                     }
 
                     DEBUG(adapterInfo("    readData     : "));
-                    wordList readData = interfaceDict.lookupType<wordList>("readData"); // We use this deprecated lookupType<>() for backwards compatibility
+                    auto readData = interfaceDict.get<wordList>("readData");
                     for (auto readDatum : readData)
                     {
                         interfaceConfig.readData.push_back(readDatum);

--- a/FSI/ForceBase.C
+++ b/FSI/ForceBase.C
@@ -76,8 +76,7 @@ Foam::tmp<Foam::volScalarField> preciceAdapter::FSI::ForceBase::rho() const
                     IOobject::NO_READ,
                     IOobject::NO_WRITE),
                 mesh_,
-                dimensionedScalar(FSIDict.get<dimensionedScalar>("rho"))
-                ));
+                dimensionedScalar(FSIDict.get<dimensionedScalar>("rho"))));
     }
     else
     {

--- a/FSI/ForceBase.C
+++ b/FSI/ForceBase.C
@@ -76,7 +76,7 @@ Foam::tmp<Foam::volScalarField> preciceAdapter::FSI::ForceBase::rho() const
                     IOobject::NO_READ,
                     IOobject::NO_WRITE),
                 mesh_,
-                dimensionedScalar(FSIDict.lookup("rho")) // We use this deprecated lookup() for backwards compatibility
+                dimensionedScalar(FSIDict.get<dimensionedScalar>("rho"))
                 ));
     }
     else
@@ -109,7 +109,7 @@ Foam::tmp<Foam::volScalarField> preciceAdapter::FSI::ForceBase::mu() const
             const dictionary& FSIDict =
                 mesh_.lookupObject<IOdictionary>("preciceDict").subOrEmptyDict("FSI");
 
-            dimensionedScalar nu(FSIDict.lookup("nu")); // We use this deprecated lookup() for backwards compatibility
+            dimensionedScalar nu(FSIDict.get<dimensionedScalar>("nu"));
 
             return tmp<volScalarField>(
                 new volScalarField(

--- a/docs/openfoam-support.md
+++ b/docs/openfoam-support.md
@@ -23,10 +23,17 @@ As these steps change your `.profile`, you need to log out and in again to make 
 
 OpenFOAM is a project with long history and many forks, of which we try to support as many as possible.
 
-Supported versions:
+We provide version-specific branches and archives for:
 
-- OpenFOAM (openfoam.com): [v1706](https://www.openfoam.com/releases/openfoam-v1706/) - [v2012](https://www.openfoam.com/releases/openfoam-v2012/) (or newer)
-- OpenFOAM (openfoam.org): version [5.x](https://openfoam.org/version/5-0/) without changes. You need different branches for the versions [4.0/4.1](https://github.com/precice/openfoam-adapter/tree/OpenFOAM4), [6](https://github.com/precice/openfoam-adapter/tree/OpenFOAM6), [7](https://github.com/precice/openfoam-adapter/tree/OpenFOAM7), [8 (experimental)](https://github.com/precice/openfoam-adapter/pull/130).
+- OpenCFD / ESI (openfoam.com):
+  - [OpenFOAM v1812-v2012](https://github.com/precice/openfoam-adapter) or newer (main target)
+  - [OpenFOAM v1806 or older](https://github.com/precice/openfoam-adapter/tree/OpenFOAMv1806)
+- OpenFOAM Foundation (openfoam.org):
+  - [OpenFOAM 8](https://github.com/precice/openfoam-adapter/pull/130) (experimental).
+  - [OpenFOAM 7](https://github.com/precice/openfoam-adapter/tree/OpenFOAM7) (experimental).
+  - [OpenFOAM 6](https://github.com/precice/openfoam-adapter/tree/OpenFOAM6) (experimental).
+  - [OpenFOAM 4.0/4.1](https://github.com/precice/openfoam-adapter/tree/OpenFOAM4).
+  - [OpenFOAM 5.x](https://github.com/precice/openfoam-adapter/tree/OpenFOAM5).
 
 Known not supported versions: OpenFOAM v1606+ or older, OpenFOAM 3 or older, foam-extend (any version).
 


### PR DESCRIPTION
Closes #172.

This should work with all ESI versions since ~~v1806~~ (update: since v1812). I want to check building this with that v1806 and maybe v1712 before merging.

Now, building with v2012 gives no warnings! :tada:

@DavidSCN mainly FYI, you may want to have a look at the diff.