### PR TITLE
Disable execute at start for OpenFOAM8

### DIFF
--- a/changelog-entries/180.md
+++ b/changelog-entries/180.md
@@ -1,0 +1,1 @@
+Disabled execute at start for OpenFOAM8 (issue #179)

--- a/changelog-entries/180.md
+++ b/changelog-entries/180.md
@@ -1,1 +1,1 @@
-Disabled execute at start for OpenFOAM8 (issue #179)
+Disabled execute at start for OpenFOAM8 (PR #180, issue #179)

--- a/preciceAdapterFunctionObject.C
+++ b/preciceAdapterFunctionObject.C
@@ -23,6 +23,7 @@ License
 \*---------------------------------------------------------------------------*/
 
 #include "preciceAdapterFunctionObject.H"
+#include "Utilities.H"
 
 // OpenFOAM header files
 #include "Time.H"
@@ -72,6 +73,9 @@ Foam::functionObjects::preciceAdapterFunctionObject::~preciceAdapterFunctionObje
 
 bool Foam::functionObjects::preciceAdapterFunctionObject::read(const dictionary& dict)
 {
+    // We disable executeAtStart explicitly here and don't read the respective entry from the dictionary(fvMeshFunctionObject::read(dict)). Have a look at issue #179 for the rationale.
+    this->executeAtStart_ = false;
+    DEBUG(adapterInfo("Execute at start set to (dictionary input is ignored): " this->executeAtStart()));
     adapter_.configure();
 
     return true;


### PR DESCRIPTION
I cannot run `clang-format` 
```
YAML:22:16: error: invalid boolean
AlignOperands: AlignAfterOperator
               ^~~~~~~~~~~~~~~~~~
Error reading /home/schneidd/precice/openfoam-adapter/.clang-format: Invalid argument
```

and I cannot find the changelog-entries directory. Is the contributor supposed to create it at every time. 
Closes #179 

- <del>[ ] I updated the documentation in `docs/`<del>
- [x] I added a changelog entry in `changelog-entries/` (create directory if missing)
