### PR TITLE
Remove last else-cases in FF and CHT

### DIFF
--- a/Adapter.C
+++ b/Adapter.C
@@ -278,8 +278,8 @@ void preciceAdapter::Adapter::configure()
                 }
                 else if (inModules > 1)
                 {
-                    adapterInfo("It looks like more than one modules can write " + dataName
-                                    + "and I don't know how to choose. Try disabling one of the modules.",
+                    adapterInfo("It looks like more than one modules can write \"" + dataName
+                                    + "\" and I don't know how to choose. Try disabling one of the modules.",
                                 "error-deferred");
                 }
 

--- a/Adapter.C
+++ b/Adapter.C
@@ -304,8 +304,8 @@ void preciceAdapter::Adapter::configure()
 
                 if (inModules == 0)
                 {
-                    adapterInfo("I don't know how to read " + dataName
-                                    + ". Maybe this is a typo or maybe you need to enable some adapter module?",
+                    adapterInfo("I don't know how to read \"" + dataName
+                                    + "\". Maybe this is a typo or maybe you need to enable some adapter module?",
                                 "error-deferred");
                 }
                 else if (inModules > 1)

--- a/Adapter.C
+++ b/Adapter.C
@@ -262,13 +262,22 @@ void preciceAdapter::Adapter::configure()
                 unsigned int inModules = 0;
 
                 // Add CHT-related coupling data writers
-                if (CHTenabled_ && CHT_->addWriters(dataName, interface)) inModules++;
+                if (CHTenabled_ && CHT_->addWriters(dataName, interface)) 
+                {
+                    inModules++;
+                }
 
                 // Add FSI-related coupling data writers
-                if (FSIenabled_ && FSI_->addWriters(dataName, interface)) inModules++;
+                if (FSIenabled_ && FSI_->addWriters(dataName, interface))
+                {
+                    inModules++;
+                }
 
                 // Add FF-related coupling data writers
-                if (FFenabled_ && FF_->addWriters(dataName, interface)) inModules++;
+                if (FFenabled_ && FF_->addWriters(dataName, interface))
+                {
+                    inModules++;
+                }
 
                 if (inModules == 0)
                 {

--- a/Adapter.C
+++ b/Adapter.C
@@ -259,22 +259,27 @@ void preciceAdapter::Adapter::configure()
             {
                 std::string dataName = interfacesConfig_.at(i).writeData.at(j);
 
+                unsigned int inModules = 0;
+
                 // Add CHT-related coupling data writers
-                if (CHTenabled_)
-                {
-                    CHT_->addWriters(dataName, interface);
-                }
+                if (CHTenabled_ && CHT_->addWriters(dataName, interface)) inModules++;
 
                 // Add FSI-related coupling data writers
-                if (FSIenabled_)
-                {
-                    FSI_->addWriters(dataName, interface);
-                }
+                if (FSIenabled_ && FSI_->addWriters(dataName, interface)) inModules++;
 
                 // Add FF-related coupling data writers
-                if (FFenabled_)
+                if (FFenabled_ && FF_->addWriters(dataName, interface)) inModules++;
+
+                if (inModules == 0)
                 {
-                    FF_->addWriters(dataName, interface);
+                    adapterInfo("I don't know how to write " + dataName
+                                + ". Maybe this is a typo or maybe you need to enable some adapter module?", "error-deferred");
+                }
+                else if (inModules > 1)
+                {
+                    adapterInfo("It looks like more than one modules can write " + dataName
+                                + "and I don't know how to choose. Try disabling one of the modules.",
+                                "error-deferred");
                 }
 
                 // NOTE: Add any coupling data writers for your module here.
@@ -285,22 +290,28 @@ void preciceAdapter::Adapter::configure()
             {
                 std::string dataName = interfacesConfig_.at(i).readData.at(j);
 
+                unsigned int inModules = 0;
+
                 // Add CHT-related coupling data readers
-                if (CHTenabled_)
-                {
-                    CHT_->addReaders(dataName, interface);
-                }
+                if (CHTenabled_ && CHT_->addReaders(dataName, interface)) inModules++;
 
                 // Add FSI-related coupling data readers
-                if (FSIenabled_)
-                {
-                    FSI_->addReaders(dataName, interface);
-                }
+                if (FSIenabled_ && FSI_->addReaders(dataName, interface)) inModules++;
 
                 // Add FF-related coupling data readers
-                if (FFenabled_)
+                if (FFenabled_ && FF_->addReaders(dataName, interface)) inModules++;
+
+                if (inModules == 0)
                 {
-                    FF_->addReaders(dataName, interface);
+                    adapterInfo("I don't know how to read " + dataName
+                                    + ". Maybe this is a typo or maybe you need to enable some adapter module?",
+                                "error-deferred");
+                }
+                else if (inModules > 1)
+                {
+                    adapterInfo("It looks like more than one modules can read " + dataName
+                                + "and I don't know how to choose. Try disabling one of the modules.",
+                                "error-deferred");
                 }
 
                 // NOTE: Add any coupling data readers for your module here.

--- a/Adapter.C
+++ b/Adapter.C
@@ -272,9 +272,9 @@ void preciceAdapter::Adapter::configure()
 
                 if (inModules == 0)
                 {
-                    adapterInfo("I don't know how to write " + dataName
-                                    + ". Maybe this is a typo or maybe you need to enable some adapter module?",
-                                "error-deferred");
+                    adapterInfo("I don't know how to write \"" + dataName
+                                    + "\". Maybe this is a typo or maybe you need to enable some adapter module?",
+                                "error-deferred");                                
                 }
                 else if (inModules > 1)
                 {

--- a/Adapter.C
+++ b/Adapter.C
@@ -310,8 +310,8 @@ void preciceAdapter::Adapter::configure()
                 }
                 else if (inModules > 1)
                 {
-                    adapterInfo("It looks like more than one modules can read " + dataName
-                                    + "and I don't know how to choose. Try disabling one of the modules.",
+                    adapterInfo("It looks like more than one modules can read \"" + dataName
+                                    + "\" and I don't know how to choose. Try disabling one of the modules.",
                                 "error-deferred");
                 }
 

--- a/Adapter.C
+++ b/Adapter.C
@@ -273,12 +273,13 @@ void preciceAdapter::Adapter::configure()
                 if (inModules == 0)
                 {
                     adapterInfo("I don't know how to write " + dataName
-                                + ". Maybe this is a typo or maybe you need to enable some adapter module?", "error-deferred");
+                                    + ". Maybe this is a typo or maybe you need to enable some adapter module?",
+                                "error-deferred");
                 }
                 else if (inModules > 1)
                 {
                     adapterInfo("It looks like more than one modules can write " + dataName
-                                + "and I don't know how to choose. Try disabling one of the modules.",
+                                    + "and I don't know how to choose. Try disabling one of the modules.",
                                 "error-deferred");
                 }
 
@@ -310,7 +311,7 @@ void preciceAdapter::Adapter::configure()
                 else if (inModules > 1)
                 {
                     adapterInfo("It looks like more than one modules can read " + dataName
-                                + "and I don't know how to choose. Try disabling one of the modules.",
+                                    + "and I don't know how to choose. Try disabling one of the modules.",
                                 "error-deferred");
                 }
 

--- a/Adapter.C
+++ b/Adapter.C
@@ -262,7 +262,7 @@ void preciceAdapter::Adapter::configure()
                 unsigned int inModules = 0;
 
                 // Add CHT-related coupling data writers
-                if (CHTenabled_ && CHT_->addWriters(dataName, interface)) 
+                if (CHTenabled_ && CHT_->addWriters(dataName, interface))
                 {
                     inModules++;
                 }
@@ -283,7 +283,7 @@ void preciceAdapter::Adapter::configure()
                 {
                     adapterInfo("I don't know how to write \"" + dataName
                                     + "\". Maybe this is a typo or maybe you need to enable some adapter module?",
-                                "error-deferred");                                
+                                "error-deferred");
                 }
                 else if (inModules > 1)
                 {

--- a/CHT/CHT.C
+++ b/CHT/CHT.C
@@ -118,10 +118,13 @@ std::string preciceAdapter::CHT::ConjugateHeatTransfer::determineSolverType()
     return solverType;
 }
 
-void preciceAdapter::CHT::ConjugateHeatTransfer::addWriters(std::string dataName, Interface* interface)
+bool preciceAdapter::CHT::ConjugateHeatTransfer::addWriters(std::string dataName, Interface* interface)
 {
+    bool found = false;
+
     if (dataName.find("Sink-Temperature") == 0)
     {
+        found = true;
         interface->addCouplingDataWriter(
             dataName,
             new SinkTemperature(mesh_, nameT_));
@@ -129,6 +132,7 @@ void preciceAdapter::CHT::ConjugateHeatTransfer::addWriters(std::string dataName
     }
     else if (dataName.find("Temperature") == 0)
     {
+        found = true;
         interface->addCouplingDataWriter(
             dataName,
             new Temperature(mesh_, nameT_));
@@ -136,6 +140,7 @@ void preciceAdapter::CHT::ConjugateHeatTransfer::addWriters(std::string dataName
     }
     else if (dataName.find("Heat-Flux") == 0)
     {
+        found = true;
         if (solverType_.compare("compressible") == 0)
         {
             interface->addCouplingDataWriter(
@@ -165,6 +170,7 @@ void preciceAdapter::CHT::ConjugateHeatTransfer::addWriters(std::string dataName
     }
     else if (dataName.find("Heat-Transfer-Coefficient") == 0)
     {
+        found = true;
         if (solverType_.compare("compressible") == 0)
         {
             interface->addCouplingDataWriter(
@@ -198,12 +204,17 @@ void preciceAdapter::CHT::ConjugateHeatTransfer::addWriters(std::string dataName
     // writer here (and as a reader below).
     // The argument of the dataName.compare() needs to match
     // the one provided in the adapter's configuration file.
+
+    return found;
 }
 
-void preciceAdapter::CHT::ConjugateHeatTransfer::addReaders(std::string dataName, Interface* interface)
+bool preciceAdapter::CHT::ConjugateHeatTransfer::addReaders(std::string dataName, Interface* interface)
 {
+    bool found = false;
+
     if (dataName.find("Sink-Temperature") == 0)
     {
+        found = true;
         interface->addCouplingDataReader(
             dataName,
             new SinkTemperature(mesh_, nameT_));
@@ -211,6 +222,7 @@ void preciceAdapter::CHT::ConjugateHeatTransfer::addReaders(std::string dataName
     }
     else if (dataName.find("Temperature") == 0)
     {
+        found = true;
         interface->addCouplingDataReader(
             dataName,
             new Temperature(mesh_, nameT_));
@@ -218,6 +230,7 @@ void preciceAdapter::CHT::ConjugateHeatTransfer::addReaders(std::string dataName
     }
     else if (dataName.find("Heat-Flux") == 0)
     {
+        found = true;
         if (solverType_.compare("compressible") == 0)
         {
             interface->addCouplingDataReader(
@@ -247,6 +260,7 @@ void preciceAdapter::CHT::ConjugateHeatTransfer::addReaders(std::string dataName
     }
     else if (dataName.find("Heat-Transfer-Coefficient") == 0)
     {
+        found = true;
         if (solverType_.compare("compressible") == 0)
         {
             interface->addCouplingDataReader(
@@ -280,4 +294,6 @@ void preciceAdapter::CHT::ConjugateHeatTransfer::addReaders(std::string dataName
     // reader here (and as a writer above).
     // The argument of the dataName.compare() needs to match
     // the one provided in the adapter's configuration file.
+
+    return found;
 }

--- a/CHT/CHT.C
+++ b/CHT/CHT.C
@@ -192,10 +192,6 @@ void preciceAdapter::CHT::ConjugateHeatTransfer::addWriters(std::string dataName
                         "error");
         }
     }
-    else
-    {
-        adapterInfo("Unknown data type - cannot add " + dataName + ".", "error");
-    }
 
     // NOTE: If you want to couple another variable, you need
     // to add your new coupling data user as a coupling data
@@ -277,10 +273,6 @@ void preciceAdapter::CHT::ConjugateHeatTransfer::addReaders(std::string dataName
             adapterInfo("Unknown solver type - cannot add heat transfer coefficient.",
                         "error");
         }
-    }
-    else
-    {
-        adapterInfo("Unknown data type - cannot add " + dataName + ".", "error");
     }
 
     // NOTE: If you want to couple another variable, you need

--- a/CHT/CHT.C
+++ b/CHT/CHT.C
@@ -120,11 +120,10 @@ std::string preciceAdapter::CHT::ConjugateHeatTransfer::determineSolverType()
 
 bool preciceAdapter::CHT::ConjugateHeatTransfer::addWriters(std::string dataName, Interface* interface)
 {
-    bool found = false;
+    bool found = true; // Set to false later, if needed.
 
     if (dataName.find("Sink-Temperature") == 0)
     {
-        found = true;
         interface->addCouplingDataWriter(
             dataName,
             new SinkTemperature(mesh_, nameT_));
@@ -132,7 +131,6 @@ bool preciceAdapter::CHT::ConjugateHeatTransfer::addWriters(std::string dataName
     }
     else if (dataName.find("Temperature") == 0)
     {
-        found = true;
         interface->addCouplingDataWriter(
             dataName,
             new Temperature(mesh_, nameT_));
@@ -140,7 +138,6 @@ bool preciceAdapter::CHT::ConjugateHeatTransfer::addWriters(std::string dataName
     }
     else if (dataName.find("Heat-Flux") == 0)
     {
-        found = true;
         if (solverType_.compare("compressible") == 0)
         {
             interface->addCouplingDataWriter(
@@ -170,7 +167,6 @@ bool preciceAdapter::CHT::ConjugateHeatTransfer::addWriters(std::string dataName
     }
     else if (dataName.find("Heat-Transfer-Coefficient") == 0)
     {
-        found = true;
         if (solverType_.compare("compressible") == 0)
         {
             interface->addCouplingDataWriter(
@@ -198,6 +194,10 @@ bool preciceAdapter::CHT::ConjugateHeatTransfer::addWriters(std::string dataName
                         "error");
         }
     }
+    else
+    {
+        found = false;
+    }
 
     // NOTE: If you want to couple another variable, you need
     // to add your new coupling data user as a coupling data
@@ -210,11 +210,10 @@ bool preciceAdapter::CHT::ConjugateHeatTransfer::addWriters(std::string dataName
 
 bool preciceAdapter::CHT::ConjugateHeatTransfer::addReaders(std::string dataName, Interface* interface)
 {
-    bool found = false;
+    bool found = true; // Set to false later, if needed.
 
     if (dataName.find("Sink-Temperature") == 0)
     {
-        found = true;
         interface->addCouplingDataReader(
             dataName,
             new SinkTemperature(mesh_, nameT_));
@@ -222,7 +221,6 @@ bool preciceAdapter::CHT::ConjugateHeatTransfer::addReaders(std::string dataName
     }
     else if (dataName.find("Temperature") == 0)
     {
-        found = true;
         interface->addCouplingDataReader(
             dataName,
             new Temperature(mesh_, nameT_));
@@ -230,7 +228,6 @@ bool preciceAdapter::CHT::ConjugateHeatTransfer::addReaders(std::string dataName
     }
     else if (dataName.find("Heat-Flux") == 0)
     {
-        found = true;
         if (solverType_.compare("compressible") == 0)
         {
             interface->addCouplingDataReader(
@@ -260,7 +257,6 @@ bool preciceAdapter::CHT::ConjugateHeatTransfer::addReaders(std::string dataName
     }
     else if (dataName.find("Heat-Transfer-Coefficient") == 0)
     {
-        found = true;
         if (solverType_.compare("compressible") == 0)
         {
             interface->addCouplingDataReader(
@@ -287,6 +283,10 @@ bool preciceAdapter::CHT::ConjugateHeatTransfer::addReaders(std::string dataName
             adapterInfo("Unknown solver type - cannot add heat transfer coefficient.",
                         "error");
         }
+    }
+    else
+    {
+        found = false;
     }
 
     // NOTE: If you want to couple another variable, you need

--- a/CHT/CHT.H
+++ b/CHT/CHT.H
@@ -60,10 +60,10 @@ public:
     bool configure(const IOdictionary& adapterConfig);
 
     //- Add coupling data writers
-    void addWriters(std::string dataName, Interface* interface);
+    bool addWriters(std::string dataName, Interface* interface);
 
     //- Add coupling data readers
-    void addReaders(std::string dataName, Interface* interface);
+    bool addReaders(std::string dataName, Interface* interface);
 };
 
 }

--- a/FF/FF.C
+++ b/FF/FF.C
@@ -127,10 +127,6 @@ void preciceAdapter::FF::FluidFluid::addWriters(std::string dataName, Interface*
             new Pressure(mesh_, nameP_));
         DEBUG(adapterInfo("Added writer: Pressure."));
     }
-    else
-    {
-        adapterInfo("Unknown data type - cannot add " + dataName + ".", "error");
-    }
 
     // NOTE: If you want to couple another variable, you need
     // to add your new coupling data user as a coupling data
@@ -168,10 +164,6 @@ void preciceAdapter::FF::FluidFluid::addReaders(std::string dataName, Interface*
             dataName,
             new Pressure(mesh_, nameP_));
         DEBUG(adapterInfo("Added reader: Pressure."));
-    }
-    else
-    {
-        adapterInfo("Unknown data type - cannot add " + dataName + ".", "error");
     }
 
     // NOTE: If you want to couple another variable, you need

--- a/FF/FF.C
+++ b/FF/FF.C
@@ -97,10 +97,13 @@ std::string preciceAdapter::FF::FluidFluid::determineSolverType()
     return solverType;
 }
 
-void preciceAdapter::FF::FluidFluid::addWriters(std::string dataName, Interface* interface)
+bool preciceAdapter::FF::FluidFluid::addWriters(std::string dataName, Interface* interface)
 {
+    bool found = false;
+
     if (dataName.find("VelocityGradient") == 0)
     {
+        found = true;
         interface->addCouplingDataWriter(
             dataName,
             new VelocityGradient(mesh_, nameU_));
@@ -108,6 +111,7 @@ void preciceAdapter::FF::FluidFluid::addWriters(std::string dataName, Interface*
     }
     else if (dataName.find("Velocity") == 0)
     {
+        found = true;
         interface->addCouplingDataWriter(
             dataName,
             new Velocity(mesh_, nameU_));
@@ -115,6 +119,7 @@ void preciceAdapter::FF::FluidFluid::addWriters(std::string dataName, Interface*
     }
     else if (dataName.find("PressureGradient") == 0)
     {
+        found = true;
         interface->addCouplingDataWriter(
             dataName,
             new PressureGradient(mesh_, nameP_));
@@ -122,6 +127,7 @@ void preciceAdapter::FF::FluidFluid::addWriters(std::string dataName, Interface*
     }
     else if (dataName.find("Pressure") == 0)
     {
+        found = true;
         interface->addCouplingDataWriter(
             dataName,
             new Pressure(mesh_, nameP_));
@@ -133,12 +139,17 @@ void preciceAdapter::FF::FluidFluid::addWriters(std::string dataName, Interface*
     // writer here (and as a reader below).
     // The argument of the dataName.compare() needs to match
     // the one provided in the adapter's configuration file.
+
+    return found;
 }
 
-void preciceAdapter::FF::FluidFluid::addReaders(std::string dataName, Interface* interface)
+bool preciceAdapter::FF::FluidFluid::addReaders(std::string dataName, Interface* interface)
 {
+    bool found = false;
+
     if (dataName.find("VelocityGradient") == 0)
     {
+        found = true;
         interface->addCouplingDataReader(
             dataName,
             new VelocityGradient(mesh_, nameU_));
@@ -146,6 +157,7 @@ void preciceAdapter::FF::FluidFluid::addReaders(std::string dataName, Interface*
     }
     else if (dataName.find("Velocity") == 0)
     {
+        found = true;
         interface->addCouplingDataReader(
             dataName,
             new Velocity(mesh_, nameU_));
@@ -153,6 +165,7 @@ void preciceAdapter::FF::FluidFluid::addReaders(std::string dataName, Interface*
     }
     else if (dataName.find("PressureGradient") == 0)
     {
+        found = true;
         interface->addCouplingDataReader(
             dataName,
             new PressureGradient(mesh_, nameP_));
@@ -160,6 +173,7 @@ void preciceAdapter::FF::FluidFluid::addReaders(std::string dataName, Interface*
     }
     else if (dataName.find("Pressure") == 0)
     {
+        found = true;
         interface->addCouplingDataReader(
             dataName,
             new Pressure(mesh_, nameP_));
@@ -171,4 +185,6 @@ void preciceAdapter::FF::FluidFluid::addReaders(std::string dataName, Interface*
     // reader here (and as a writer above).
     // The argument of the dataName.compare() needs to match
     // the one provided in the adapter's configuration file.
+
+    return found;
 }

--- a/FF/FF.C
+++ b/FF/FF.C
@@ -99,11 +99,10 @@ std::string preciceAdapter::FF::FluidFluid::determineSolverType()
 
 bool preciceAdapter::FF::FluidFluid::addWriters(std::string dataName, Interface* interface)
 {
-    bool found = false;
+    bool found = true; // Set to false later, if needed.
 
     if (dataName.find("VelocityGradient") == 0)
     {
-        found = true;
         interface->addCouplingDataWriter(
             dataName,
             new VelocityGradient(mesh_, nameU_));
@@ -111,7 +110,6 @@ bool preciceAdapter::FF::FluidFluid::addWriters(std::string dataName, Interface*
     }
     else if (dataName.find("Velocity") == 0)
     {
-        found = true;
         interface->addCouplingDataWriter(
             dataName,
             new Velocity(mesh_, nameU_));
@@ -119,7 +117,6 @@ bool preciceAdapter::FF::FluidFluid::addWriters(std::string dataName, Interface*
     }
     else if (dataName.find("PressureGradient") == 0)
     {
-        found = true;
         interface->addCouplingDataWriter(
             dataName,
             new PressureGradient(mesh_, nameP_));
@@ -127,11 +124,14 @@ bool preciceAdapter::FF::FluidFluid::addWriters(std::string dataName, Interface*
     }
     else if (dataName.find("Pressure") == 0)
     {
-        found = true;
         interface->addCouplingDataWriter(
             dataName,
             new Pressure(mesh_, nameP_));
         DEBUG(adapterInfo("Added writer: Pressure."));
+    }
+    else
+    {
+        found = false;
     }
 
     // NOTE: If you want to couple another variable, you need
@@ -145,11 +145,10 @@ bool preciceAdapter::FF::FluidFluid::addWriters(std::string dataName, Interface*
 
 bool preciceAdapter::FF::FluidFluid::addReaders(std::string dataName, Interface* interface)
 {
-    bool found = false;
+    bool found = true; // Set to false later, if needed.
 
     if (dataName.find("VelocityGradient") == 0)
     {
-        found = true;
         interface->addCouplingDataReader(
             dataName,
             new VelocityGradient(mesh_, nameU_));
@@ -157,7 +156,6 @@ bool preciceAdapter::FF::FluidFluid::addReaders(std::string dataName, Interface*
     }
     else if (dataName.find("Velocity") == 0)
     {
-        found = true;
         interface->addCouplingDataReader(
             dataName,
             new Velocity(mesh_, nameU_));
@@ -165,7 +163,6 @@ bool preciceAdapter::FF::FluidFluid::addReaders(std::string dataName, Interface*
     }
     else if (dataName.find("PressureGradient") == 0)
     {
-        found = true;
         interface->addCouplingDataReader(
             dataName,
             new PressureGradient(mesh_, nameP_));
@@ -173,11 +170,14 @@ bool preciceAdapter::FF::FluidFluid::addReaders(std::string dataName, Interface*
     }
     else if (dataName.find("Pressure") == 0)
     {
-        found = true;
         interface->addCouplingDataReader(
             dataName,
             new Pressure(mesh_, nameP_));
         DEBUG(adapterInfo("Added reader: Pressure."));
+    }
+    else
+    {
+        found = false;
     }
 
     // NOTE: If you want to couple another variable, you need

--- a/FF/FF.H
+++ b/FF/FF.H
@@ -47,10 +47,10 @@ public:
     bool configure(const IOdictionary& adapterConfig);
 
     //- Add coupling data writers
-    void addWriters(std::string dataName, Interface* interface);
+    bool addWriters(std::string dataName, Interface* interface);
 
     //- Add coupling data readers
-    void addReaders(std::string dataName, Interface* interface);
+    bool addReaders(std::string dataName, Interface* interface);
 };
 
 }

--- a/FSI/FSI.C
+++ b/FSI/FSI.C
@@ -153,7 +153,7 @@ bool preciceAdapter::FSI::FluidStructureInteraction::addWriters(std::string data
     // writer here (and as a reader below).
     // The argument of the dataName.compare() needs to match
     // the one provided in the adapter's configuration file.
-    
+
     return found;
 }
 
@@ -201,6 +201,6 @@ bool preciceAdapter::FSI::FluidStructureInteraction::addReaders(std::string data
     // writer here (and as a writer above).
     // The argument of the dataName.compare() needs to match
     // the one provided in the adapter's configuration file.
-    
+
     return found;
 }

--- a/FSI/FSI.C
+++ b/FSI/FSI.C
@@ -111,11 +111,10 @@ std::string preciceAdapter::FSI::FluidStructureInteraction::determineSolverType(
 
 bool preciceAdapter::FSI::FluidStructureInteraction::addWriters(std::string dataName, Interface* interface)
 {
-    bool found = false;
+    bool found = true; // Set to false later, if needed.
 
     if (dataName.find("Force") == 0)
     {
-        found = true;
         interface->addCouplingDataWriter(
             dataName,
             new Force(mesh_, solverType_) /* TODO: Add any other arguments here */
@@ -124,7 +123,6 @@ bool preciceAdapter::FSI::FluidStructureInteraction::addWriters(std::string data
     }
     else if (dataName.find("DisplacementDelta") == 0)
     {
-        found = true;
         interface->addCouplingDataWriter(
             dataName,
             new DisplacementDelta(mesh_, namePointDisplacement_, nameCellDisplacement_));
@@ -132,7 +130,6 @@ bool preciceAdapter::FSI::FluidStructureInteraction::addWriters(std::string data
     }
     else if (dataName.find("Displacement") == 0)
     {
-        found = true;
         interface->addCouplingDataWriter(
             dataName,
             new Displacement(mesh_, namePointDisplacement_, nameCellDisplacement_));
@@ -140,12 +137,15 @@ bool preciceAdapter::FSI::FluidStructureInteraction::addWriters(std::string data
     }
     else if (dataName.find("Stress") == 0)
     {
-        found = true;
         interface->addCouplingDataWriter(
             dataName,
             new Stress(mesh_, solverType_) /* TODO: Add any other arguments here */
         );
         DEBUG(adapterInfo("Added writer: Stress."));
+    }
+    else
+    {
+        found = false;
     }
 
     // NOTE: If you want to couple another variable, you need
@@ -159,11 +159,10 @@ bool preciceAdapter::FSI::FluidStructureInteraction::addWriters(std::string data
 
 bool preciceAdapter::FSI::FluidStructureInteraction::addReaders(std::string dataName, Interface* interface)
 {
-    bool found = false;
+    bool found = true; // Set to false later, if needed.
 
     if (dataName.find("Force") == 0)
     {
-        found = true;
         interface->addCouplingDataReader(
             dataName,
             new Force(mesh_, solverType_) /* TODO: Add any other arguments here */
@@ -172,7 +171,6 @@ bool preciceAdapter::FSI::FluidStructureInteraction::addReaders(std::string data
     }
     else if (dataName.find("DisplacementDelta") == 0)
     {
-        found = true;
         interface->addCouplingDataReader(
             dataName,
             new DisplacementDelta(mesh_, namePointDisplacement_, nameCellDisplacement_));
@@ -180,7 +178,6 @@ bool preciceAdapter::FSI::FluidStructureInteraction::addReaders(std::string data
     }
     else if (dataName.find("Displacement") == 0)
     {
-        found = true;
         interface->addCouplingDataReader(
             dataName,
             new Displacement(mesh_, namePointDisplacement_, nameCellDisplacement_));
@@ -188,12 +185,15 @@ bool preciceAdapter::FSI::FluidStructureInteraction::addReaders(std::string data
     }
     else if (dataName.find("Stress") == 0)
     {
-        found = true;
         interface->addCouplingDataReader(
             dataName,
             new Stress(mesh_, solverType_) /* TODO: Add any other arguments here */
         );
         DEBUG(adapterInfo("Added reader: Stress."));
+    }
+    else
+    {
+        found = false;
     }
 
     // NOTE: If you want to couple another variable, you need

--- a/FSI/FSI.C
+++ b/FSI/FSI.C
@@ -109,10 +109,13 @@ std::string preciceAdapter::FSI::FluidStructureInteraction::determineSolverType(
 }
 
 
-void preciceAdapter::FSI::FluidStructureInteraction::addWriters(std::string dataName, Interface* interface)
+bool preciceAdapter::FSI::FluidStructureInteraction::addWriters(std::string dataName, Interface* interface)
 {
+    bool found = false;
+
     if (dataName.find("Force") == 0)
     {
+        found = true;
         interface->addCouplingDataWriter(
             dataName,
             new Force(mesh_, solverType_) /* TODO: Add any other arguments here */
@@ -121,6 +124,7 @@ void preciceAdapter::FSI::FluidStructureInteraction::addWriters(std::string data
     }
     else if (dataName.find("DisplacementDelta") == 0)
     {
+        found = true;
         interface->addCouplingDataWriter(
             dataName,
             new DisplacementDelta(mesh_, namePointDisplacement_, nameCellDisplacement_));
@@ -128,6 +132,7 @@ void preciceAdapter::FSI::FluidStructureInteraction::addWriters(std::string data
     }
     else if (dataName.find("Displacement") == 0)
     {
+        found = true;
         interface->addCouplingDataWriter(
             dataName,
             new Displacement(mesh_, namePointDisplacement_, nameCellDisplacement_));
@@ -135,6 +140,7 @@ void preciceAdapter::FSI::FluidStructureInteraction::addWriters(std::string data
     }
     else if (dataName.find("Stress") == 0)
     {
+        found = true;
         interface->addCouplingDataWriter(
             dataName,
             new Stress(mesh_, solverType_) /* TODO: Add any other arguments here */
@@ -147,12 +153,17 @@ void preciceAdapter::FSI::FluidStructureInteraction::addWriters(std::string data
     // writer here (and as a reader below).
     // The argument of the dataName.compare() needs to match
     // the one provided in the adapter's configuration file.
+    
+    return found;
 }
 
-void preciceAdapter::FSI::FluidStructureInteraction::addReaders(std::string dataName, Interface* interface)
+bool preciceAdapter::FSI::FluidStructureInteraction::addReaders(std::string dataName, Interface* interface)
 {
+    bool found = false;
+
     if (dataName.find("Force") == 0)
     {
+        found = true;
         interface->addCouplingDataReader(
             dataName,
             new Force(mesh_, solverType_) /* TODO: Add any other arguments here */
@@ -161,6 +172,7 @@ void preciceAdapter::FSI::FluidStructureInteraction::addReaders(std::string data
     }
     else if (dataName.find("DisplacementDelta") == 0)
     {
+        found = true;
         interface->addCouplingDataReader(
             dataName,
             new DisplacementDelta(mesh_, namePointDisplacement_, nameCellDisplacement_));
@@ -168,6 +180,7 @@ void preciceAdapter::FSI::FluidStructureInteraction::addReaders(std::string data
     }
     else if (dataName.find("Displacement") == 0)
     {
+        found = true;
         interface->addCouplingDataReader(
             dataName,
             new Displacement(mesh_, namePointDisplacement_, nameCellDisplacement_));
@@ -175,6 +188,7 @@ void preciceAdapter::FSI::FluidStructureInteraction::addReaders(std::string data
     }
     else if (dataName.find("Stress") == 0)
     {
+        found = true;
         interface->addCouplingDataReader(
             dataName,
             new Stress(mesh_, solverType_) /* TODO: Add any other arguments here */
@@ -187,4 +201,6 @@ void preciceAdapter::FSI::FluidStructureInteraction::addReaders(std::string data
     // writer here (and as a writer above).
     // The argument of the dataName.compare() needs to match
     // the one provided in the adapter's configuration file.
+    
+    return found;
 }

--- a/FSI/FSI.H
+++ b/FSI/FSI.H
@@ -56,10 +56,10 @@ public:
     bool configure(const IOdictionary& adapterConfig);
 
     //- Add coupling data writers
-    void addWriters(std::string dataName, Interface* interface);
+    bool addWriters(std::string dataName, Interface* interface);
 
     //- Add coupling data readers
-    void addReaders(std::string dataName, Interface* interface);
+    bool addReaders(std::string dataName, Interface* interface);
 };
 
 }

--- a/changelog-entries/197.md
+++ b/changelog-entries/197.md
@@ -1,0 +1,1 @@
+- Fix a bug that was not allowing more than one module at the same time and add an error message for the case when a dataset is not known by any or too many modules. [#197](https://github.com/precice/openfoam-adapter/pull/197)

--- a/changelog-entries/197.md
+++ b/changelog-entries/197.md
@@ -1,1 +1,1 @@
-- Fix a bug that was not allowing more than one module at the same time and add an error message for the case when a dataset is not known by any or too many modules. [#197](https://github.com/precice/openfoam-adapter/pull/197)
+- Fixed a bug that was not allowing more than one module at the same time and added an error message for the case when a dataset is not known by any or too many modules. [#197](https://github.com/precice/openfoam-adapter/pull/197)


### PR DESCRIPTION
Loading several modules e.g. FF and FSI results in an error message (see issue #196).
The last else-case in the FF- and CHT-modules for writing and reading participants is deleted,
which should provide a first fix. Now the branching should be consistent in all three available modules (FSI, FF, CHT).