### PR TITLE
Cleanup virtual/override/final

### DIFF
--- a/CHT/HeatFlux.H
+++ b/CHT/HeatFlux.H
@@ -33,16 +33,16 @@ public:
 
     //- Compute heat flux values from the temperature field
     //  and write them into the buffer
-    virtual void write(double* buffer, bool meshConnectivity, const unsigned int dim);
+    void write(double* buffer, bool meshConnectivity, const unsigned int dim) final;
 
     //- Read heat flux values from the buffer and assign them to
     //  the gradient of the temperature field
-    virtual void read(double* buffer, const unsigned int dim);
+    void read(double* buffer, const unsigned int dim) final;
 
-    bool isLocationTypeSupported(const bool meshConnectivity) const override;
+    bool isLocationTypeSupported(const bool meshConnectivity) const final;
 
     //- Get the name of the current data field
-    std::string getDataName() const override;
+    std::string getDataName() const final;
 
     //- Destructor
     virtual ~HeatFlux() {};
@@ -59,10 +59,10 @@ protected:
     KappaEff_Compressible* Kappa_;
 
     //- Wrapper for the extract() method of the corresponding KappaEff class
-    virtual void extractKappaEff(uint patchID, bool meshConnectivity);
+    void extractKappaEff(uint patchID, bool meshConnectivity) final;
 
     //- Wrapper for the getAt() method of the corresponding KappaEff class
-    virtual Foam::scalar getKappaEffAt(int i);
+    Foam::scalar getKappaEffAt(int i) final;
 
 public:
     //- Constructor
@@ -71,7 +71,7 @@ public:
         const std::string nameT);
 
     //- Destructor
-    virtual ~HeatFlux_Compressible();
+    ~HeatFlux_Compressible() final;
 };
 
 //- Implementation of the HeatFlux for incompresible, turbulent flow solvers
@@ -85,10 +85,10 @@ protected:
     KappaEff_Incompressible* Kappa_;
 
     //- Wrapper for the extract() method of the corresponding KappaEff class
-    virtual void extractKappaEff(uint patchID, bool meshConnectivity);
+    void extractKappaEff(uint patchID, bool meshConnectivity) final;
 
     //- Wrapper for the getAt() method of the corresponding KappaEff class
-    virtual Foam::scalar getKappaEffAt(int i);
+    Foam::scalar getKappaEffAt(int i) final;
 
 public:
     //- Constructor
@@ -101,7 +101,7 @@ public:
         const std::string nameAlphat);
 
     //- Destructor
-    virtual ~HeatFlux_Incompressible();
+    ~HeatFlux_Incompressible() final;
 };
 
 //- Implementation of the HeatFlux for basic solvers
@@ -115,10 +115,10 @@ protected:
     KappaEff_Basic* Kappa_;
 
     //- Wrapper for the extract() method of the corresponding KappaEff class
-    virtual void extractKappaEff(uint patchID, bool meshConnectivity);
+    void extractKappaEff(uint patchID, bool meshConnectivity) final;
 
     //- Wrapper for the getAt() method of the corresponding KappaEff class
-    virtual Foam::scalar getKappaEffAt(int i);
+    Foam::scalar getKappaEffAt(int i) final;
 
 public:
     //- Constructor
@@ -128,7 +128,7 @@ public:
         const std::string nameKappa);
 
     //- Destructor
-    virtual ~HeatFlux_Basic();
+    ~HeatFlux_Basic() final;
 };
 
 }

--- a/CHT/HeatTransferCoefficient.H
+++ b/CHT/HeatTransferCoefficient.H
@@ -35,15 +35,15 @@ public:
         const std::string nameT);
 
     //- Write the heat transfer coefficient values into the buffer
-    virtual void write(double* buffer, bool meshConnectivity, const unsigned int dim);
+    void write(double* buffer, bool meshConnectivity, const unsigned int dim) final;
 
     //- Read the heat transfer coefficient values from the buffer
-    virtual void read(double* buffer, const unsigned int dim);
+    void read(double* buffer, const unsigned int dim) final;
 
-    bool isLocationTypeSupported(const bool meshConnectivity) const override;
+    bool isLocationTypeSupported(const bool meshConnectivity) const final;
 
     //- Get the name of the current data field
-    std::string getDataName() const override;
+    std::string getDataName() const final;
 
     //- Destructor
     virtual ~HeatTransferCoefficient() {};
@@ -60,10 +60,10 @@ protected:
     KappaEff_Compressible* Kappa_;
 
     //- Wrapper for the extract() method of the corresponding KappaEff class
-    virtual void extractKappaEff(uint patchID, bool meshConnectivity);
+    void extractKappaEff(uint patchID, bool meshConnectivity) final;
 
     //- Wrapper for the getAt() method of the corresponding KappaEff class
-    virtual Foam::scalar getKappaEffAt(int i);
+    Foam::scalar getKappaEffAt(int i) final;
 
 public:
     //- Constructor
@@ -72,7 +72,7 @@ public:
         const std::string nameT);
 
     //- Destructor
-    virtual ~HeatTransferCoefficient_Compressible();
+    ~HeatTransferCoefficient_Compressible() final;
 };
 
 //- Implementation of the HeatTransferCoefficient for incompresible, turbulent flow solvers
@@ -86,10 +86,10 @@ protected:
     KappaEff_Incompressible* Kappa_;
 
     //- Wrapper for the extract() method of the corresponding KappaEff class
-    virtual void extractKappaEff(uint patchID, bool meshConnectivity);
+    void extractKappaEff(uint patchID, bool meshConnectivity) final;
 
     //- Wrapper for the getAt() method of the corresponding KappaEff class
-    virtual Foam::scalar getKappaEffAt(int i);
+    Foam::scalar getKappaEffAt(int i) final;
 
 public:
     //- Constructor
@@ -102,7 +102,7 @@ public:
         const std::string nameAlphat);
 
     //- Destructor
-    virtual ~HeatTransferCoefficient_Incompressible();
+    ~HeatTransferCoefficient_Incompressible() final;
 };
 
 
@@ -117,10 +117,10 @@ protected:
     KappaEff_Basic* Kappa_;
 
     //- Wrapper for the extract() method of the corresponding KappaEff class
-    virtual void extractKappaEff(uint patchID, bool meshConnectivity);
+    void extractKappaEff(uint patchID, bool meshConnectivity) final;
 
     //- Wrapper for the getAt() method of the corresponding KappaEff class
-    virtual Foam::scalar getKappaEffAt(int i);
+    Foam::scalar getKappaEffAt(int i) final;
 
 public:
     //- Constructor
@@ -130,7 +130,7 @@ public:
         const std::string nameKappa);
 
     //- Destructor
-    virtual ~HeatTransferCoefficient_Basic();
+    ~HeatTransferCoefficient_Basic() final;
 };
 
 }

--- a/CHT/SinkTemperature.H
+++ b/CHT/SinkTemperature.H
@@ -31,10 +31,10 @@ public:
     //- Read the sink temperature values from the buffer
     void read(double* buffer, const unsigned int dim);
 
-    bool isLocationTypeSupported(const bool meshConnectivity) const override;
+    bool isLocationTypeSupported(const bool meshConnectivity) const final;
 
     //- Get the name of the current data field
-    std::string getDataName() const override;
+    std::string getDataName() const final;
 };
 
 }

--- a/CHT/Temperature.H
+++ b/CHT/Temperature.H
@@ -31,10 +31,10 @@ public:
     //- Read the temperature values from the buffer
     void read(double* buffer, const unsigned int dim);
 
-    bool isLocationTypeSupported(const bool meshConnectivity) const override;
+    bool isLocationTypeSupported(const bool meshConnectivity) const final;
 
     //- Get the name of the current data field
-    std::string getDataName() const override;
+    std::string getDataName() const final;
 };
 
 }

--- a/FF/Pressure.H
+++ b/FF/Pressure.H
@@ -30,10 +30,10 @@ public:
     //- Read the pressure values from the buffer
     void read(double* buffer, const unsigned int dim);
 
-    bool isLocationTypeSupported(const bool meshConnectivity) const override;
+    bool isLocationTypeSupported(const bool meshConnectivity) const final;
 
     //- Get the name of the current data field
-    std::string getDataName() const override;
+    std::string getDataName() const final;
 };
 
 }

--- a/FF/PressureGradient.H
+++ b/FF/PressureGradient.H
@@ -30,10 +30,10 @@ public:
     //- Read the pressure gradient values from the buffer
     void read(double* buffer, const unsigned int dim);
 
-    bool isLocationTypeSupported(const bool meshConnectivity) const override;
+    bool isLocationTypeSupported(const bool meshConnectivity) const final;
 
     //- Get the name of the current data field
-    std::string getDataName() const override;
+    std::string getDataName() const final;
 };
 
 }

--- a/FF/Velocity.H
+++ b/FF/Velocity.H
@@ -30,10 +30,10 @@ public:
     //- Read the velocity values from the buffer
     void read(double* buffer, const unsigned int dim);
 
-    bool isLocationTypeSupported(const bool meshConnectivity) const override;
+    bool isLocationTypeSupported(const bool meshConnectivity) const final;
 
     //- Get the name of the current data field
-    std::string getDataName() const override;
+    std::string getDataName() const final;
 };
 
 }

--- a/FF/VelocityGradient.H
+++ b/FF/VelocityGradient.H
@@ -25,15 +25,15 @@ public:
         const std::string nameU);
 
     //- Write the velocity gradient values into the buffer
-    void write(double* buffer, bool meshConnectivity, const unsigned int dim) override;
+    void write(double* buffer, bool meshConnectivity, const unsigned int dim) final;
 
     //- Read the velocity gradient values from the buffer
-    void read(double* buffer, const unsigned int dim) override;
+    void read(double* buffer, const unsigned int dim) final;
 
-    bool isLocationTypeSupported(const bool meshConnectivity) const override;
+    bool isLocationTypeSupported(const bool meshConnectivity) const final;
 
     //- Get the name of the current data field
-    std::string getDataName() const override;
+    std::string getDataName() const final;
 };
 
 }

--- a/FSI/Displacement.H
+++ b/FSI/Displacement.H
@@ -36,19 +36,19 @@ public:
         const std::string nameCellDisplacement);
 
     //- Write the displacement values into the buffer
-    void write(double* buffer, bool meshConnectivity, const unsigned int dim) override;
+    void write(double* buffer, bool meshConnectivity, const unsigned int dim) final;
 
     //- Read the displacement values from the buffer
-    void read(double* buffer, const unsigned int dim) override;
+    void read(double* buffer, const unsigned int dim) final;
 
-    bool isLocationTypeSupported(const bool meshConnectivity) const override;
+    bool isLocationTypeSupported(const bool meshConnectivity) const final;
 
     //- Get the name of the current data field
-    std::string getDataName() const override;
+    std::string getDataName() const final;
 
     //- We need to initialize the cell-based vector and the interpolation object
     // in case we want to use the faceCenter location for the coupling
-    void initialize() override;
+    void initialize() final;
 };
 
 }

--- a/FSI/DisplacementDelta.H
+++ b/FSI/DisplacementDelta.H
@@ -36,19 +36,19 @@ public:
         const std::string nameCellDisplacement);
 
     //- Write the displacementDelta values into the buffer
-    void write(double* buffer, bool meshConnectivity, const unsigned int dim) override;
+    void write(double* buffer, bool meshConnectivity, const unsigned int dim) final;
 
     //- Read the displacementDelta values from the buffer
-    void read(double* buffer, const unsigned int dim) override;
+    void read(double* buffer, const unsigned int dim) final;
 
-    bool isLocationTypeSupported(const bool meshConnectivity) const override;
+    bool isLocationTypeSupported(const bool meshConnectivity) const final;
 
     //- Get the name of the current data field
-    virtual std::string getDataName() const;
+    std::string getDataName() const;
 
     //- We need to initialize the cell-based vector and the interpolation object
     // in case we want to use the faceCenter location for the coupling
-    void initialize() override;
+    void initialize() final;
 };
 
 }

--- a/FSI/Force.H
+++ b/FSI/Force.H
@@ -26,18 +26,18 @@ public:
         const std::string nameSolidForce);
 
     //- Write the forces values into the buffer
-    void write(double* buffer, bool meshConnectivity, const unsigned int dim) override;
+    void write(double* buffer, bool meshConnectivity, const unsigned int dim) final;
 
     //- Read the forces values from the buffer
-    void read(double* buffer, const unsigned int dim) override;
+    void read(double* buffer, const unsigned int dim) final;
 
-    bool isLocationTypeSupported(const bool meshConnectivity) const override;
+    bool isLocationTypeSupported(const bool meshConnectivity) const final;
 
     //- Get the name of the current data field
-    std::string getDataName() const override;
+    std::string getDataName() const final;
 
     //- Returns the normal vectors multiplied by the face area
-    Foam::tmp<Foam::vectorField> getFaceVectors(const unsigned int patchID) const override;
+    Foam::tmp<Foam::vectorField> getFaceVectors(const unsigned int patchID) const final;
 
     //- Destructor
     ~Force();

--- a/FSI/Stress.H
+++ b/FSI/Stress.H
@@ -27,18 +27,18 @@ public:
         const std::string solverType);
 
     //- Write the stress values into the buffer
-    void write(double* buffer, bool meshConnectivity, const unsigned int dim) override;
+    void write(double* buffer, bool meshConnectivity, const unsigned int dim) final;
 
     //- Read the stress values from the buffer
-    void read(double* buffer, const unsigned int dim) override;
+    void read(double* buffer, const unsigned int dim) final;
 
-    bool isLocationTypeSupported(const bool meshConnectivity) const override;
+    bool isLocationTypeSupported(const bool meshConnectivity) const final;
 
     //- Get the name of the current data field
-    std::string getDataName() const override;
+    std::string getDataName() const final;
 
     //- Returns the face normal vectors (no multiplication by area)
-    Foam::tmp<Foam::vectorField> getFaceVectors(const unsigned int patchID) const override;
+    Foam::tmp<Foam::vectorField> getFaceVectors(const unsigned int patchID) const final;
 
     //- Destructor
     ~Stress();

--- a/changelog-entries/245.md
+++ b/changelog-entries/245.md
@@ -1,0 +1,1 @@
+- Changed virtual function declarations to explicitly define one (only) of virtual/override/final. If you need to extend a method marked as `final`, please report. [#245](https://github.com/precice/openfoam-adapter/pull/245)

--- a/preciceAdapterFunctionObject.H
+++ b/preciceAdapterFunctionObject.H
@@ -106,25 +106,25 @@ public:
 
 
     //- Destructor
-    virtual ~preciceAdapterFunctionObject();
+    ~preciceAdapterFunctionObject() final;
 
 
     // Member Functions
 
     //- Read the preciceAdapterFunctionObject data
-    virtual bool read(const dictionary&);
+    bool read(const dictionary&) final;
 
     //- Execute in the beginning of each time-loop, after the first one
-    virtual bool execute();
+    bool execute() final;
 
     //- Execute at the final time-loop, after execute()
-    virtual bool end();
+    bool end() final;
 
     //- Write the preciceAdapterFunctionObject
-    virtual bool write();
+    bool write() final;
 
     //- Called at the end of Time::adjustDeltaT() if adjustTime is true
-    virtual bool adjustTimeStep();
+    bool adjustTimeStep() final;
 
     /*
         // NOTE: If you add a new module that needs to execute methods
@@ -132,10 +132,10 @@ public:
         // you may put your calls inside the following methods.
 
         // Update for changes of mesh
-        virtual void updateMesh(const mapPolyMesh& mpm);
+        void updateMesh(const mapPolyMesh& mpm) final;
 
         // Update for changes of mesh
-        virtual void movePoints(const polyMesh& mesh);
+        void movePoints(const polyMesh& mesh) final;
     */
 };
 


### PR DESCRIPTION
This is implementing the [C++ Core Guideline 128](https://github.com/isocpp/CppCoreGuidelines/blob/master/CppCoreGuidelines.md#c128-virtual-functions-should-specify-exactly-one-of-virtual-override-or-final) and is mainly a reaction to https://github.com/precice/openfoam-adapter/issues/237.

I tried reproducing with GCC and `-Wsuggest-override`, but this led to an unreadably long log, since OpenFOAM itself does not seem to follow the rule. I also tried making WMake to use Clang on my system, which in the end I could not figure out. @solids4foam / @philipcardiff could you please try if this PR compiles fine for you?

@davidscn please also have a look. Possible side-effect: if people extend the adapter by deriving from some of our classes, the `final` may restrict them from doing so. If anyone runs in this case, please report here, and just change the `final` to `override`. But for now, I think stricter measures are saner.

TODO list:

- I updated the documentation in `docs/` -> N/A
- [x] I added a changelog entry in `changelog-entries/` (create directory if missing)
