### PR TITLE
Remove deprecated isReadDataAvailable

### DIFF
--- a/Interface.C
+++ b/Interface.C
@@ -371,38 +371,34 @@ void preciceAdapter::Interface::createBuffer()
 
 void preciceAdapter::Interface::readCouplingData()
 {
-    // Are new data available or is the participant subcycling?
-    if (precice_.isReadDataAvailable())
+    // Make every coupling data reader read
+    for (uint i = 0; i < couplingDataReaders_.size(); i++)
     {
-        // Make every coupling data reader read
-        for (uint i = 0; i < couplingDataReaders_.size(); i++)
+        // Pointer to the current reader
+        preciceAdapter::CouplingDataUser*
+            couplingDataReader = couplingDataReaders_.at(i);
+
+        // Make preCICE read vector or scalar data
+        // and fill the adapter's buffer
+        if (couplingDataReader->hasVectorData())
         {
-            // Pointer to the current reader
-            preciceAdapter::CouplingDataUser*
-                couplingDataReader = couplingDataReaders_.at(i);
-
-            // Make preCICE read vector or scalar data
-            // and fill the adapter's buffer
-            if (couplingDataReader->hasVectorData())
-            {
-                precice_.readBlockVectorData(
-                    couplingDataReader->dataID(),
-                    numDataLocations_,
-                    vertexIDs_,
-                    dataBuffer_);
-            }
-            else
-            {
-                precice_.readBlockScalarData(
-                    couplingDataReader->dataID(),
-                    numDataLocations_,
-                    vertexIDs_,
-                    dataBuffer_);
-            }
-
-            // Read the received data from the buffer
-            couplingDataReader->read(dataBuffer_, dim_);
+            precice_.readBlockVectorData(
+                couplingDataReader->dataID(),
+                numDataLocations_,
+                vertexIDs_,
+                dataBuffer_);
         }
+        else
+        {
+            precice_.readBlockScalarData(
+                couplingDataReader->dataID(),
+                numDataLocations_,
+                vertexIDs_,
+                dataBuffer_);
+        }
+
+        // Read the received data from the buffer
+        couplingDataReader->read(dataBuffer_, dim_);
     }
 }
 

--- a/changelog-entries/247.md
+++ b/changelog-entries/247.md
@@ -1,0 +1,1 @@
+- Removed the (deprecated since preCICE v2.5.0) call to isReadDataAvailable. [#247](https://github.com/precice/openfoam-adapter/pull/247)


### PR DESCRIPTION
As discussed in https://github.com/precice/precice/issues/1223, preCICE v2.5.0 deprecated `isReadDataAvailable()`, which is planned for removal in preCICE v3. Related: #235.

This PR already removes this call, to avoid the deprecation warning when compiling the adapter.

It should currently not matter for results, as it re-reads the same information on the boundary, but it should make time interpolation easier in the future. I quickly ran the flow-over-heated-plate case with subcycling (2 solver time steps for 1 coupling time window) and implicit coupling (hint: we currently have issues with FSI and subcycling #58), and the result files are identical. In this small case, the runtime seems to be approximately the same (without any rigorous performance test, just one sample for each case).

Still, the adapter performs now each assignment on the boundaries every time.

@uekerman / @davidscn Anything else to consider here?

The diff may look a bit complicated, but it is just removing one `if` check and indenting-out.

TODO list:

- [x] I updated the documentation in `docs/`
- [x] I added a changelog entry in `changelog-entries/` (create directory if missing)
