### PR TITLE
Change xy-plane check error to warning

### DIFF
--- a/Interface.C
+++ b/Interface.C
@@ -153,11 +153,11 @@ void preciceAdapter::Interface::configureMesh(const fvMesh& mesh)
                     }
                     else
                     {
-                        FatalErrorInFunction
-                            << "It seems like you are using preCICE in 2D and your geometry is not located int the xy-plane. "
-                               "The OpenFOAM adapter implementation supports preCICE 2D cases only with the z-axis as out-of-plane direction."
-                               "Please rotate your geometry so that the geometry is located in the xy-plane."
-                            << exit(FatalError);
+                        adapterInfo("It seems like you are using preCICE in 2D and your geometry is not located int the xy-plane. "
+                                    "The OpenFOAM adapter implementation supports preCICE 2D cases only with the z-axis as out-of-plane direction."
+                                    "Please rotate your geometry so that the geometry is located in the xy-plane."
+                                    "If you are running a 2D axisymmetric case just ignore this.",
+                                    "warning");
                     }
                 }
             }

--- a/changelog-entries/246.md
+++ b/changelog-entries/246.md
@@ -1,0 +1,1 @@
+- Changed the xy-plane error to a warning, to support 2D axisymmetric cases. [#246](https://github.com/precice/openfoam-adapter/pull/246)

--- a/docs/config.md
+++ b/docs/config.md
@@ -404,7 +404,7 @@ The user can toggle debug messages at [build time](https://precice.org/adapter-o
 
 ## Coupling OpenFOAM with 2D solvers
 
-The adapter asks preCICE for the dimensions of the coupling data defined in the `precice-config.xml` (2D or 3D). It then automatically operates in either 3D (normal) or 2D (reduced) mode, with z-axis being the out-of-plane dimension. [Read more](https://github.com/precice/openfoam-adapter/pull/96).
+The adapter asks preCICE for the dimensions of the coupling data defined in the `precice-config.xml` (2D or 3D). It then automatically operates in either 3D (normal) or 2D (reduced) mode, with z-axis being the out-of-plane dimension. [Read more](https://github.com/precice/openfoam-adapter/pull/96). In 2D mode, the adapter also supports axisymmetric cases.
 
 ## Porting your older cases to the current configuration format
 


### PR DESCRIPTION
This adds support for axisymmetric cases, closes #228.

@arvedes FYI (I also directly used the `adapterInfo` function). Thanks for contributing the suggestion!

@davidscn please do a sanity check. In #228, you suggested a more elaborate fix, but according to @arvedes, this is already enough for his use case.

TODO list:

- [x] I updated the documentation in `docs/`
- [x] I added a changelog entry in `changelog-entries/` (create directory if missing)
- [ ] Squash before merging