### PR TITLE
Add OpenFOAM 10 to GitHub Actions workflow

### DIFF
--- a/.github/workflows/build-custom.yml
+++ b/.github/workflows/build-custom.yml
@@ -101,6 +101,12 @@ jobs:
             wget -q -O - https://dl.openfoam.com/add-debian-repo.sh | sudo bash
             sudo apt-get install openfoam1912-dev
             echo "::set-output name=openfoam_exec::/usr/bin/openfoam1912";;
+          OpenFOAM10)
+            sudo sh -c "wget -O - https://dl.openfoam.org/gpg.key | apt-key add -"
+            sudo add-apt-repository http://dl.openfoam.org/ubuntu
+            sudo apt-get update
+            sudo apt-get -y install openfoam10
+            echo "::set-output name=openfoam_exec::. /opt/openfoam10/etc/bashrc &&";;
           OpenFOAM9)
             sudo sh -c "wget -O - https://dl.openfoam.org/gpg.key | apt-key add -"
             sudo add-apt-repository http://dl.openfoam.org/ubuntu

--- a/.github/workflows/build-custom.yml
+++ b/.github/workflows/build-custom.yml
@@ -25,6 +25,7 @@ on:
           - OpenFOAMv2012
           - OpenFOAMv2006
           - OpenFOAMv1912
+          - OpenFOAM10
           - OpenFOAM9
           - OpenFOAM8
           - OpenFOAM7


### PR DESCRIPTION
I ported (with some precious help from @jheylmun) the adapter to OpenFOAM 10 in the branch [OpenFOAM10](https://github.com/precice/openfoam-adapter/tree/OpenFOAM10). This PR just adds OpenFOAM 10 to the available options in the "custom build" GitHub Actions workflow.

TODO list:

- [x] I updated the documentation in `docs/`
- [ ] I added a changelog entry in `changelog-entries/` (create directory if missing)
