### PR TITLE
Reword warning for nearest-projection mapping

### DIFF
--- a/Adapter.C
+++ b/Adapter.C
@@ -161,12 +161,12 @@ bool preciceAdapter::Adapter::configFileRead()
                 if (interfacesConfig_.at(i).meshConnectivity == true)
                 {
                     adapterInfo(
-                        "Mesh connectivity is not supported for FSI, as, usually, "
-                        "the Solid participant needs to provide the connectivity information. "
-                        "Therefore, set provideMeshConnectivity = false. "
-                        "Have a look in the adapter documentation for more information. ",
+                        "You have requested mesh connectivity (most probably for nearest-projection mapping) "
+                        "and you have enabled the FSI module. "
+                        "Note that this is only supported for specific data fields and locations. "
+                        "Have a look in the adapter documentation for more information: "
+                        "https://precice.org/adapter-openfoam-config.html#nearest-projection-mapping ",
                         "warning");
-                    return false;
                 }
             }
 

--- a/Adapter.C
+++ b/Adapter.C
@@ -163,10 +163,9 @@ bool preciceAdapter::Adapter::configFileRead()
                     adapterInfo(
                         "You have requested mesh connectivity (most probably for nearest-projection mapping) "
                         "and you have enabled the FSI module. "
-                        "Note that this is only supported for specific data fields and locations. "
-                        "Have a look in the adapter documentation for more information: "
-                        "https://precice.org/adapter-openfoam-config.html#nearest-projection-mapping ",
+                        "Mapping with connectivity information is not implemented for FSI, only for CHT-related fields. "
                         "warning");
+                        return false;
                 }
             }
 

--- a/Adapter.C
+++ b/Adapter.C
@@ -165,7 +165,7 @@ bool preciceAdapter::Adapter::configFileRead()
                         "and you have enabled the FSI module. "
                         "Mapping with connectivity information is not implemented for FSI, only for CHT-related fields. "
                         "warning");
-                        return false;
+                    return false;
                 }
             }
 

--- a/changelog-entries/248.md
+++ b/changelog-entries/248.md
@@ -1,0 +1,1 @@
+- Changed a nearest-projection related error to a warning. [#248](https://github.com/precice/openfoam-adapter/pull/248)

--- a/changelog-entries/248.md
+++ b/changelog-entries/248.md
@@ -1,1 +1,0 @@
-- Changed a nearest-projection related error to a warning. [#248](https://github.com/precice/openfoam-adapter/pull/248)

--- a/docs/config.md
+++ b/docs/config.md
@@ -279,7 +279,7 @@ Data is obtained at the face centers, then interpolated to face nodes. Here, we 
 It is important to notice that the target data location is again the face center mesh of the coupling partner. In the standard CHT case, where both data sets are exchanged by a nearest-projection mapping, this leads to two interface meshes (centers and nodes) per participant. Having both the centers and nodes defined, we can skip one interpolation step and read data directly to the centers (cf. picture solver B).
 
 {% note %}
-As already mentioned, the `Fluid` participant does not need to provide the mesh connectivity in case of a standard FSI. Therefore, the `Solid` participant needs to provide it and nothing special needs to be considered compared to other mapping methods. This implementation supports all CHT-related fields, which are mapped with a `consistent` constraint.
+As already mentioned, the `Fluid` participant does not need to provide the mesh connectivity in case of a standard FSI writing forces. It can, however, provide the mesh connectivity when writing stresses. Alternatively, the `Solid` participant can to provide mesh connectivity on the displacements mesh, and nothing special needs to be considered in the adapter implementation compared to other mapping methods. This implementation supports all CHT-related fields, which are mapped with a `consistent` constraint.
 {% endnote %}
 
 ### Additional properties for some solvers

--- a/docs/config.md
+++ b/docs/config.md
@@ -279,7 +279,7 @@ Data is obtained at the face centers, then interpolated to face nodes. Here, we 
 It is important to notice that the target data location is again the face center mesh of the coupling partner. In the standard CHT case, where both data sets are exchanged by a nearest-projection mapping, this leads to two interface meshes (centers and nodes) per participant. Having both the centers and nodes defined, we can skip one interpolation step and read data directly to the centers (cf. picture solver B).
 
 {% note %}
-As already mentioned, the `Fluid` participant does not need to provide the mesh connectivity in case of a standard FSI writing forces. It can, however, provide the mesh connectivity when writing stresses. Alternatively, the `Solid` participant can to provide mesh connectivity on the displacements mesh, and nothing special needs to be considered in the adapter implementation compared to other mapping methods. This implementation supports all CHT-related fields, which are mapped with a `consistent` constraint.
+As already mentioned, the `Fluid` participant does not need to provide the mesh connectivity in case of a standard FSI writing forces. It can, however, provide the mesh connectivity when writing stresses. Alternatively, the `Solid` participant can provide mesh connectivity on the displacements mesh, in which case nothing special needs to be considered in the adapter implementation compared to other mapping methods. This implementation supports all CHT-related fields, which are mapped with a `consistent` constraint.
 {% endnote %}
 
 ### Additional properties for some solvers

--- a/docs/config.md
+++ b/docs/config.md
@@ -279,7 +279,7 @@ Data is obtained at the face centers, then interpolated to face nodes. Here, we 
 It is important to notice that the target data location is again the face center mesh of the coupling partner. In the standard CHT case, where both data sets are exchanged by a nearest-projection mapping, this leads to two interface meshes (centers and nodes) per participant. Having both the centers and nodes defined, we can skip one interpolation step and read data directly to the centers (cf. picture solver B).
 
 {% note %}
-As already mentioned, the `Fluid` participant does not need to provide the mesh connectivity in case of a standard FSI writing forces. It can, however, provide the mesh connectivity when writing stresses. Alternatively, the `Solid` participant can provide mesh connectivity on the displacements mesh, in which case nothing special needs to be considered in the adapter implementation compared to other mapping methods. This implementation supports all CHT-related fields, which are mapped with a `consistent` constraint.
+This is implemented for all CHT-related fields mapped with a `consistent` constraint, but it is not implemented for the `FSI` and `FF` modules.
 {% endnote %}
 
 ### Additional properties for some solvers


### PR DESCRIPTION
Closes #135.

I followed the easier approach for now: convert the error to a warning (when FSI + connectivity) and add a note in the documentation. I think it does not need to be more complicated, while configuring FSI with mesh connectivity is already a specific enough case for a warning.

The adapter now refers to the documentation via URL, which I think we should start doing more often. Even if the targets change eventually, a URL is better than looking manually through the documentation.

@davidscn please check. I have not yet checked what happens with solid OpenFOAM solvers that can write displacements.

TODO list:

- [x] I updated the documentation in `docs/`
- [x] I added a changelog entry in `changelog-entries/` (create directory if missing) -> not needed with the changes after review
- [ ] Squash before merging
