### PR TITLE
Add redirect_from adapter-openfoam.html

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,7 @@
 ---
 title: The OpenFOAM adapter
 permalink: adapter-openfoam-overview.html
+redirect_from: adapter-openfoam.html
 keywords: adapter, openfoam, cite, versions
 summary: An OpenFOAM function object for CHT, FSI, and fluid-fluid coupled simulations using preCICE.
 ---


### PR DESCRIPTION
This PR adds a redirection from `adapter-openfoam.html` to the overview page.

@MakisH would you also like to redirect from `adapter-of.html`?

TODO list:

- [x] I updated the documentation in `docs/`
- [ ] I added a changelog entry in `changelog-entries/` (create directory if missing)
