### PR TITLE
Extend Allwmake suggestions for possible problems

### DIFF
--- a/Allwmake
+++ b/Allwmake
@@ -54,7 +54,7 @@ if command -v pkg-config >/dev/null 2>&1; then
         Check the preCICE documentation page 'Linking to preCICE' for more details, or proceed if you know what you are doing."
     fi
 else
-    warning "pkg-config is not installed and is used to detect the preCICE installation. Only proceed if you know what you are doing."
+    warning "pkg-config is not installed and cannot be used to detect the preCICE installation. Only proceed if you know what you are doing."
 fi
 export ADAPTER_PKG_CONFIG_CFLAGS
 export ADAPTER_PKG_CONFIG_LIBS

--- a/Allwmake
+++ b/Allwmake
@@ -54,7 +54,7 @@ if command -v pkg-config >/dev/null 2>&1; then
         Check the preCICE documentation page 'Linking to preCICE' for more details, or proceed if you know what you are doing."
     fi
 else
-    warning "pkg-config is not installed and cannot be used to detect the preCICE installation. Only proceed if you know what you are doing."
+    warning "pkg-config is not installed and cannot be used to detect the preCICE installation. If building succeeds, ignore this warning."
 fi
 export ADAPTER_PKG_CONFIG_CFLAGS
 export ADAPTER_PKG_CONFIG_LIBS

--- a/Allwmake
+++ b/Allwmake
@@ -24,6 +24,11 @@ DOC_COMPATIBILITY="https://www.precice.org/adapter-openfoam-support.html"
 log() {
     echo "$@" | tee -a "Allwmake.log"
 }
+# Function to print warnings
+warning() {
+    log "WARNING: $*"
+    export ADAPTER_WARNINGS="true"
+}
 ################################################################################
 
 # Information header
@@ -33,22 +38,26 @@ log "Building the OpenFOAM-preCICE adapter..."
 export ADAPTER_PREP_FLAGS
 export ADAPTER_TARGET_DIR
 
-if pkg-config libprecice; then
-  ADAPTER_PKG_CONFIG_CFLAGS="$(pkg-config --silence-errors --cflags libprecice)"
-  ADAPTER_PKG_CONFIG_LIBS="$(pkg-config --silence-errors --libs libprecice)"
+# Check if pkg-config is available and get the config for preCICE
+ADAPTER_PKG_CONFIG_CFLAGS=""
+ADAPTER_PKG_CONFIG_LIBS=""
+if command -v pkg-config >/dev/null 2>&1; then
+    if pkg-config libprecice; then
+        ADAPTER_PKG_CONFIG_CFLAGS="$(pkg-config --silence-errors --cflags libprecice)"
+        ADAPTER_PKG_CONFIG_LIBS="$(pkg-config --silence-errors --libs libprecice)"
+        log ""
+        log "If not already known by the system, preCICE may be located using:"
+        log "  pkg-config --cflags libprecice  = ${ADAPTER_PKG_CONFIG_CFLAGS}"
+        log "  pkg-config --libs libprecice    = ${ADAPTER_PKG_CONFIG_LIBS}"
+    else
+        warning "pkg-config configuration file 'libprecice.pc' was not found in the PKG_CONFIG_PATH.
+        Check the preCICE documentation page 'Linking to preCICE' for more details, or proceed if you know what you are doing."
+    fi
 else
-  log "WARNING: No configuration file 'libprecice.pc' was found in the PKG_CONFIG_PATH."
-  log "Check the preCICE documentation page 'Linking to preCICE' for more details, or proceed if you know what you are doing."
-  ADAPTER_PKG_CONFIG_CFLAGS=""
-  ADAPTER_PKG_CONFIG_LIBS=""
+    warning "pkg-config is not installed and is used to detect the preCICE installation. Only proceed if you know what you are doing."
 fi
 export ADAPTER_PKG_CONFIG_CFLAGS
 export ADAPTER_PKG_CONFIG_LIBS
-
-log ""
-log "If not already known by the system, preCICE may be located using:"
-log "  pkg-config --cflags libprecice  = ${ADAPTER_PKG_CONFIG_CFLAGS}"
-log "  pkg-config --libs libprecice    = ${ADAPTER_PKG_CONFIG_LIBS}"
 
 # Check if an OpenFOAM environment is available
 log ""
@@ -106,4 +115,8 @@ else
     else
         log "=== OK: Building completed successfully! ==="
     fi
+fi
+
+if [ "${ADAPTER_WARNINGS:-}" = "true" ]; then
+    echo "There have been warnings. Check the log above."
 fi

--- a/Allwmake
+++ b/Allwmake
@@ -89,6 +89,7 @@ if ! adapter_build_command 2>&1 | tee wmake.log ||
     log "- Make sure you are using a compatible version of the adapter for your OpenFOAM version:"
     log "  ${DOC_COMPATIBILITY}"
     log "- Is preCICE discoverable at compile time? Check the content of ADAPTER_PKG_CONFIG_CFLAGS above."
+    log "Attach your Allwmake.log and wmake.log when asking for help."
     exit 1
 else
     ADAPTER_WMAKE_UNDEFINED_SYMBOLS=$(grep -c -E "undefined|not defined" wmake.log) || echo "Everything looks fine in wmake.log."
@@ -97,8 +98,11 @@ else
     if [ "${ADAPTER_WMAKE_UNDEFINED_SYMBOLS}" -gt 0 ] || [ "${ADAPTER_LD_UNDEFINED_SYMBOLS}" -gt 0 ]; then
         log "=== ERROR: Building completed with linking problems: there were undefined symbols. ==="
         log "Possible causes:"
-        log "- Is preCICE discoverable at runtime? Check the content of ADAPTER_PKG_CONFIG_LIBS above."
+        log "- Is preCICE discoverable at runtime? Check the content of pkg-config output above."
+        log "- Did anything go wrong while installing preCICE? Can you run any other preCICE tutorials?"
+        log "- Did anything go wrong while installing OpenFOAM? Can you run any other OpenFOAM tutorials?"
         log "See wmake.log and ldd.log for more details."
+        log "Attach your Allwmake.log, wmake.log, and ldd.log when asking for help."
     else
         log "=== OK: Building completed successfully! ==="
     fi

--- a/changelog-entries/220.md
+++ b/changelog-entries/220.md
@@ -1,0 +1,1 @@
+- Added a warning for trying to build without pkg-config being available and more suggestions for possible problems [#220](https://github.com/precice/openfoam-adapter/pull/220).


### PR DESCRIPTION
This extend the `Allwmake` output to propose more ideas when something is going wrong during building. Inspired by recent topics on Discourse.

@DavidSCN do you think we should add anything else here?

TODO list:

- [x] I updated the documentation in `docs/` -> N/A
- [x] I added a changelog entry in `changelog-entries/` (create directory if missing) ~~-> Not sure if we really need one.~~ added
