### PR TITLE
Allwmake: Use all available procs

### DIFF
--- a/Allwmake
+++ b/Allwmake
@@ -7,10 +7,8 @@ set -e -u
 ADAPTER_PREP_FLAGS=""
 
 # Build command and options
-# In order to compile with multiple threads, add e.g. "-j 4".
-# Make sure that these options are supported by your OpenFOAM version.
 adapter_build_command(){
-    wmake -j 4 libso
+    wmake -j "$(nproc)" libso
 }
 
 # Where should the adapter be built? Default: "${FOAM_USER_LIBBIN}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ Read more details in the issue [#52: Releases and versioning](https://github.com
 - OpenFOAM version bumped to v2112 in GitHub Actions (including preCICE v2.2.1 --> v2.3.0) and documentation. GitHub Action clang-format-action switched to main branch. [#211](https://github.com/precice/openfoam-adapter/pull/211).
 - Cleaned-up the handling of adding checkpoint fields and replaced various unnecessary copies by references [#209](https://github.com/precice/openfoam-adapter/pull/209).
 - Disabled automatic checking of links. This is now a manual workflow [#215](https://github.com/precice/openfoam-adapter/pull/215).
+- The adapter now is being built with all available logical processors (`nproc`), instead of 4 as default. This should work on every modern system and OpenFOAM version [#219](https://github.com/precice/openfoam-adapter/pull/219).
 
 ### Fixed
 

--- a/docs/get.md
+++ b/docs/get.md
@@ -13,7 +13,6 @@ To build the adapter, you need to install a few dependencies and then execute th
 4. Execute the build script: `./Allwmake`.
     * See and adjust the configuration in the beginning of the script first, if needed.
     * Check for any error messages and suggestions at the end.
-    * Modify the `adapter_build_command` to e.g. build using more threads, e.g. `wmake -j 4 libso`.
 
 The adapter also requires [pkg-config](https://linux.die.net/man/1/pkg-config) to [link to preCICE](https://precice.org/installation-linking.html). This is a very common dependency on Linux and is usually already installed.
 


### PR DESCRIPTION
We are currently calling `wmake -j 4` and asking the user to change it manually, if they need more. This PR is replacing the `wmake -j 4` with `wmake -j "$(nproc)"`.

The motivation for not using `nproc` earlier was that in cases with many cores but little memory (e.g., a VM), this could lead to some memory usage issues. [Measuring](https://unix.stackexchange.com/a/647621/36693) on a `nproc=8` system, I see that the maximum memory usage is 685MB for 4 threads, and the same for 8 threads (I guess almost everything is OpenFOAM libraries we anyway load). This should be reasonable for any modern system. On the other hand, the time benefit is also rather negligible (if statistically significant at all).

In any case, this will also not over-subscribe the CPU by default (e.g., on a sinle-core system), leading to the same or lower compilation time in all cases.

Originally, we had no parallelization in `wmake`, as this was not supported by older OpenFOAM versions. All the OpenFOAM versions we now test provide the `-j` option (i.e., no need to comment on that anymore). Potentially OpenFOAM 4 does not support that, but we can handle such few support requests, if any.

TODO list:

- [x] I updated the documentation in `docs/`
- [x] I added a changelog entry in `changelog-entries/` (create directory if missing)
