### PR TITLE
Remove explicit casting of boundary conditions

### DIFF
--- a/CHT/HeatFlux.C
+++ b/CHT/HeatFlux.C
@@ -28,8 +28,7 @@ void preciceAdapter::CHT::HeatFlux::write(double* buffer, bool meshConnectivity,
         int patchID = patchIDs_.at(j);
 
         const scalarField gradientPatch(
-            refCast<const fixedValueFvPatchScalarField>(
-                T_->boundaryField()[patchID])
+            (T_->boundaryField()[patchID])
                 .snGrad());
 
         // Extract the effective conductivity on the patch

--- a/FF/PressureGradient.C
+++ b/FF/PressureGradient.C
@@ -22,10 +22,8 @@ void preciceAdapter::FF::PressureGradient::write(double* buffer, bool meshConnec
         int patchID = patchIDs_.at(j);
 
         // Get the pressure gradient boundary patch
-        scalarField gradientPatch(
-            refCast<fixedValueFvPatchScalarField>(
-                p_->boundaryFieldRef()[patchID])
-                .snGrad());
+        const scalarField gradientPatch((p_->boundaryFieldRef()[patchID])
+                                            .snGrad());
 
         // For every cell of the patch
         forAll(gradientPatch, i)

--- a/FF/VelocityGradient.C
+++ b/FF/VelocityGradient.C
@@ -22,10 +22,8 @@ void preciceAdapter::FF::VelocityGradient::write(double* buffer, bool meshConnec
         int patchID = patchIDs_.at(j);
 
         // Get the velocity gradient boundary patch
-        vectorField gradientPatch(
-            refCast<fixedValueFvPatchVectorField>(
-                U_->boundaryFieldRef()[patchID])
-                .snGrad());
+        vectorField gradientPatch((U_->boundaryFieldRef()[patchID])
+                                      .snGrad());
 
         // For every cell of the patch
         forAll(gradientPatch, i)

--- a/changelog-entries/195.md
+++ b/changelog-entries/195.md
@@ -1,0 +1,1 @@
+- Remove explicit casting of boundary conditions in the adapter's write function in order to allow more boundary conditions to be compatible with the adapter (e.g. groovyBC) [#195](https://github.com/precice/openfoam-adapter/pull/195)


### PR DESCRIPTION
when writing gradients as this rises the opportunity to select other boundary conditions at the interface such as groovyBCs.

<del> - [ ] I updated the documentation in `docs/` <del/>
- [x] I added a changelog entry in `changelog-entries/` (create directory if missing)
