### PR TITLE
Remove -j 4 flag, document WM_NCOMPPROCS

### DIFF
--- a/Allwmake
+++ b/Allwmake
@@ -56,7 +56,7 @@ log ""
 log "Current OpenFOAM environment:"
 log "  WM_PROJECT = ${WM_PROJECT:-}"
 log "  WM_PROJECT_VERSION = ${WM_PROJECT_VERSION:-}"
-log "  WM_NCOMPPROCS = ${WM_NCOMP_PROCS:-} (set number for parallel builds)"
+log "  WM_NCOMPPROCS = ${WM_NCOMPPROCS:-} (number of threads for parallel builds)"
 
 if [ -z "${WM_PROJECT:-}" ]; then
     log ""

--- a/Allwmake
+++ b/Allwmake
@@ -7,10 +7,11 @@ set -e -u
 ADAPTER_PREP_FLAGS=""
 
 # Build command and options
-# In order to compile with multiple threads, add e.g. "-j 4".
+# In order to compile with multiple threads, set the environment variable WM_NCOMPPROCS,
+# e.g., add "export WM_NCOMP_PROCS=4" to your ~/.bashrc
 # Make sure that these options are supported by your OpenFOAM version.
 adapter_build_command(){
-    wmake -j 4 libso
+    wmake libso
 }
 
 # Where should the adapter be built? Default: "${FOAM_USER_LIBBIN}"
@@ -55,6 +56,7 @@ log ""
 log "Current OpenFOAM environment:"
 log "  WM_PROJECT = ${WM_PROJECT:-}"
 log "  WM_PROJECT_VERSION = ${WM_PROJECT_VERSION:-}"
+log "  WM_NCOMPPROCS = ${WM_NCOMP_PROCS:-} (set number for parallel builds)"
 
 if [ -z "${WM_PROJECT:-}" ]; then
     log ""

--- a/Allwmake
+++ b/Allwmake
@@ -56,7 +56,7 @@ log ""
 log "Current OpenFOAM environment:"
 log "  WM_PROJECT = ${WM_PROJECT:-}"
 log "  WM_PROJECT_VERSION = ${WM_PROJECT_VERSION:-}"
-log "  WM_NCOMPPROCS = ${WM_NCOMPPROCS:-} (number of threads for parallel builds)"
+log "  WM_NCOMPPROCS = ${WM_NCOMPPROCS:=1} (number of threads for parallel builds)"
 
 if [ -z "${WM_PROJECT:-}" ]; then
     log ""

--- a/changelog-entries/244.md
+++ b/changelog-entries/244.md
@@ -1,0 +1,1 @@
+- Removed the default `-j 4` option from the wmake command. Instead, documented the `WM_NCOMPPROCS` option of OpenFOAM. [#244](Remove -j 4 flag, document WM_NCOMPPROCS)

--- a/changelog-entries/244.md
+++ b/changelog-entries/244.md
@@ -1,1 +1,1 @@
-- Removed the default `-j 4` option from the wmake command. Instead, documented the `WM_NCOMPPROCS` option of OpenFOAM. [#244](Remove -j 4 flag, document WM_NCOMPPROCS)
+- Removed the default `-j 4` option from the wmake command. Instead, documented the `WM_NCOMPPROCS` option of OpenFOAM. [#244](https://github.com/precice/openfoam-adapter/pull/244)

--- a/docs/get.md
+++ b/docs/get.md
@@ -18,6 +18,8 @@ The adapter also requires [pkg-config](https://linux.die.net/man/1/pkg-config) t
 
 Adding `-DADAPTER_DEBUG_MODE` flag to the `ADAPTER_PREP_FLAGS` activates additional debug messages. You may also change the target directory or specify the number of threads to use for the compilation. See the comments in `Allwmake` for more.
 
+If you are building the adapter often, you may want to build it in parallel. You can set the environment variable `WM_NCOMP_PROCS` to the number of parallel threads you want WMake to use.
+
 Next: [configure and load the adapter](https://precice.org/adapter-openfoam-config.html) or [run a tutorial](https://precice.org/tutorials.html).
 
 ## What does the adapter version mean?

--- a/docs/get.md
+++ b/docs/get.md
@@ -18,7 +18,7 @@ The adapter also requires [pkg-config](https://linux.die.net/man/1/pkg-config) t
 
 Adding `-DADAPTER_DEBUG_MODE` flag to the `ADAPTER_PREP_FLAGS` activates additional debug messages. You may also change the target directory or specify the number of threads to use for the compilation. See the comments in `Allwmake` for more.
 
-If you are building the adapter often, you may want to build it in parallel. You can set the environment variable `WM_NCOMP_PROCS` to the number of parallel threads you want WMake to use.
+If you are building the adapter often, you may want to build it in parallel. You can set the environment variable `WM_NCOMPPROCS` to the number of parallel threads you want WMake to use.
 
 Next: [configure and load the adapter](https://precice.org/adapter-openfoam-config.html) or [run a tutorial](https://precice.org/tutorials.html).
 

--- a/docs/get.md
+++ b/docs/get.md
@@ -13,7 +13,6 @@ To build the adapter, you need to install a few dependencies and then execute th
 4. Execute the build script: `./Allwmake`.
     * See and adjust the configuration in the beginning of the script first, if needed.
     * Check for any error messages and suggestions at the end.
-    * Modify the `adapter_build_command` to e.g. build using more threads, e.g. `wmake -j 4 libso`.
 
 The adapter also requires [pkg-config](https://linux.die.net/man/1/pkg-config) to [link to preCICE](https://precice.org/installation-linking.html). This is a very common dependency on Linux and is usually already installed.
 


### PR DESCRIPTION
This replaces/closes #219.

By default, the adapter does not take very long to compile (maybe a minute or two), and the typical user would only do that once. Instead of hard-coding the number of processes, or trying to run using all processes (both could lead to issues on some systems), this PR:

- Reports the current value of this variable:
   ```bash
   Current OpenFOAM environment:
     WM_PROJECT = OpenFOAM
     WM_PROJECT_VERSION = v2206
     WM_NCOMPPROCS = 4 (number of threads for parallel builds)
   ```
   If the variable is not set, it is just shown as empty.
- Documents the option as a side-hint:
   ```text
   If you are building the adapter often, you may want to build it in parallel. You can set the environment variable `WM_NCOMP_PROCS` to the number of parallel threads you want WMake to use.
   ```

TODO list:

- [x] I updated the documentation in `docs/`
- [x] I added a changelog entry in `changelog-entries/` (create directory if missing)
- [ ] Squash before merging