### PR TITLE
Implement restart from reference configuration

### DIFF
--- a/Adapter.C
+++ b/Adapter.C
@@ -110,6 +110,10 @@ bool preciceAdapter::Adapter::configFileRead()
                     }
                     DEBUG(adapterInfo("    connectivity : " + std::to_string(interfaceConfig.meshConnectivity)));
 
+                    // Reset the displacement when defining the interface
+                    interfaceConfig.resetDisplacement = interfaceDict.lookupOrDefault<bool>("resetDisplacement", true);
+                    DEBUG(adapterInfo("    reset displacement : " + std::to_string(interfaceConfig.resetDisplacement)));
+
                     DEBUG(adapterInfo("    patches      : "));
                     auto patches = interfaceDict.get<wordList>("patches");
                     for (auto patch : patches)
@@ -249,7 +253,7 @@ void preciceAdapter::Adapter::configure()
         DEBUG(adapterInfo("Creating interfaces..."));
         for (uint i = 0; i < interfacesConfig_.size(); i++)
         {
-            Interface* interface = new Interface(*precice_, mesh_, interfacesConfig_.at(i).meshName, interfacesConfig_.at(i).locationsType, interfacesConfig_.at(i).patchNames, interfacesConfig_.at(i).meshConnectivity);
+            Interface* interface = new Interface(*precice_, mesh_, interfacesConfig_.at(i).meshName, interfacesConfig_.at(i).locationsType, interfacesConfig_.at(i).patchNames, interfacesConfig_.at(i).meshConnectivity, interfacesConfig_.at(i).resetDisplacement);
             interfaces_.push_back(interface);
             DEBUG(adapterInfo("Interface created on mesh " + interfacesConfig_.at(i).meshName));
 

--- a/Adapter.C
+++ b/Adapter.C
@@ -114,8 +114,8 @@ bool preciceAdapter::Adapter::configFileRead()
                     // We do this by resetting the displacement when defining the interface.
                     // Since this is a feature that may not work as expected, depending on the implementation of the
                     // structure solver used, we make this feature opt-in.
-                    interfaceConfig.restoreUndeformedInterface = interfaceDict.lookupOrDefault<bool>("restoreUndeformedInterface", false);
-                    DEBUG(adapterInfo("    restore undeformed interface : " + std::to_string(interfaceConfig.restoreUndeformedInterface)));
+                    interfaceConfig.restartFromDeformed = interfaceDict.lookupOrDefault<bool>("restartFromDeformed", true);
+                    DEBUG(adapterInfo("    restart from deformed : " + std::to_string(interfaceConfig.restartFromDeformed)));
 
                     DEBUG(adapterInfo("    patches      : "));
                     auto patches = interfaceDict.get<wordList>("patches");
@@ -259,7 +259,7 @@ void preciceAdapter::Adapter::configure()
             std::string namePointDisplacement = FSIenabled_ ? FSI_->getPointDisplacementFieldName() : "default";
             std::string nameCellDisplacement = FSIenabled_ ? FSI_->getCellDisplacementFieldName() : "default";
 
-            Interface* interface = new Interface(*precice_, mesh_, interfacesConfig_.at(i).meshName, interfacesConfig_.at(i).locationsType, interfacesConfig_.at(i).patchNames, interfacesConfig_.at(i).meshConnectivity, interfacesConfig_.at(i).restoreUndeformedInterface, namePointDisplacement, nameCellDisplacement);
+            Interface* interface = new Interface(*precice_, mesh_, interfacesConfig_.at(i).meshName, interfacesConfig_.at(i).locationsType, interfacesConfig_.at(i).patchNames, interfacesConfig_.at(i).meshConnectivity, interfacesConfig_.at(i).restartFromDeformed, namePointDisplacement, nameCellDisplacement);
             interfaces_.push_back(interface);
             DEBUG(adapterInfo("Interface created on mesh " + interfacesConfig_.at(i).meshName));
 

--- a/Adapter.C
+++ b/Adapter.C
@@ -113,7 +113,7 @@ bool preciceAdapter::Adapter::configFileRead()
                     // When restarting FSI simulations, we may need to account for previous displacement.
                     // We do this by resetting the displacement when defining the interface.
                     // Since this is a feature that may not work as expected, depending on the implementation of the
-                    // structure solver used, we allow the user to enable this feature.
+                    // structure solver used, we make this feature opt-in.
                     interfaceConfig.resetDisplacement = interfaceDict.lookupOrDefault<bool>("resetDisplacement", false);
                     DEBUG(adapterInfo("    reset displacement : " + std::to_string(interfaceConfig.resetDisplacement)));
 

--- a/Adapter.C
+++ b/Adapter.C
@@ -251,7 +251,7 @@ void preciceAdapter::Adapter::configure()
         {
             std::string namePointDisplacement = FSIenabled_ ? FSI_->getPointDisplacementFieldName() : "default";
             std::string nameCellDisplacement = FSIenabled_ ? FSI_->getCellDisplacementFieldName() : "default";
-            bool restartFromDeformed = FSIenabled_ ? FSI_->restartFromDeformed() : false;
+            bool restartFromDeformed = FSIenabled_ ? FSI_->isRestartingFromDeformed() : false;
 
             Interface* interface = new Interface(*precice_, mesh_, interfacesConfig_.at(i).meshName, interfacesConfig_.at(i).locationsType, interfacesConfig_.at(i).patchNames, interfacesConfig_.at(i).meshConnectivity, restartFromDeformed, namePointDisplacement, nameCellDisplacement);
             interfaces_.push_back(interface);

--- a/Adapter.C
+++ b/Adapter.C
@@ -114,8 +114,8 @@ bool preciceAdapter::Adapter::configFileRead()
                     // We do this by resetting the displacement when defining the interface.
                     // Since this is a feature that may not work as expected, depending on the implementation of the
                     // structure solver used, we make this feature opt-in.
-                    interfaceConfig.resetDisplacement = interfaceDict.lookupOrDefault<bool>("resetDisplacement", false);
-                    DEBUG(adapterInfo("    reset displacement : " + std::to_string(interfaceConfig.resetDisplacement)));
+                    interfaceConfig.restoreUndeformedInterface = interfaceDict.lookupOrDefault<bool>("restoreUndeformedInterface", false);
+                    DEBUG(adapterInfo("    restore undeformed interface : " + std::to_string(interfaceConfig.restoreUndeformedInterface)));
 
                     DEBUG(adapterInfo("    patches      : "));
                     auto patches = interfaceDict.get<wordList>("patches");
@@ -259,7 +259,7 @@ void preciceAdapter::Adapter::configure()
             std::string namePointDisplacement = FSIenabled_ ? FSI_->getPointDisplacementFieldName() : "default";
             std::string nameCellDisplacement = FSIenabled_ ? FSI_->getCellDisplacementFieldName() : "default";
 
-            Interface* interface = new Interface(*precice_, mesh_, interfacesConfig_.at(i).meshName, interfacesConfig_.at(i).locationsType, interfacesConfig_.at(i).patchNames, interfacesConfig_.at(i).meshConnectivity, interfacesConfig_.at(i).resetDisplacement, namePointDisplacement, nameCellDisplacement);
+            Interface* interface = new Interface(*precice_, mesh_, interfacesConfig_.at(i).meshName, interfacesConfig_.at(i).locationsType, interfacesConfig_.at(i).patchNames, interfacesConfig_.at(i).meshConnectivity, interfacesConfig_.at(i).restoreUndeformedInterface, namePointDisplacement, nameCellDisplacement);
             interfaces_.push_back(interface);
             DEBUG(adapterInfo("Interface created on mesh " + interfacesConfig_.at(i).meshName));
 

--- a/Adapter.C
+++ b/Adapter.C
@@ -111,7 +111,7 @@ bool preciceAdapter::Adapter::configFileRead()
                     DEBUG(adapterInfo("    connectivity : " + std::to_string(interfaceConfig.meshConnectivity)));
 
                     // Reset the displacement when defining the interface
-                    interfaceConfig.resetDisplacement = interfaceDict.lookupOrDefault<bool>("resetDisplacement", true);
+                    interfaceConfig.resetDisplacement = interfaceDict.lookupOrDefault<bool>("resetDisplacement", false);
                     DEBUG(adapterInfo("    reset displacement : " + std::to_string(interfaceConfig.resetDisplacement)));
 
                     DEBUG(adapterInfo("    patches      : "));

--- a/Adapter.C
+++ b/Adapter.C
@@ -253,7 +253,14 @@ void preciceAdapter::Adapter::configure()
         DEBUG(adapterInfo("Creating interfaces..."));
         for (uint i = 0; i < interfacesConfig_.size(); i++)
         {
-            Interface* interface = new Interface(*precice_, mesh_, interfacesConfig_.at(i).meshName, interfacesConfig_.at(i).locationsType, interfacesConfig_.at(i).patchNames, interfacesConfig_.at(i).meshConnectivity, interfacesConfig_.at(i).resetDisplacement);
+            std::string namePointDisplacement = "pointDisplacement";
+            std::string nameCellDisplacement = "cellDisplacement";
+            if (FSIenabled_)
+            {
+                namePointDisplacement = FSI_->namePointDisplacement;
+                nameCellDisplacement = FSI_->nameCellDisplacement;
+            }
+            Interface* interface = new Interface(*precice_, mesh_, interfacesConfig_.at(i).meshName, interfacesConfig_.at(i).locationsType, interfacesConfig_.at(i).patchNames, interfacesConfig_.at(i).meshConnectivity, interfacesConfig_.at(i).resetDisplacement, namePointDisplacement, nameCellDisplacement);
             interfaces_.push_back(interface);
             DEBUG(adapterInfo("Interface created on mesh " + interfacesConfig_.at(i).meshName));
 

--- a/Adapter.C
+++ b/Adapter.C
@@ -110,13 +110,6 @@ bool preciceAdapter::Adapter::configFileRead()
                     }
                     DEBUG(adapterInfo("    connectivity : " + std::to_string(interfaceConfig.meshConnectivity)));
 
-                    // When restarting FSI simulations, we may need to account for previous displacement.
-                    // We do this by resetting the displacement when defining the interface.
-                    // Since this is a feature that may not work as expected, depending on the implementation of the
-                    // structure solver used, we make this feature opt-in.
-                    interfaceConfig.restartFromDeformed = interfaceDict.lookupOrDefault<bool>("restartFromDeformed", true);
-                    DEBUG(adapterInfo("    restart from deformed : " + std::to_string(interfaceConfig.restartFromDeformed)));
-
                     DEBUG(adapterInfo("    patches      : "));
                     auto patches = interfaceDict.get<wordList>("patches");
                     for (auto patch : patches)
@@ -258,8 +251,9 @@ void preciceAdapter::Adapter::configure()
         {
             std::string namePointDisplacement = FSIenabled_ ? FSI_->getPointDisplacementFieldName() : "default";
             std::string nameCellDisplacement = FSIenabled_ ? FSI_->getCellDisplacementFieldName() : "default";
+            bool restartFromDeformed = FSIenabled_ ? FSI_->restartFromDeformed() : false;
 
-            Interface* interface = new Interface(*precice_, mesh_, interfacesConfig_.at(i).meshName, interfacesConfig_.at(i).locationsType, interfacesConfig_.at(i).patchNames, interfacesConfig_.at(i).meshConnectivity, interfacesConfig_.at(i).restartFromDeformed, namePointDisplacement, nameCellDisplacement);
+            Interface* interface = new Interface(*precice_, mesh_, interfacesConfig_.at(i).meshName, interfacesConfig_.at(i).locationsType, interfacesConfig_.at(i).patchNames, interfacesConfig_.at(i).meshConnectivity, restartFromDeformed, namePointDisplacement, nameCellDisplacement);
             interfaces_.push_back(interface);
             DEBUG(adapterInfo("Interface created on mesh " + interfacesConfig_.at(i).meshName));
 

--- a/Adapter.C
+++ b/Adapter.C
@@ -256,8 +256,8 @@ void preciceAdapter::Adapter::configure()
         DEBUG(adapterInfo("Creating interfaces..."));
         for (uint i = 0; i < interfacesConfig_.size(); i++)
         {
-            std::string namePointDisplacement = FSIenabled_ ? FSI_->namePointDisplacement : "default";
-            std::string nameCellDisplacement = FSIenabled_ ? FSI_->nameCellDisplacement : "default";
+            std::string namePointDisplacement = FSIenabled_ ? FSI_->getPointDisplacementFieldName() : "default";
+            std::string nameCellDisplacement = FSIenabled_ ? FSI_->getCellDisplacementFieldName() : "default";
 
             Interface* interface = new Interface(*precice_, mesh_, interfacesConfig_.at(i).meshName, interfacesConfig_.at(i).locationsType, interfacesConfig_.at(i).patchNames, interfacesConfig_.at(i).meshConnectivity, interfacesConfig_.at(i).resetDisplacement, namePointDisplacement, nameCellDisplacement);
             interfaces_.push_back(interface);

--- a/Adapter.C
+++ b/Adapter.C
@@ -110,7 +110,10 @@ bool preciceAdapter::Adapter::configFileRead()
                     }
                     DEBUG(adapterInfo("    connectivity : " + std::to_string(interfaceConfig.meshConnectivity)));
 
-                    // Reset the displacement when defining the interface
+                    // When restarting FSI simulations, we may need to account for previous displacement.
+                    // We do this by resetting the displacement when defining the interface.
+                    // Since this is a feature that may not work as expected, depending on the implementation of the
+                    // structure solver used, we allow the user to enable this feature.
                     interfaceConfig.resetDisplacement = interfaceDict.lookupOrDefault<bool>("resetDisplacement", false);
                     DEBUG(adapterInfo("    reset displacement : " + std::to_string(interfaceConfig.resetDisplacement)));
 

--- a/Adapter.C
+++ b/Adapter.C
@@ -253,13 +253,9 @@ void preciceAdapter::Adapter::configure()
         DEBUG(adapterInfo("Creating interfaces..."));
         for (uint i = 0; i < interfacesConfig_.size(); i++)
         {
-            std::string namePointDisplacement = "pointDisplacement";
-            std::string nameCellDisplacement = "cellDisplacement";
-            if (FSIenabled_)
-            {
-                namePointDisplacement = FSI_->namePointDisplacement;
-                nameCellDisplacement = FSI_->nameCellDisplacement;
-            }
+            std::string namePointDisplacement = FSIenabled_ ? FSI_->namePointDisplacement : "default";
+            std::string nameCellDisplacement = FSIenabled_ ? FSI_->nameCellDisplacement : "default";
+
             Interface* interface = new Interface(*precice_, mesh_, interfacesConfig_.at(i).meshName, interfacesConfig_.at(i).locationsType, interfacesConfig_.at(i).patchNames, interfacesConfig_.at(i).meshConnectivity, interfacesConfig_.at(i).resetDisplacement, namePointDisplacement, nameCellDisplacement);
             interfaces_.push_back(interface);
             DEBUG(adapterInfo("Interface created on mesh " + interfacesConfig_.at(i).meshName));

--- a/Adapter.C
+++ b/Adapter.C
@@ -161,10 +161,9 @@ bool preciceAdapter::Adapter::configFileRead()
                 if (interfacesConfig_.at(i).meshConnectivity == true)
                 {
                     adapterInfo(
-                        "Mesh connectivity is not supported for FSI, as, usually, "
-                        "the Solid participant needs to provide the connectivity information. "
-                        "Therefore, set provideMeshConnectivity = false. "
-                        "Have a look in the adapter documentation for more information. ",
+                        "You have requested mesh connectivity (most probably for nearest-projection mapping) "
+                        "and you have enabled the FSI module. "
+                        "Mapping with connectivity information is not implemented for FSI, only for CHT-related fields. "
                         "warning");
                     return false;
                 }

--- a/Adapter.H
+++ b/Adapter.H
@@ -40,7 +40,7 @@ private:
         std::string meshName;
         std::string locationsType;
         bool meshConnectivity;
-        bool resetDisplacement;
+        bool restoreUndeformedInterface;
         std::vector<std::string> patchNames;
         std::vector<std::string> writeData;
         std::vector<std::string> readData;

--- a/Adapter.H
+++ b/Adapter.H
@@ -40,7 +40,7 @@ private:
         std::string meshName;
         std::string locationsType;
         bool meshConnectivity;
-        bool restoreUndeformedInterface;
+        bool restartFromDeformed;
         std::vector<std::string> patchNames;
         std::vector<std::string> writeData;
         std::vector<std::string> readData;

--- a/Adapter.H
+++ b/Adapter.H
@@ -40,6 +40,7 @@ private:
         std::string meshName;
         std::string locationsType;
         bool meshConnectivity;
+        bool resetDisplacement;
         std::vector<std::string> patchNames;
         std::vector<std::string> writeData;
         std::vector<std::string> readData;

--- a/Adapter.H
+++ b/Adapter.H
@@ -40,7 +40,6 @@ private:
         std::string meshName;
         std::string locationsType;
         bool meshConnectivity;
-        bool restartFromDeformed;
         std::vector<std::string> patchNames;
         std::vector<std::string> writeData;
         std::vector<std::string> readData;

--- a/FSI/FSI.C
+++ b/FSI/FSI.C
@@ -234,7 +234,7 @@ std::string preciceAdapter::FSI::FluidStructureInteraction::getPointDisplacement
     return namePointDisplacement_;
 }
 
-bool preciceAdapter::FSI::FluidStructureInteraction::restartFromDeformed()
+bool preciceAdapter::FSI::FluidStructureInteraction::isRestartingFromDeformed()
 {
     return restartFromDeformed_;
 }

--- a/FSI/FSI.C
+++ b/FSI/FSI.C
@@ -61,13 +61,15 @@ bool preciceAdapter::FSI::FluidStructureInteraction::readConfig(const IOdictiona
     // structure solver used, we make this feature opt-in.
     restartFromDeformed_ = FSIdict.lookupOrDefault<bool>("restartFromDeformed", true);
 
-    DEBUG(adapterInfo("    restart from deformed : " + std::to_string(restartFromDeformed_)));
-
     if (solverType_ == "solid" && !restartFromDeformed_)
     {
         adapterInfo("The option \"restartFromDeformed\" is only valid for Fluid solvers. Solid solvers usually use exclusively the reference configuration for computations and the mesh is not deforming over time.", "error");
     }
 
+    if (solverType_ != "solid")
+    {
+        DEBUG(adapterInfo("    restart from deformed : " + std::to_string(restartFromDeformed_)));
+    }
     /* TODO: Read the names of any needed fields and parameters.
      * Include the force here?
      */

--- a/FSI/FSI.C
+++ b/FSI/FSI.C
@@ -55,6 +55,14 @@ bool preciceAdapter::FSI::FluidStructureInteraction::readConfig(const IOdictiona
     solverType_ = FSIdict.lookupOrDefault<word>("solverType", "");
     DEBUG(adapterInfo("    user-defined solver type : " + solverType_));
 
+    // When restarting FSI simulations, we may need to account for previous displacement.
+    // We do this by resetting the displacement when defining the interface.
+    // Since this is a feature that may not work as expected, depending on the implementation of the
+    // structure solver used, we make this feature opt-in.
+    restartFromDeformed_ = FSIdict.lookupOrDefault<bool>("restartFromDeformed", true);
+
+    DEBUG(adapterInfo("    restart from deformed : " + restartFromDeformed_));
+
     /* TODO: Read the names of any needed fields and parameters.
      * Include the force here?
      */
@@ -219,4 +227,9 @@ std::string preciceAdapter::FSI::FluidStructureInteraction::getCellDisplacementF
 std::string preciceAdapter::FSI::FluidStructureInteraction::getPointDisplacementFieldName()
 {
     return namePointDisplacement_;
+}
+
+bool preciceAdapter::FSI::FluidStructureInteraction::restartFromDeformed()
+{
+    return restartFromDeformed_;
 }

--- a/FSI/FSI.C
+++ b/FSI/FSI.C
@@ -63,9 +63,9 @@ bool preciceAdapter::FSI::FluidStructureInteraction::readConfig(const IOdictiona
 
     DEBUG(adapterInfo("    restart from deformed : " + std::to_string(restartFromDeformed_)));
 
-    if (solverType_.compare("solid") && !restartFromDeformed_)
+    if (solverType_ == "solid" && !restartFromDeformed_)
     {
-        adapterInfo("Solid solvers usually use exclusively the reference configuration for computations and the mesh is not deforming over time. Therefore, you have to set \"restartFromDeformed = true\" in order to restart from the initial configuraiton.", "warning");
+        adapterInfo("The option \"restartFromDeformed\" is only valid for Fluid solvers. Solid solvers usually use exclusively the reference configuration for computations and the mesh is not deforming over time.", "error");
     }
 
     /* TODO: Read the names of any needed fields and parameters.

--- a/FSI/FSI.C
+++ b/FSI/FSI.C
@@ -60,12 +60,12 @@ bool preciceAdapter::FSI::FluidStructureInteraction::readConfig(const IOdictiona
      */
 
     // Read the name of the pointDisplacement field (if different)
-    namePointDisplacement = FSIdict.lookupOrDefault<word>("namePointDisplacement", "pointDisplacement");
-    DEBUG(adapterInfo("    pointDisplacement field name : " + namePointDisplacement));
+    namePointDisplacement_ = FSIdict.lookupOrDefault<word>("namePointDisplacement", "pointDisplacement");
+    DEBUG(adapterInfo("    pointDisplacement field name : " + namePointDisplacement_));
 
     // Read the name of the pointDisplacement field (if different)
-    nameCellDisplacement = FSIdict.lookupOrDefault<word>("nameCellDisplacement", "cellDisplacement");
-    DEBUG(adapterInfo("    cellDisplacement field name : " + nameCellDisplacement));
+    nameCellDisplacement_ = FSIdict.lookupOrDefault<word>("nameCellDisplacement", "cellDisplacement");
+    DEBUG(adapterInfo("    cellDisplacement field name : " + nameCellDisplacement_));
 
     // Read the name of the solidForce field (if different)
     nameSolidForce_ = FSIdict.lookupOrDefault<word>("nameSolidForce", "solidForce");
@@ -131,14 +131,14 @@ bool preciceAdapter::FSI::FluidStructureInteraction::addWriters(std::string data
     {
         interface->addCouplingDataWriter(
             dataName,
-            new DisplacementDelta(mesh_, namePointDisplacement, nameCellDisplacement));
+            new DisplacementDelta(mesh_, namePointDisplacement_, nameCellDisplacement_));
         DEBUG(adapterInfo("Added writer: DisplacementDelta."));
     }
     else if (dataName.find("Displacement") == 0)
     {
         interface->addCouplingDataWriter(
             dataName,
-            new Displacement(mesh_, namePointDisplacement, nameCellDisplacement));
+            new Displacement(mesh_, namePointDisplacement_, nameCellDisplacement_));
         DEBUG(adapterInfo("Added writer: Displacement."));
     }
     else if (dataName.find("Stress") == 0)
@@ -179,14 +179,14 @@ bool preciceAdapter::FSI::FluidStructureInteraction::addReaders(std::string data
     {
         interface->addCouplingDataReader(
             dataName,
-            new DisplacementDelta(mesh_, namePointDisplacement, nameCellDisplacement));
+            new DisplacementDelta(mesh_, namePointDisplacement_, nameCellDisplacement_));
         DEBUG(adapterInfo("Added reader: DisplacementDelta."));
     }
     else if (dataName.find("Displacement") == 0)
     {
         interface->addCouplingDataReader(
             dataName,
-            new Displacement(mesh_, namePointDisplacement, nameCellDisplacement));
+            new Displacement(mesh_, namePointDisplacement_, nameCellDisplacement_));
         DEBUG(adapterInfo("Added reader: Displacement."));
     }
     else if (dataName.find("Stress") == 0)

--- a/FSI/FSI.C
+++ b/FSI/FSI.C
@@ -65,7 +65,7 @@ bool preciceAdapter::FSI::FluidStructureInteraction::readConfig(const IOdictiona
 
     if (solverType_.compare("solid") && !restartFromDeformed_)
     {
-        adapterInfo("Solid solvers usually use exclusively the reference configuration for computations and the mesh is not deforming over time. Therefore, you have to set \"restartFromDeformed = true\" in order to restart from the initial configuraiton.", "warning")
+        adapterInfo("Solid solvers usually use exclusively the reference configuration for computations and the mesh is not deforming over time. Therefore, you have to set \"restartFromDeformed = true\" in order to restart from the initial configuraiton.", "warning");
     }
 
     /* TODO: Read the names of any needed fields and parameters.

--- a/FSI/FSI.C
+++ b/FSI/FSI.C
@@ -63,6 +63,11 @@ bool preciceAdapter::FSI::FluidStructureInteraction::readConfig(const IOdictiona
 
     DEBUG(adapterInfo("    restart from deformed : " + std::to_string(restartFromDeformed_)));
 
+    if (solverType_.compare("solid") && !restartFromDeformed_)
+    {
+        adapterInfo("Solid solvers usually use exclusively the reference configuration for computations and the mesh is not deforming over time. Therefore, you have to set \"restartFromDeformed = true\" in order to restart from the initial configuraiton.", "warning")
+    }
+
     /* TODO: Read the names of any needed fields and parameters.
      * Include the force here?
      */

--- a/FSI/FSI.C
+++ b/FSI/FSI.C
@@ -61,7 +61,7 @@ bool preciceAdapter::FSI::FluidStructureInteraction::readConfig(const IOdictiona
     // structure solver used, we make this feature opt-in.
     restartFromDeformed_ = FSIdict.lookupOrDefault<bool>("restartFromDeformed", true);
 
-    DEBUG(adapterInfo("    restart from deformed : " + restartFromDeformed_));
+    DEBUG(adapterInfo("    restart from deformed : " + std::to_string(restartFromDeformed_)));
 
     /* TODO: Read the names of any needed fields and parameters.
      * Include the force here?

--- a/FSI/FSI.C
+++ b/FSI/FSI.C
@@ -210,3 +210,13 @@ bool preciceAdapter::FSI::FluidStructureInteraction::addReaders(std::string data
 
     return found;
 }
+
+std::string preciceAdapter::FSI::FluidStructureInteraction::getCellDisplacementFieldName()
+{
+    return nameCellDisplacement_;
+}
+
+std::string preciceAdapter::FSI::FluidStructureInteraction::getPointDisplacementFieldName()
+{
+    return namePointDisplacement_;
+}

--- a/FSI/FSI.C
+++ b/FSI/FSI.C
@@ -60,12 +60,12 @@ bool preciceAdapter::FSI::FluidStructureInteraction::readConfig(const IOdictiona
      */
 
     // Read the name of the pointDisplacement field (if different)
-    namePointDisplacement_ = FSIdict.lookupOrDefault<word>("namePointDisplacement", "pointDisplacement");
-    DEBUG(adapterInfo("    pointDisplacement field name : " + namePointDisplacement_));
+    namePointDisplacement = FSIdict.lookupOrDefault<word>("namePointDisplacement", "pointDisplacement");
+    DEBUG(adapterInfo("    pointDisplacement field name : " + namePointDisplacement));
 
     // Read the name of the pointDisplacement field (if different)
-    nameCellDisplacement_ = FSIdict.lookupOrDefault<word>("nameCellDisplacement", "cellDisplacement");
-    DEBUG(adapterInfo("    cellDisplacement field name : " + nameCellDisplacement_));
+    nameCellDisplacement = FSIdict.lookupOrDefault<word>("nameCellDisplacement", "cellDisplacement");
+    DEBUG(adapterInfo("    cellDisplacement field name : " + nameCellDisplacement));
 
     // Read the name of the solidForce field (if different)
     nameSolidForce_ = FSIdict.lookupOrDefault<word>("nameSolidForce", "solidForce");
@@ -131,14 +131,14 @@ bool preciceAdapter::FSI::FluidStructureInteraction::addWriters(std::string data
     {
         interface->addCouplingDataWriter(
             dataName,
-            new DisplacementDelta(mesh_, namePointDisplacement_, nameCellDisplacement_));
+            new DisplacementDelta(mesh_, namePointDisplacement, nameCellDisplacement));
         DEBUG(adapterInfo("Added writer: DisplacementDelta."));
     }
     else if (dataName.find("Displacement") == 0)
     {
         interface->addCouplingDataWriter(
             dataName,
-            new Displacement(mesh_, namePointDisplacement_, nameCellDisplacement_));
+            new Displacement(mesh_, namePointDisplacement, nameCellDisplacement));
         DEBUG(adapterInfo("Added writer: Displacement."));
     }
     else if (dataName.find("Stress") == 0)
@@ -179,14 +179,14 @@ bool preciceAdapter::FSI::FluidStructureInteraction::addReaders(std::string data
     {
         interface->addCouplingDataReader(
             dataName,
-            new DisplacementDelta(mesh_, namePointDisplacement_, nameCellDisplacement_));
+            new DisplacementDelta(mesh_, namePointDisplacement, nameCellDisplacement));
         DEBUG(adapterInfo("Added reader: DisplacementDelta."));
     }
     else if (dataName.find("Displacement") == 0)
     {
         interface->addCouplingDataReader(
             dataName,
-            new Displacement(mesh_, namePointDisplacement_, nameCellDisplacement_));
+            new Displacement(mesh_, namePointDisplacement, nameCellDisplacement));
         DEBUG(adapterInfo("Added reader: Displacement."));
     }
     else if (dataName.find("Stress") == 0)

--- a/FSI/FSI.H
+++ b/FSI/FSI.H
@@ -63,6 +63,12 @@ public:
 
     //- Add coupling data readers
     bool addReaders(std::string dataName, Interface* interface);
+
+    //- Return the nameCellDisplacement_ field name
+    std::string getCellDisplacementFieldName();
+
+    //- Return the namePointDisplacement_ field name
+    std::string getPointDisplacementFieldName();
 };
 
 }

--- a/FSI/FSI.H
+++ b/FSI/FSI.H
@@ -28,6 +28,9 @@ protected:
     //- Solver type
     std::string solverType_ = "none";
 
+    //- Restart a simulation from an undeformed or a deformed interface
+    bool restartFromDeformed_;
+
     //- Name of the pointDisplacement field
     std::string namePointDisplacement_ = "pointDisplacement";
 
@@ -69,6 +72,9 @@ public:
 
     //- Return the namePointDisplacement_ field name
     std::string getPointDisplacementFieldName();
+
+    //- Return the boolean variable stored in the class
+    bool restartFromDeformed();
 };
 
 }

--- a/FSI/FSI.H
+++ b/FSI/FSI.H
@@ -28,6 +28,12 @@ protected:
     //- Solver type
     std::string solverType_ = "none";
 
+    //- Name of the pointDisplacement field
+    std::string namePointDisplacement_ = "pointDisplacement";
+
+    //- Name of the pointDisplacement field
+    std::string nameCellDisplacement_ = "cellDisplacement";
+
     //- Name of the force field used by the solid
     std::string nameSolidForce_ = "solidForce";
 
@@ -57,12 +63,6 @@ public:
 
     //- Add coupling data readers
     bool addReaders(std::string dataName, Interface* interface);
-
-    //- Name of the pointDisplacement field
-    std::string namePointDisplacement = "pointDisplacement";
-
-    //- Name of the pointDisplacement field
-    std::string nameCellDisplacement = "cellDisplacement";
 };
 
 }

--- a/FSI/FSI.H
+++ b/FSI/FSI.H
@@ -74,7 +74,7 @@ public:
     std::string getPointDisplacementFieldName();
 
     //- Return the boolean variable stored in the class
-    bool restartFromDeformed();
+    bool isRestartingFromDeformed();
 };
 
 }

--- a/FSI/FSI.H
+++ b/FSI/FSI.H
@@ -28,12 +28,6 @@ protected:
     //- Solver type
     std::string solverType_ = "none";
 
-    //- Name of the pointDisplacement field
-    std::string namePointDisplacement_ = "pointDisplacement";
-
-    //- Name of the pointDisplacement field
-    std::string nameCellDisplacement_ = "cellDisplacement";
-
     //- Name of the force field used by the solid
     std::string nameSolidForce_ = "solidForce";
 
@@ -63,6 +57,12 @@ public:
 
     //- Add coupling data readers
     bool addReaders(std::string dataName, Interface* interface);
+
+    //- Name of the pointDisplacement field
+    std::string namePointDisplacement = "pointDisplacement";
+
+    //- Name of the pointDisplacement field
+    std::string nameCellDisplacement = "cellDisplacement";
 };
 
 }

--- a/Interface.C
+++ b/Interface.C
@@ -12,14 +12,14 @@ preciceAdapter::Interface::Interface(
     std::string locationsType,
     std::vector<std::string> patchNames,
     bool meshConnectivity,
-    bool restoreUndeformedInterface,
+    bool restartFromDeformed,
     const std::string& namePointDisplacement,
     const std::string& nameCellDisplacement)
 : precice_(precice),
   meshName_(meshName),
   patchNames_(patchNames),
   meshConnectivity_(meshConnectivity),
-  restoreUndeformedInterface_(restoreUndeformedInterface)
+  restartFromDeformed_(restartFromDeformed)
 {
     // Get the meshID from preCICE
     meshID_ = precice_.getMeshID(meshName_);
@@ -121,7 +121,7 @@ void preciceAdapter::Interface::configureMesh(const fvMesh& mesh, const std::str
             // to account for any displacements accumulated before restarting the simulation.
             // This is information that OpenFOAM reads from its result/restart files.
             // If the simulation is not restarted, the displacement should be zero and this line should have no effect.
-            if (cellDisplacement != nullptr && restoreUndeformedInterface_)
+            if (cellDisplacement != nullptr && restartFromDeformed_)
                 faceCenters -= cellDisplacement->boundaryField()[patchIDs_.at(j)];
 
             // Assign the (x,y,z) locations to the vertices
@@ -227,7 +227,7 @@ void preciceAdapter::Interface::configureMesh(const fvMesh& mesh, const std::str
             // to account for any displacements accumulated before restarting the simulation.
             // This is information that OpenFOAM reads from its result/restart files.
             // If the simulation is not restarted, the displacement should be zero and this line should have no effect.
-            if (pointDisplacement != nullptr && restoreUndeformedInterface_)
+            if (pointDisplacement != nullptr && restartFromDeformed_)
             {
                 const vectorField& resetField = refCast<const vectorField>(
                     pointDisplacement->boundaryField()[patchIDs_.at(j)]);
@@ -273,7 +273,7 @@ void preciceAdapter::Interface::configureMesh(const fvMesh& mesh, const std::str
                 Field<point> pointCoords = mesh.boundaryMesh()[patchIDs_.at(j)].localPoints();
 
                 // Subtract the displacement part in case we have deformation
-                if (pointDisplacement != nullptr && restoreUndeformedInterface_)
+                if (pointDisplacement != nullptr && restartFromDeformed_)
                 {
                     const vectorField& resetField = refCast<const vectorField>(
                         pointDisplacement->boundaryField()[patchIDs_.at(j)]);

--- a/Interface.C
+++ b/Interface.C
@@ -12,7 +12,9 @@ preciceAdapter::Interface::Interface(
     std::string locationsType,
     std::vector<std::string> patchNames,
     bool meshConnectivity,
-    bool resetDisplacement)
+    bool resetDisplacement,
+    const std::string& namePointDisplacement,
+    const std::string& nameCellDisplacement)
 : precice_(precice),
   meshName_(meshName),
   patchNames_(patchNames),
@@ -70,8 +72,7 @@ preciceAdapter::Interface::Interface(
     }
 
     // Configure the mesh (set the data locations)
-    // TODO: We need to extract the names from the FSI module in case it was enabled
-    configureMesh(mesh, "pointDisplacement", "cellDisplacement");
+    configureMesh(mesh, namePointDisplacement, nameCellDisplacement);
 }
 
 void preciceAdapter::Interface::configureMesh(const fvMesh& mesh, const std::string& namePointDisplacement, const std::string& nameCellDisplacement)

--- a/Interface.C
+++ b/Interface.C
@@ -121,7 +121,7 @@ void preciceAdapter::Interface::configureMesh(const fvMesh& mesh, const std::str
             // to account for any displacements accumulated before restarting the simulation.
             // This is information that OpenFOAM reads from its result/restart files.
             // If the simulation is not restarted, the displacement should be zero and this line should have no effect.
-            if (cellDisplacement != nullptr && restartFromDeformed_)
+            if (cellDisplacement != nullptr && !restartFromDeformed_)
                 faceCenters -= cellDisplacement->boundaryField()[patchIDs_.at(j)];
 
             // Assign the (x,y,z) locations to the vertices
@@ -227,7 +227,7 @@ void preciceAdapter::Interface::configureMesh(const fvMesh& mesh, const std::str
             // to account for any displacements accumulated before restarting the simulation.
             // This is information that OpenFOAM reads from its result/restart files.
             // If the simulation is not restarted, the displacement should be zero and this line should have no effect.
-            if (pointDisplacement != nullptr && restartFromDeformed_)
+            if (pointDisplacement != nullptr && !restartFromDeformed_)
             {
                 const vectorField& resetField = refCast<const vectorField>(
                     pointDisplacement->boundaryField()[patchIDs_.at(j)]);
@@ -273,7 +273,7 @@ void preciceAdapter::Interface::configureMesh(const fvMesh& mesh, const std::str
                 Field<point> pointCoords = mesh.boundaryMesh()[patchIDs_.at(j)].localPoints();
 
                 // Subtract the displacement part in case we have deformation
-                if (pointDisplacement != nullptr && restartFromDeformed_)
+                if (pointDisplacement != nullptr && !restartFromDeformed_)
                 {
                     const vectorField& resetField = refCast<const vectorField>(
                         pointDisplacement->boundaryField()[patchIDs_.at(j)]);

--- a/Interface.C
+++ b/Interface.C
@@ -12,14 +12,14 @@ preciceAdapter::Interface::Interface(
     std::string locationsType,
     std::vector<std::string> patchNames,
     bool meshConnectivity,
-    bool resetDisplacement,
+    bool restoreUndeformedInterface,
     const std::string& namePointDisplacement,
     const std::string& nameCellDisplacement)
 : precice_(precice),
   meshName_(meshName),
   patchNames_(patchNames),
   meshConnectivity_(meshConnectivity),
-  resetDisplacement_(resetDisplacement)
+  restoreUndeformedInterface_(restoreUndeformedInterface)
 {
     // Get the meshID from preCICE
     meshID_ = precice_.getMeshID(meshName_);
@@ -121,7 +121,7 @@ void preciceAdapter::Interface::configureMesh(const fvMesh& mesh, const std::str
             // to account for any displacements accumulated before restarting the simulation.
             // This is information that OpenFOAM reads from its result/restart files.
             // If the simulation is not restarted, the displacement should be zero and this line should have no effect.
-            if (cellDisplacement != nullptr && resetDisplacement_)
+            if (cellDisplacement != nullptr && restoreUndeformedInterface_)
                 faceCenters -= cellDisplacement->boundaryField()[patchIDs_.at(j)];
 
             // Assign the (x,y,z) locations to the vertices
@@ -227,7 +227,7 @@ void preciceAdapter::Interface::configureMesh(const fvMesh& mesh, const std::str
             // to account for any displacements accumulated before restarting the simulation.
             // This is information that OpenFOAM reads from its result/restart files.
             // If the simulation is not restarted, the displacement should be zero and this line should have no effect.
-            if (pointDisplacement != nullptr && resetDisplacement_)
+            if (pointDisplacement != nullptr && restoreUndeformedInterface_)
             {
                 const vectorField& resetField = refCast<const vectorField>(
                     pointDisplacement->boundaryField()[patchIDs_.at(j)]);
@@ -273,7 +273,7 @@ void preciceAdapter::Interface::configureMesh(const fvMesh& mesh, const std::str
                 Field<point> pointCoords = mesh.boundaryMesh()[patchIDs_.at(j)].localPoints();
 
                 // Subtract the displacement part in case we have deformation
-                if (pointDisplacement != nullptr && resetDisplacement_)
+                if (pointDisplacement != nullptr && restoreUndeformedInterface_)
                 {
                     const vectorField& resetField = refCast<const vectorField>(
                         pointDisplacement->boundaryField()[patchIDs_.at(j)]);

--- a/Interface.H
+++ b/Interface.H
@@ -52,7 +52,7 @@ protected:
     bool meshConnectivity_;
 
     //- Reset the displacement during interface definition
-    bool resetDisplacement_;
+    bool restoreUndeformedInterface_;
 
     // Simulation dimension
     unsigned int dim_;
@@ -72,7 +72,7 @@ public:
         std::string locationsType,
         std::vector<std::string> patchNames,
         bool meshConnectivity,
-        bool resetDisplacement,
+        bool restoreUndeformedInterface,
         const std::string& namePointDisplacement,
         const std::string& nameCellDisplacement);
 

--- a/Interface.H
+++ b/Interface.H
@@ -7,6 +7,7 @@
 #include "CouplingDataUser.H"
 #include "precice/SolverInterface.hpp"
 
+#include "pointPatchField.H"
 
 namespace preciceAdapter
 {
@@ -50,12 +51,17 @@ protected:
     //Switch for faceTriangulation (nearest projection)
     bool meshConnectivity_;
 
+    //- Reset the displacement during interface definition
+    bool resetDisplacement_;
+
     // Simulation dimension
     unsigned int dim_;
 
     //- Extracts the locations of the face centers or face nodes
     //  and exposes them to preCICE with setMeshVertices
-    void configureMesh(const Foam::fvMesh& mesh);
+    void configureMesh(const Foam::fvMesh& mesh,
+                       const std::string& namePointDisplacement,
+                       const std::string& nameCellDisplacement);
 
 public:
     //- Constructor
@@ -65,7 +71,8 @@ public:
         std::string meshName,
         std::string locationsType,
         std::vector<std::string> patchNames,
-        bool meshConnectivity);
+        bool meshConnectivity,
+        bool resetDisplacement);
 
     //- Add a CouplingDataUser to read data from the interface
     void addCouplingDataReader(

--- a/Interface.H
+++ b/Interface.H
@@ -72,7 +72,9 @@ public:
         std::string locationsType,
         std::vector<std::string> patchNames,
         bool meshConnectivity,
-        bool resetDisplacement);
+        bool resetDisplacement,
+        const std::string& namePointDisplacement,
+        const std::string& nameCellDisplacement);
 
     //- Add a CouplingDataUser to read data from the interface
     void addCouplingDataReader(

--- a/Interface.H
+++ b/Interface.H
@@ -52,7 +52,7 @@ protected:
     bool meshConnectivity_;
 
     //- Reset the displacement during interface definition
-    bool restoreUndeformedInterface_;
+    bool restartFromDeformed_;
 
     // Simulation dimension
     unsigned int dim_;
@@ -72,7 +72,7 @@ public:
         std::string locationsType,
         std::vector<std::string> patchNames,
         bool meshConnectivity,
-        bool restoreUndeformedInterface,
+        bool restartFromDeformed,
         const std::string& namePointDisplacement,
         const std::string& nameCellDisplacement);
 

--- a/changelog-entries/224.md
+++ b/changelog-entries/224.md
@@ -1,0 +1,1 @@
+- Added support for a restart from the initial undeformed interface mesh for FSI simulations [#224](https://github.com/precice/openfoam-adapter/pull/224).

--- a/changelog-entries/224.md
+++ b/changelog-entries/224.md
@@ -1,1 +1,1 @@
-- Added support for a restart from the initial undeformed interface mesh for FSI simulations [#224](https://github.com/precice/openfoam-adapter/pull/224).
+- Added support for a restart from the initial undeformed interface mesh for Fluid solvers in FSI simulations [#224](https://github.com/precice/openfoam-adapter/pull/224).

--- a/docs/config.md
+++ b/docs/config.md
@@ -440,7 +440,7 @@ Note that the adapter does not automatically adapt the pressure name for solvers
 
 #### Restarting FSI simulations
 
-Restarting a coupled simulation using the OpenFOAM adapter works in principle in the same way as restarting a standalone OpenFOAM solver. However, the adapter and preCICE always redefine the coupling interface and the interface node locations. In case of FSI simulations, the interface deforms over time, which leads to the definition of a deformed interface during the restart. The boolean variable `restoreUndeformedInterface` (`false` by default) allows to account for the previously accumulated interface deformation such that the initial interface configuration (`t = 0`) is completely recovered. The setting here needs to coincide with the behavior of the selected solid solver.
+Restarting a coupled simulation using the OpenFOAM adapter works in principle in the same way as restarting a standalone OpenFOAM solver. However, the adapter and preCICE define the coupling interface and the interface node locations based on the mesh at the particular time. In case of FSI simulations, the interface deforms over time, which leads to the definition of a deformed interface during the restart. The boolean variable `restoreUndeformedInterface` (`false` by default) allows to account for the previously accumulated interface deformation such that the initial interface configuration (`t = 0`) is completely recovered. The setting here needs to agree with the behavior of the selected solid solver.
 
 ```c++
 FSI

--- a/docs/config.md
+++ b/docs/config.md
@@ -451,7 +451,7 @@ FSI
 ```
 
 {% note %}
-The CalculiX adapter restarts simulations from the deformed interface mesh, so that the default setting `restoreUndeformedInterface false` should be used.
+The CalculiX adapter restarts simulations from the deformed interface mesh. This means that you need to set `restoreUndeformedInterface false`.
 {% endnote %}
 
 #### Debugging

--- a/docs/config.md
+++ b/docs/config.md
@@ -395,6 +395,22 @@ FSI
 
 Use the option `namePointDisplacement unused;` for solvers that do not create a pointDisplacement field, such as the RBFMeshMotionSolver.
 
+#### Restarting FSI simulations
+
+Restarting a coupled simulation using the OpenFOAM adapter works in principle in the same way as restarting a standalone OpenFOAM solver. However, the adapter and preCICE always redefine the coupling interface and the interface node locations. In case of FSI simulations, the interface deforms over time, which leads to the definition of a deformed interface during the restart. The boolean variable `resetDisplacement` (`false` by default) allows to account for the previously accumulated interface deformation such that the initial interface configuration (`t = 0`) is completely recovered. The setting here needs to coincide with the behavior of the selected solid solver.
+
+```c++
+FSI
+{
+    // Account for previous displacement during a restart
+    resetDisplacement true;
+}
+```
+
+{% note %}
+The CalculiX adapter restarts simulations from the deformed interface mesh.
+{% endnote %}
+
 #### Debugging
 
 The adapter also recognizes a few more parameters, which are mainly used in debugging or development.

--- a/docs/config.md
+++ b/docs/config.md
@@ -450,9 +450,9 @@ FSI
 }
 ```
 
-{% note %}
-The CalculiX adapter restarts simulations from the deformed interface mesh. This means that you need to set `restartFromDeformed true`.
-{% endnote %}
+{% important %}
+The option here defines the way the interface mesh is initialized when restarting an FSI simulation in OpenFOAM. In order to restart a coupled simulation, your solid solver needs to be capable of restarting mechanism as well. You can find more information about restarting coupled simulations on [Dsicourse](https://precice.discourse.group/t/how-can-i-restart-a-coupled-simulation/675).
+{% endimportant %}
 
 #### Debugging
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -440,18 +440,18 @@ Note that the adapter does not automatically adapt the pressure name for solvers
 
 #### Restarting FSI simulations
 
-Restarting a coupled simulation using the OpenFOAM adapter works in principle in the same way as restarting a standalone OpenFOAM solver. However, the adapter and preCICE define the coupling interface and the interface node locations based on the mesh at the particular time. In case of FSI simulations, the interface deforms over time, which leads to the definition of a deformed interface during the restart. The boolean variable `restoreUndeformedInterface` (`false` by default) allows to account for the previously accumulated interface deformation such that the initial interface configuration (`t = 0`) is completely recovered. The setting here needs to agree with the behavior of the selected solid solver.
+Restarting a coupled simulation using the OpenFOAM adapter works in principle in the same way as restarting a standalone OpenFOAM solver. However, the adapter and preCICE define the coupling interface and the interface node locations based on the mesh at the particular time. In case of FSI simulations, the interface deforms over time, which leads to the definition of a deformed interface during the restart. The boolean variable `restartFromDeformed` (`true` by default) allows to account for the previously accumulated interface deformation such that the initial interface configuration (`t = 0`) is completely recovered. The setting here needs to agree with the behavior of the selected solid solver.
 
 ```c++
 FSI
 {
     // Account for previous displacement during a restart
-    restoreUndeformedInterface true;
+    restartFromDeformed true;
 }
 ```
 
 {% note %}
-The CalculiX adapter restarts simulations from the deformed interface mesh. This means that you need to set `restoreUndeformedInterface false`.
+The CalculiX adapter restarts simulations from the deformed interface mesh. This means that you need to set `restartFromDeformed true`.
 {% endnote %}
 
 #### Debugging

--- a/docs/config.md
+++ b/docs/config.md
@@ -440,18 +440,18 @@ Note that the adapter does not automatically adapt the pressure name for solvers
 
 #### Restarting FSI simulations
 
-Restarting a coupled simulation using the OpenFOAM adapter works in principle in the same way as restarting a standalone OpenFOAM solver. However, the adapter and preCICE always redefine the coupling interface and the interface node locations. In case of FSI simulations, the interface deforms over time, which leads to the definition of a deformed interface during the restart. The boolean variable `resetDisplacement` (`false` by default) allows to account for the previously accumulated interface deformation such that the initial interface configuration (`t = 0`) is completely recovered. The setting here needs to coincide with the behavior of the selected solid solver.
+Restarting a coupled simulation using the OpenFOAM adapter works in principle in the same way as restarting a standalone OpenFOAM solver. However, the adapter and preCICE always redefine the coupling interface and the interface node locations. In case of FSI simulations, the interface deforms over time, which leads to the definition of a deformed interface during the restart. The boolean variable `restoreUndeformedInterface` (`false` by default) allows to account for the previously accumulated interface deformation such that the initial interface configuration (`t = 0`) is completely recovered. The setting here needs to coincide with the behavior of the selected solid solver.
 
 ```c++
 FSI
 {
     // Account for previous displacement during a restart
-    resetDisplacement true;
+    restoreUndeformedInterface true;
 }
 ```
 
 {% note %}
-The CalculiX adapter restarts simulations from the deformed interface mesh.
+The CalculiX adapter restarts simulations from the deformed interface mesh, so that the default setting `restoreUndeformedInterface false` should be used.
 {% endnote %}
 
 #### Debugging

--- a/docs/config.md
+++ b/docs/config.md
@@ -279,7 +279,7 @@ Data is obtained at the face centers, then interpolated to face nodes. Here, we 
 It is important to notice that the target data location is again the face center mesh of the coupling partner. In the standard CHT case, where both data sets are exchanged by a nearest-projection mapping, this leads to two interface meshes (centers and nodes) per participant. Having both the centers and nodes defined, we can skip one interpolation step and read data directly to the centers (cf. picture solver B).
 
 {% note %}
-As already mentioned, the `Fluid` participant does not need to provide the mesh connectivity in case of a standard FSI. Therefore, the `Solid` participant needs to provide it and nothing special needs to be considered compared to other mapping methods. This implementation supports all CHT-related fields, which are mapped with a `consistent` constraint.
+This is implemented for all CHT-related fields mapped with a `consistent` constraint, but it is not implemented for the `FSI` and `FF` modules.
 {% endnote %}
 
 ### Additional properties for some solvers


### PR DESCRIPTION
<!-- Thank you for your contribution! Have a look at the file `CONTRIBUTING.md` for a few hints and guidelines. -->
Closes #223 

With this, we can restart the 'initial' simulation by resetting the deformation accumulated throughout the simulation. It would be important to check how other (structural) codes handle the restart: If they define also the 'deformed' interface mesh when restarting, the reset here would be undesired. Do we have solver which behave this way? I only checked deal.II for now, and the functionality used there is entirely based on the initial configuration.

TODO list:

- [x] I updated the documentation in `docs/`
- [x] I added a changelog entry in `changelog-entries/` (create directory if missing)
