### PR TITLE
Add pull request template, document versioning

### DIFF
--- a/Adapter.C
+++ b/Adapter.C
@@ -10,7 +10,7 @@ preciceAdapter::Adapter::Adapter(const Time& runTime, const fvMesh& mesh)
 : runTime_(runTime),
   mesh_(mesh)
 {
-    adapterInfo("Loaded the OpenFOAM-preCICE adapter - v1.0.1.", "info");
+    adapterInfo("Loaded the OpenFOAM-preCICE adapter - v1.1.0.", "info");
 
     return;
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ Read more details in the issue [#52: Releases and versioning](https://github.com
 
 ## [Unreleased]
 
-## [v1.1.0] 2022-02-03
+## [v1.1.0] 2022-02-07
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ Read more details in the issue [#52: Releases and versioning](https://github.com
 
 ## [Unreleased]
 
-## [v1.0.1] 2022-01-24
+## [v1.1.0] 2022-02-03
 
 ### Added
 
@@ -18,6 +18,7 @@ Read more details in the issue [#52: Releases and versioning](https://github.com
 - Extended the adapter's DEBUG output to print the rank in addition to the message in parallel runs
 [#201](https://github.com/precice/openfoam-adapter/pull/201).
 - Added a custom build workflow to check building the adapter with any supported OpenFOAM version [#214](https://github.com/precice/openfoam-adapter/pull/214).
+- Added a release pull request template and documented the versioning strategy and release artifact names. [#216](https://github.com/precice/openfoam-adapter/pull/216)
 
 ### Changed
 

--- a/docs/get.md
+++ b/docs/get.md
@@ -21,6 +21,18 @@ Adding `-DADAPTER_DEBUG_MODE` flag to the `ADAPTER_PREP_FLAGS` activates additio
 
 Next: [configure and load the adapter](https://precice.org/adapter-openfoam-config.html) or [run a tutorial](https://precice.org/tutorials.html).
 
+## What does the adapter version mean?
+
+We use [semantic versioning](https://semver.org/) (MAJOR.MINOR.PATCH), adapted to the nature of an adapter:
+
+* As "API" we define the tutorial configuration files. If you would need to update your `preciceDict`, `controlDict` or any other configuration file to keep using your simulation cases with the same OpenFOAM version, this would be a new major version.
+* If you could run the same cases without any changes, but you would also get new features or modified behavior (non-trivial), then this would be a new minor version.
+* If there would be only bugfixes or trivial changes not affecting the configuration or behavior, then this would be a new patch version.
+
+Note that the OpenFOAM version is not part of the version of the adapter. It is only reflected in the release archives, which target a range of compatible versions. By default, we support the latest OpenFOAM version from OpenCFD (openfoam.com) and we update our release archives or release a new adapter version (including more than compatibility changes) as soon as there is a new OpenFOAM version.
+
+Read the [discussion that lead to this versioning strategy](https://github.com/precice/openfoam-adapter/issues/52) for more details.
+
 ## Troubleshooting
 
 The following are common problems that may appear during building the OpenFOAM adapter if something went wrong in the described steps. Make sure to always check for error messages at every step before continuing to the next.

--- a/docs/openfoam-support.md
+++ b/docs/openfoam-support.md
@@ -21,19 +21,19 @@ As these steps change your `.profile`, you need to log out and in again to make 
 
 ## Supported OpenFOAM versions
 
-OpenFOAM is a project with long history and many forks, of which we try to support as many as possible.
+OpenFOAM is a project with long history and many forks, of which we try to support as many as possible. Since several HPC systems only provide older versions, we try to also support a wide range of versions.
 
-We provide version-specific branches and [release archives](https://github.com/precice/openfoam-adapter/releases/latest) for:
+We provide version-specific [release archives](https://github.com/precice/openfoam-adapter/releases/latest) and respective Git branches for:
 
 - OpenCFD / ESI (openfoam.com) - main focus:
   - [OpenFOAM v1812-v2112](https://github.com/precice/openfoam-adapter) or newer
-  - [OpenFOAM v1612-v1806](https://github.com/precice/openfoam-adapter/tree/OpenFOAMv1806)
+  - [OpenFOAM v1612-v1806](https://github.com/precice/openfoam-adapter/tree/OpenFOAMv1806) (not tested)
 - OpenFOAM Foundation (openfoam.org) - secondary, consider experimental:
   - [OpenFOAM 8](https://github.com/precice/openfoam-adapter/tree/OpenFOAM8)
   - [OpenFOAM 7](https://github.com/precice/openfoam-adapter/tree/OpenFOAM7)
   - [OpenFOAM 6](https://github.com/precice/openfoam-adapter/tree/OpenFOAM6)
   - [OpenFOAM 5.x](https://github.com/precice/openfoam-adapter/tree/OpenFOAM5)
-  - [OpenFOAM 4.0/4.1](https://github.com/precice/openfoam-adapter/tree/OpenFOAM4)
+  - [OpenFOAM 4.0/4.1](https://github.com/precice/openfoam-adapter/tree/OpenFOAM4) (not tested)
 
 Known not supported versions: OpenFOAM 9 ([issue - contributions welcome](https://github.com/precice/openfoam-adapter/issues/200)), OpenFOAM v1606+ or older, OpenFOAM 3 or older, foam-extend (any version).
 

--- a/tools/release_pull_request_template.md
+++ b/tools/release_pull_request_template.md
@@ -1,0 +1,72 @@
+# Release checklist
+
+Copy this template to the release pull request description.
+
+## Update workflows
+
+- [ ] `.github/workflows/build.yml` and `.github/workflows/install-dependencies.sh`: Update the OpenFOAM and preCICE versions, if needed.
+- [ ] `build-custom.yml`: Add any new OpenFOAM versions and update the default preCICE version, if needed.
+
+## Prepare branches
+
+- [ ] Merge `master` to `develop`, if needed
+- [ ] Open a pull request from `develop` to `master`.
+  - We don't use release branches, unless there are changes we don't want to release, potentially when preparing a major release.
+- [ ] Run and fix all workflows
+
+## Test
+
+- [ ] Run and check flow-over-heated-plate OpenFOAM-OpenFOAM
+- [ ] Run and check quickstart
+- [ ] Run and check perpendicular-flap OpenFOAM-deal.II
+- [ ] Run and check elastic-tube-3d OpenFOAM-CalculiX
+- [ ] Run and check partitioned-pipe sonicLiquidFoam-sonicLiquidFoam
+
+Until we get automated system tests again, run all the tests manually.
+
+## Prepare version-specific branches
+
+- [ ] Rebase `OpenFOAM4` on `develop` and force-push
+  - `git checkout OpenFOAM4 && git rebase develop`
+  - Resolve any conflicts. We should have only one commit in the end.
+  - `git push --force`
+- [ ] Rebase `OpenFOAM5` on `OpenFOAM4`, `OpenFOAM6` on `OpenFOAM5`, ...
+- [ ] Trigger a custom build for each version
+
+## Preparing the Changelog
+
+- [ ] Copy all the changelog entries into `CHANGELOG.md`
+- [ ] Delete `changelog-entries/`
+
+## Bump the version
+
+- [ ] Decide on the version using the versioning strategy documented in the user docs (see page "Get the OpenFOAM adapter")
+- [ ] Bump the version in `CHANGELOG.md`
+- [ ] Bump the version in `Adapter.C`
+
+## Merge
+
+- [ ] Review pull request
+- [ ] Merge pull request
+- [ ] Merge back from `master` to `develop`. No PR is needed for that.
+- [ ] Update the version in `Adapter.C` on `develop` to reflect that this is an unreleased version
+- [ ] Rebase the version-specific branches on `master`
+
+## Release
+
+- [ ] Draft and discuss release notes
+- [ ] Create a Release on GitHub
+- [ ] Download an archive of the repository (i.e., no `.git/` or `.gitignore`) for each version and attach to the release
+  - branch `master`: archive `openfoam-adapter_v1.0.0_OpenFOAMv1812-v2112.tar.gz` (adjust `v2112` to the latest supported, and `v1.0.0` to the actual version)
+  - branch `OpenFOAM4`: archive `openfoam-adapter_v1.0.0_OpenFOAM4_5_v1806.tar.gz`
+  - branch `OpenFOAM6`: archive `openfoam-adapter_v1.0.0_OpenFOAM6_experimental.tar.gz`
+  - branch `OpenFOAM7`: archive `openfoam-adapter_v1.0.0_OpenFOAM7_experimental.tar.gz`
+  - branch `OpenFOAM8`: archive `openfoam-adapter_v1.0.0_OpenFOAM8_experimental.tar.gz`
+
+## Post-release
+
+- [ ] Update the git module on the website
+- [ ] Update workflows in the tutorials repository, if needed (e.g., OpenFOAM version)
+- [ ] Update the VM provisioning, if needed (e.g., OpenFOAM version)
+- [ ] Update this release checklist (`tools/release_pull_request_template.md`)
+- [ ] Advertise and celebrate! :tada:

--- a/tools/release_pull_request_template.md
+++ b/tools/release_pull_request_template.md
@@ -34,7 +34,8 @@ Until we get automated system tests again, run all the tests manually.
 - [ ] Trigger a custom build for each version
 
 Overview of branches:
-```
+
+```text
 master <-- OpenFOAM4 <-- OpenFOAM5 <-- OpenFOAM6 <-- OpenFOAM7 <-- OpenFOAM8 <-- OpenFOAMdev
 ^-- develop     ^-- OpenFOAMv1806
 ```

--- a/tools/release_pull_request_template.md
+++ b/tools/release_pull_request_template.md
@@ -43,6 +43,7 @@ master <-- OpenFOAM4 <-- OpenFOAM5 <-- OpenFOAM6 <-- OpenFOAM7 <-- OpenFOAM8 <--
 
 - [ ] Copy all the changelog entries into `CHANGELOG.md`
 - [ ] Delete `changelog-entries/`
+- [ ] Draft and discuss release notes
 
 ## Bump the version
 
@@ -60,7 +61,6 @@ master <-- OpenFOAM4 <-- OpenFOAM5 <-- OpenFOAM6 <-- OpenFOAM7 <-- OpenFOAM8 <--
 
 ## Release
 
-- [ ] Draft and discuss release notes
 - [ ] Create a Release on GitHub
 - [ ] Download an archive of the repository (i.e., no `.git/` or `.gitignore`) for each version and attach to the release
   - branch `master`: archive `openfoam-adapter_v1.0.0_OpenFOAMv1812-v2112.tar.gz` (adjust `v2112` to the latest supported, and `v1.0.0` to the actual version)

--- a/tools/release_pull_request_template.md
+++ b/tools/release_pull_request_template.md
@@ -33,6 +33,12 @@ Until we get automated system tests again, run all the tests manually.
 - [ ] Rebase `OpenFOAM5` on `OpenFOAM4`, `OpenFOAM6` on `OpenFOAM5`, ...
 - [ ] Trigger a custom build for each version
 
+Overview of branches:
+```
+master <-- OpenFOAM4 <-- OpenFOAM5 <-- OpenFOAM6 <-- OpenFOAM7 <-- OpenFOAM8 <-- OpenFOAMdev
+^-- develop     ^-- OpenFOAMv1806
+```
+
 ## Preparing the Changelog
 
 - [ ] Copy all the changelog entries into `CHANGELOG.md`
@@ -47,7 +53,7 @@ Until we get automated system tests again, run all the tests manually.
 ## Merge
 
 - [ ] Review pull request
-- [ ] Merge pull request
+- [ ] Merge pull request (**not** squash)
 - [ ] Merge back from `master` to `develop`. No PR is needed for that.
 - [ ] Update the version in `Adapter.C` on `develop` to reflect that this is an unreleased version
 - [ ] Rebase the version-specific branches on `master`


### PR DESCRIPTION
This PR:

- adds a release pull request template in `tools/` (meant to just be copied in the PR description manually). Closes #178.
- explains the version numbers in the "Get the OpenFOAM adapter" page
- clarifies a few minor things in the OpenFOAM support page
- changes the version from the (originally planned) `1.0.1` to the now agreed `1.1.0`.

TODO list:

- [x] I updated the documentation in `docs/`
- [x] I added a changelog entry in `changelog-entries/` (create directory if missing)

@DavidSCN have a look on the template and versioning strategy. Do we still need to clarify anything else?