### PR TITLE
Add volume coupling in Interface class

### DIFF
--- a/182.md
+++ b/182.md
@@ -1,0 +1,40 @@
+# ChangeLog: Volume Coupling for OpenFOAM v2012 adapter PR #182
+
+The PR contains the edits required for doing Volume coupling.
+
+Added `locationsType == "volume"`
+
+To keep this PR simple I did not add the usage of the volume field.
+Another PR can be opened for that, specifically Generic volume scalar field and Generic volume vector field.
+
+This is in regards to issue[ #591](https://precice.discourse.group/t/extending-openfoam-adapter-for-volumetric-coupling/591) opened on Discourse.
+
+## Usage: 
+
+in `Fluid/system/preciceDict`
+
+```
+
+interfaces
+{
+  Interface1
+  {
+    mesh              Fluid-Mesh-PV;
+    patches           ();
+    locations         volume;
+    
+    readData
+    (
+        Volume_field_data_to_read
+    );
+    
+    writeData
+    (
+        Volume_field_data_to_write
+    );
+  };
+};
+
+```
+
+Ofcourse the volume dataFields `Volume_field_data_to_read` and `Volume_field_data_to_write` needs to be added to a module in order to use them.

--- a/182.md
+++ b/182.md
@@ -37,4 +37,4 @@ interfaces
 
 ```
 
-Ofcourse the volume dataFields `Volume_field_data_to_read` and `Volume_field_data_to_write` needs to be added to a module in order to use them.
+Of course the volume dataFields `Volume_field_data_to_read` and `Volume_field_data_to_write` needs to be added to a module in order to use them.

--- a/182.md
+++ b/182.md
@@ -7,7 +7,7 @@ Added `locationsType == "volume"`
 To keep this PR simple I did not add the usage of the volume field.
 Another PR can be opened for that, specifically Generic volume scalar field and Generic volume vector field.
 
-This is in regards to issue[ #591](https://precice.discourse.group/t/extending-openfoam-adapter-for-volumetric-coupling/591) opened on Discourse.
+This is in regards to issue[#591](https://precice.discourse.group/t/extending-openfoam-adapter-for-volumetric-coupling/591) opened on Discourse.
 
 ## Usage: 
 

--- a/182.md
+++ b/182.md
@@ -9,12 +9,11 @@ Another PR can be opened for that, specifically Generic volume scalar field and 
 
 This is in regards to issue[#591](https://precice.discourse.group/t/extending-openfoam-adapter-for-volumetric-coupling/591) opened on Discourse.
 
-## Usage: 
+## Usage
 
 in `Fluid/system/preciceDict`
 
-```
-
+```cpp
 interfaces
 {
   Interface1

--- a/Interface.C
+++ b/Interface.C
@@ -298,7 +298,6 @@ void preciceAdapter::Interface::configureMesh(const fvMesh& mesh)
             {
                 vertices[verticesIndex++] = CellCenters[i].z();
             }
-
         }
 
         // Get the locations of the mesh vertices (here: face centers)
@@ -324,7 +323,7 @@ void preciceAdapter::Interface::configureMesh(const fvMesh& mesh)
         // Pass the mesh vertices information to preCICE
         precice_.setMeshVertices(meshID_, numDataLocations_, vertices, vertexIDs_);
     }
-else
+    else
     {
         FatalErrorInFunction
             << "ERROR: interface points location type "

--- a/Interface.C
+++ b/Interface.C
@@ -272,7 +272,7 @@ void preciceAdapter::Interface::configureMesh(const fvMesh& mesh)
         for (uint j = 0; j < patchIDs_.size(); j++)
         {
             numDataLocations_ +=
-                    mesh.boundaryMesh()[patchIDs_.at(j)].faceCentres().size();
+                mesh.boundaryMesh()[patchIDs_.at(j)].faceCentres().size();
         }
         DEBUG(adapterInfo("Number of coupling volumes: " + std::to_string(numDataLocations_)));
 

--- a/Interface.C
+++ b/Interface.C
@@ -317,7 +317,7 @@ void preciceAdapter::Interface::configureMesh(const fvMesh& mesh)
         // Pass the mesh vertices information to preCICE
         precice_.setMeshVertices(meshID_, numDataLocations_, vertices, vertexIDs_);
     }
-    if (!(locationsType_ == "faceNodes" || locationsType_ == "faceCenters" || locationsType_ == "faceCentres" || locationsType_ == "volume"))
+else
     {
         FatalErrorInFunction
             << "ERROR: interface points location type "

--- a/Interface.C
+++ b/Interface.C
@@ -314,7 +314,10 @@ void preciceAdapter::Interface::configureMesh(const fvMesh& mesh)
             {
                 vertices[verticesIndex++] = faceCenters[i].x();
                 vertices[verticesIndex++] = faceCenters[i].y();
-                vertices[verticesIndex++] = faceCenters[i].z();
+                if (dim_ == 3)
+                {
+                    vertices[verticesIndex++] = faceCenters[i].z();
+                }
             }
         }
 

--- a/Interface.C
+++ b/Interface.C
@@ -274,7 +274,7 @@ void preciceAdapter::Interface::configureMesh(const fvMesh& mesh)
             numDataLocations_ +=
                     mesh.boundaryMesh()[patchIDs_.at(j)].faceCentres().size();
         }
-        DEBUG(adapterInfo("Number of face centres: " + std::to_string(numDataLocations_)));
+        DEBUG(adapterInfo("Number of coupling volumes: " + std::to_string(numDataLocations_)));
 
         // Array of the mesh vertices.
         // One mesh is used for all the patches and each vertex has 3D coordinates.

--- a/Interface.C
+++ b/Interface.C
@@ -278,7 +278,7 @@ void preciceAdapter::Interface::configureMesh(const fvMesh& mesh)
 
         // Array of the mesh vertices.
         // One mesh is used for all the patches and each vertex has 3D coordinates.
-        double vertices[3 * numDataLocations_];
+        double vertices[dim_ * numDataLocations_];
 
         // Array of the indices of the mesh vertices.
         // Each vertex has one index, but three coordinates.
@@ -294,7 +294,10 @@ void preciceAdapter::Interface::configureMesh(const fvMesh& mesh)
         {
             vertices[verticesIndex++] = CellCenters[i].x();
             vertices[verticesIndex++] = CellCenters[i].y();
-            vertices[verticesIndex++] = CellCenters[i].z();
+            if (dim_ == 2)
+            {
+                vertices[verticesIndex++] = CellCenters[i].z();
+            }
         }
 
         // Get the locations of the mesh vertices (here: face centers)

--- a/Interface.C
+++ b/Interface.C
@@ -294,10 +294,11 @@ void preciceAdapter::Interface::configureMesh(const fvMesh& mesh)
         {
             vertices[verticesIndex++] = CellCenters[i].x();
             vertices[verticesIndex++] = CellCenters[i].y();
-            if (dim_ == 2)
+            if (dim_ == 3)
             {
                 vertices[verticesIndex++] = CellCenters[i].z();
             }
+
         }
 
         // Get the locations of the mesh vertices (here: face centers)

--- a/Interface.C
+++ b/Interface.C
@@ -262,7 +262,7 @@ void preciceAdapter::Interface::configureMesh(const fvMesh& mesh)
         // did not work properly
         //
         // the module for volume coupling considers the mesh points in the volume and
-        // on the patches in order to take the boundary conditions into account
+        // on the boundary patches in order to take the boundary conditions into account
 
         // get the number (volume centered) mesh points in the volume
         numDataLocations_ = mesh.C().size();

--- a/Interface.C
+++ b/Interface.C
@@ -288,7 +288,7 @@ void preciceAdapter::Interface::configureMesh(const fvMesh& mesh)
         int verticesIndex = 0;
 
         // Get the locations of the volume centered mesh vertices
-        const vectorField & CellCenters = mesh.C();
+        const vectorField& CellCenters = mesh.C();
 
         for (int i = 0; i < CellCenters.size(); i++)
         {
@@ -306,8 +306,8 @@ void preciceAdapter::Interface::configureMesh(const fvMesh& mesh)
         for (uint j = 0; j < patchIDs_.size(); j++)
         {
             // Get the face centers of the current patch
-            const vectorField & faceCenters =
-                    mesh.boundaryMesh()[patchIDs_.at(j)].faceCentres();
+            const vectorField faceCenters =
+                mesh.boundaryMesh()[patchIDs_.at(j)].faceCentres();
 
             // Assign the (x,y,z) locations to the vertices
             for (int i = 0; i < faceCenters.size(); i++)


### PR DESCRIPTION
The PR contains the edits required for doing Volume coupling.

To keep this PR simple I did not add the usage of the volume field.
Another PR can be opened for that, specifically Generic volume scalar field and Generic volume vector field.

This is in regards to issue[ #591](https://precice.discourse.group/t/extending-openfoam-adapter-for-volumetric-coupling/591) opened on Discourse.

TODO list:

- [x] add changelog md
