### PR TITLE
Add gradient data write functionality

### DIFF
--- a/CHT/Temperature.C
+++ b/CHT/Temperature.C
@@ -56,6 +56,21 @@ void preciceAdapter::CHT::Temperature::write(double* buffer, bool meshConnectivi
     }
 }
 
+void preciceAdapter::CHT::Temperature::writeGradients(std::vector<double>& gradientBuffer, const unsigned int dim)
+{
+    for (const label patchID : patchIDs_)
+    {
+        const auto& TGrad = fvc::grad(*T_);
+        forAll(TGrad().boundaryField()[patchID], i)
+        {
+            for (unsigned int d = 0; d < dim; ++d)
+            {
+                gradientBuffer[i * dim + d] = TGrad().boundaryField()[patchID][i][d];
+            }
+        }
+    }
+}
+
 void preciceAdapter::CHT::Temperature::read(double* buffer, const unsigned int dim)
 {
     int bufferIndex = 0;

--- a/CHT/Temperature.H
+++ b/CHT/Temperature.H
@@ -28,6 +28,9 @@ public:
     //- Write the temperature values into the buffer
     void write(double* buffer, bool meshConnectivity, const unsigned int dim);
 
+    //- Write gradient data
+    void writeGradients(std::vector<double>& gradientBuffer, const unsigned int dim) override;
+
     //- Read the temperature values from the buffer
     void read(double* buffer, const unsigned int dim);
 

--- a/CouplingDataUser.C
+++ b/CouplingDataUser.C
@@ -36,6 +36,15 @@ void preciceAdapter::CouplingDataUser::setLocationsType(LocationType locationsTy
     locationType_ = locationsType;
 }
 
+void preciceAdapter::CouplingDataUser::writeGradients(std::vector<double>& gradientBuffer, const unsigned int dim)
+{
+    adapterInfo("Data \"" + getDataName() + "\" does not support writing gradients. Please select a different "
+                                      "data or a different mapping configuration, which does not require "
+                                      "additional gradient information.",
+                "error");
+}
+
+
 void preciceAdapter::CouplingDataUser::checkDataLocation(const bool meshConnectivity) const
 {
     if (this->isLocationTypeSupported(meshConnectivity) == false)

--- a/CouplingDataUser.H
+++ b/CouplingDataUser.H
@@ -69,6 +69,9 @@ public:
     //- Write the coupling data to the buffer
     virtual void write(double* dataBuffer, bool meshConnectivity, const unsigned int dim) = 0;
 
+    //- Write gradient data to the gradient buffer
+    virtual void writeGradients(std::vector<double>& gradientBuffer, const unsigned int dim);
+
     //- Read the coupling data from the buffer
     virtual void read(double* dataBuffer, const unsigned int dim) = 0;
 

--- a/Interface.C
+++ b/Interface.C
@@ -330,6 +330,7 @@ void preciceAdapter::Interface::createBuffer()
     // Will the interface buffer need to store 3D vector data?
     bool needsVectorData = false;
     int dataBufferSize = 0;
+    bool requiresGradientData = false;
 
     // Check all the coupling data readers
     for (uint i = 0; i < couplingDataReaders_.size(); i++)
@@ -346,6 +347,10 @@ void preciceAdapter::Interface::createBuffer()
         if (couplingDataWriters_.at(i)->hasVectorData())
         {
             needsVectorData = true;
+        }
+        if (precice_.isGradientDataRequired(couplingDataWriters_.at(i)->dataID()))
+        {
+            requiresGradientData = true;
         }
     }
 
@@ -367,6 +372,10 @@ void preciceAdapter::Interface::createBuffer()
     // preCICE implementation, it should work as, when writing scalars,
     // it should  only use the first 1/3 elements of the buffer.
     dataBuffer_ = new double[dataBufferSize]();
+    if (requiresGradientData)
+    {
+        gradientBuffer_.resize(dim_ * dataBufferSize);
+    }
 }
 
 void preciceAdapter::Interface::readCouplingData()
@@ -430,6 +439,15 @@ void preciceAdapter::Interface::writeCouplingData()
                 numDataLocations_,
                 vertexIDs_,
                 dataBuffer_);
+
+            if (precice_.isGradientDataRequired(couplingDataWriter->dataID()))
+            {
+                couplingDataWriter->writeGradients(gradientBuffer_, dim_);
+                precice_.writeBlockVectorGradientData(couplingDataWriter->dataID(),
+                                                      numDataLocations_,
+                                                      vertexIDs_,
+                                                      gradientBuffer_.data());
+            }
         }
         else
         {
@@ -438,6 +456,15 @@ void preciceAdapter::Interface::writeCouplingData()
                 numDataLocations_,
                 vertexIDs_,
                 dataBuffer_);
+
+            if (precice_.isGradientDataRequired(couplingDataWriter->dataID()))
+            {
+                couplingDataWriter->writeGradients(gradientBuffer_, dim_);
+                precice_.writeBlockScalarGradientData(couplingDataWriter->dataID(),
+                                                      numDataLocations_,
+                                                      vertexIDs_,
+                                                      gradientBuffer_.data());
+            }
         }
     }
     // }

--- a/Interface.H
+++ b/Interface.H
@@ -41,6 +41,9 @@ protected:
     //- Buffer for the coupling data
     double* dataBuffer_;
 
+    //- Buffer for writing gradient data
+    std::vector<double> gradientBuffer_;
+
     //- Vector of CouplingDataReaders
     std::vector<CouplingDataUser*> couplingDataReaders_;
 


### PR DESCRIPTION
... in case gradient data is required for the mapping.

The current changes only implement the functionality for a simple CHT case. We need to go through all relevant fields and have a look, where it makes sense to support this feature. We also need to find a proper solution in order to avoid code duplication in all the fields, as the 'write' step looks similar for all fields (mainly depending on the number of data components).

TODO list:

- [ ] I updated the documentation in `docs/`
- [ ] I added a changelog entry in `changelog-entries/` (create directory if missing)
