### PR TITLE
Add a hint to cite the adapter

### DIFF
--- a/Adapter.C
+++ b/Adapter.C
@@ -468,11 +468,9 @@ void preciceAdapter::Adapter::execute()
             "The simulation was ended by preCICE. "
             "Calling the end() methods of any functionObject explicitly.",
             "info");
-        adapterInfo("\033[32m" // green color 
-                    "Great that you are using the OpenFOAM-preCICE adapter! "
+        adapterInfo("Great that you are using the OpenFOAM-preCICE adapter! "
                     "Next to the preCICE library and any other components, please also cite this adapter. "
-                    "Find how on https://precice.org/adapter-openfoam-overview.html."
-                    "\033[0m", // restore color
+                    "Find how on https://precice.org/adapter-openfoam-overview.html.",
                     "info");
         const_cast<Time&>(runTime_).functionObjects().end();
     }

--- a/Adapter.C
+++ b/Adapter.C
@@ -468,6 +468,12 @@ void preciceAdapter::Adapter::execute()
             "The simulation was ended by preCICE. "
             "Calling the end() methods of any functionObject explicitly.",
             "info");
+        adapterInfo("\033[32m" // green color 
+                    "Great that you are using the OpenFOAM-preCICE adapter! "
+                    "Next to the preCICE library and any other components, please also cite this adapter. "
+                    "Find how on https://precice.org/adapter-openfoam-overview.html."
+                    "\033[0m", // restore color
+                    "info");
         const_cast<Time&>(runTime_).functionObjects().end();
     }
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Read more details in the issue [#52: Releases and versioning](https://github.com
 [#201](https://github.com/precice/openfoam-adapter/pull/201).
 - Added a custom build workflow to check building the adapter with any supported OpenFOAM version [#214](https://github.com/precice/openfoam-adapter/pull/214).
 - Added a release pull request template and documented the versioning strategy and release artifact names. [#216](https://github.com/precice/openfoam-adapter/pull/216)
+- Added a hint to also cite the adapter, at the end of the coupling. [#217](https://github.com/precice/openfoam-adapter/pull/217)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ Read more details in the issue [#52: Releases and versioning](https://github.com
 [#201](https://github.com/precice/openfoam-adapter/pull/201).
 - Added a custom build workflow to check building the adapter with any supported OpenFOAM version [#214](https://github.com/precice/openfoam-adapter/pull/214).
 - Added a release pull request template and documented the versioning strategy and release artifact names. [#216](https://github.com/precice/openfoam-adapter/pull/216)
-- Added a hint to also cite the adapter, at the end of the coupling. [#217](https://github.com/precice/openfoam-adapter/pull/217)
+- Added a hint to also cite the adapter, at the end of the coupling. [#218](https://github.com/precice/openfoam-adapter/pull/218)
 
 ### Changed
 


### PR DESCRIPTION
This adds the following hint at the end of each simulation:

![Screenshot from 2022-02-06 19-50-36](https://user-images.githubusercontent.com/4943683/152697010-926b9795-fff3-4830-8979-905c1047cce0.png)

The motivation is that sometimes, users cite the preCICE library, but not the adapters they are using. This is a suggestion that we could port also to other adapters. @uekerman 

A few notes:
- I want this to appear in the end, because information in the beginning is often missing.
- I added this in the `!isCouplingOngoing()` branch and not in the destructor, so that it only appears at the end of a (hopfully) successful simulation, not next to wild adapter or OpenFOAM errors.
- The green color highlights the message, but also serves as an implicit "success" sign at the end. I hope it is not too aggressive. We do use color codes in other places as well, this is the only case where we use green.
- I point to the website, as we want to be able to update this in the future. The version is already anyway reported in the beginning.

@DavidSCN do you agree? Any further suggestions? Let's integrate this in this release, as users take a while to upgrade.

TODO list:

- [x] I updated the documentation in `docs/` -> nothing needed
- [x] I added a changelog entry in `changelog-entries/` (create directory if missing) -> directly in the prepared changelog
