### PR TITLE
Disable automatic links checking (make manual)

### DIFF
--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -1,0 +1,14 @@
+name: Check links (manual)
+on: workflow_dispatch
+jobs:
+  check_links:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v2
+      - name: Check links in markdown files (markdown-link-check)
+        uses: gaurav-nelson/github-action-markdown-link-check@v1
+        with:
+          use-quiet-mode: 'yes'
+          use-verbose-mode: 'no'
+          config-file: '.markdown-link-check-config.json'

--- a/.github/workflows/check-markdown.yml
+++ b/.github/workflows/check-markdown.yml
@@ -1,4 +1,4 @@
-name: Lint docs and check links
+name: Lint docs
 on: [push, pull_request]
 jobs:
   check_md:
@@ -12,9 +12,3 @@ jobs:
           config: .markdownlint.json
           files: '.'
           ignore: changelog-entries
-      - name: Check links in markdown files (markdown-link-check)
-        uses: gaurav-nelson/github-action-markdown-link-check@v1
-        with:
-          use-quiet-mode: 'yes'
-          use-verbose-mode: 'no'
-          config-file: '.markdown-link-check-config.json'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ Read more details in the issue [#52: Releases and versioning](https://github.com
 - Removed explicit casting of boundary conditions in the adapter's write function in order to allow more boundary conditions to be compatible with the adapter (e.g. groovyBC) [#195](https://github.com/precice/openfoam-adapter/pull/195).
 - OpenFOAM version bumped to v2112 in GitHub Actions (including preCICE v2.2.1 --> v2.3.0) and documentation. GitHub Action clang-format-action switched to main branch. [#211](https://github.com/precice/openfoam-adapter/pull/211).
 - Cleaned-up the handling of adding checkpoint fields and replaced various unnecessary copies by references [#209](https://github.com/precice/openfoam-adapter/pull/209).
+- Disabled automatic checking of links. This is now a manual workflow [#215](https://github.com/precice/openfoam-adapter/pull/215).
 
 ### Fixed
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,5 +18,9 @@ You can format all files with clang-format 11 by running `./tools/format-code.sh
 
 We check every contribution with a few GitHub Actions workflows that report at the bottom of each pull request.
 
-Additionally, there is an "custom build" workflow, which can be triggered manually to build any branch of the repository
-with any of the available OpenFOAM versions. Members of the repository can trigger this workflow in the "Actions" tab.
+There are also a few additional workflows that can be triggered manually:
+
+- `Custom build`: builds any branch of the repository with any of the available OpenFOAM versions.
+- `Check links`: checks the links in all markdown files to verify if they are still reachable.
+
+Members of the repository can trigger these workflows in the "Actions" tab.


### PR DESCRIPTION
We currently have an automatic check for unreachable links. This can turn a bit annoying, as it most often fails in irrelevant PRs.

This converts it to a manual workflow. I am not making it a cron job as it will again associate its status with a specific commit, which would be misleading.

TODO list:

- [x] I updated the documentation in `docs/` -> Added in `CONTRIBUTING.md`
- [x] I added a changelog entry in `changelog-entries/` (create directory if missing) -> Added in the already prepared changelog.
