### PR TITLE
Fixed misplaced data reading in advance function

### DIFF
--- a/Adapter.C
+++ b/Adapter.C
@@ -395,9 +395,6 @@ void preciceAdapter::Adapter::execute()
         fulfilledReadCheckpoint();
     }
 
-    // Read the received coupling data from the buffer
-    readCouplingData();
-
     // Adjust the timestep, if it is fixed
     if (!adjustableTimestep_)
     {
@@ -429,6 +426,9 @@ void preciceAdapter::Adapter::execute()
             const_cast<Time&>(runTime_).writeNow();
         }
     }
+
+    // Read the received coupling data from the buffer
+    readCouplingData();
 
     // If the coupling is not going to continue, tear down everything
     // and stop the simulation.

--- a/changelog-entries/188.md
+++ b/changelog-entries/188.md
@@ -1,0 +1,1 @@
+- Fixed the misplaced data reading in the adapter 'advance' function [#188](https://github.com/precice/openfoam-adapter/pull/188)


### PR DESCRIPTION
In the final implicit coupling time-step, we first read new coupling data and afterwards write the result files to the system. This leads of course to inconsistent result files, as we store now the converged solution of the past time  step + the coupling data of the first iteration during the new time-step, which might look like this:

![](https://user-images.githubusercontent.com/33414590/125451118-e57a63c0-46b3-4048-a474-4eb23f68eab9.png)
 
Note also the inconsistency between the gradients/flux and the coupling variable `T`.  Not completely sure about the reason but the misbehavior is more obvious in case OpenFOAM is the `second` participant (as opposed to most of our tutorials).

We also stored the new coupling data within the new checkpoint, which is (@uekerman corrects me otherwise) wrong (inconsistent). The error is hidden though since we override the coupling data again after reloading the checkpoint.

- [x] I added a changelog entry in `changelog-entries/` (create directory if missing)
