### PR TITLE
Parameterize the FSI force field name (merge solidForce and Force)

### DIFF
--- a/FSI/FSI.C
+++ b/FSI/FSI.C
@@ -67,9 +67,9 @@ bool preciceAdapter::FSI::FluidStructureInteraction::readConfig(const IOdictiona
     nameCellDisplacement_ = FSIdict.lookupOrDefault<word>("nameCellDisplacement", "cellDisplacement");
     DEBUG(adapterInfo("    cellDisplacement field name : " + nameCellDisplacement_));
 
-    // Read the name of the solidForce field (if different)
-    nameSolidForce_ = FSIdict.lookupOrDefault<word>("nameSolidForce", "solidForce");
-    DEBUG(adapterInfo("    solidForce field name : " + nameSolidForce_));
+    // Read the name of the force field (if different)
+    nameForce_ = FSIdict.lookupOrDefault<word>("nameForce", "Force");
+    DEBUG(adapterInfo("    force field name : " + nameForce_));
 
     return true;
 }
@@ -123,7 +123,7 @@ bool preciceAdapter::FSI::FluidStructureInteraction::addWriters(std::string data
     {
         interface->addCouplingDataWriter(
             dataName,
-            new Force(mesh_, solverType_, nameSolidForce_) /* TODO: Add any other arguments here */
+            new Force(mesh_, solverType_, nameForce_) /* TODO: Add any other arguments here */
         );
         DEBUG(adapterInfo("Added writer: Force."));
     }
@@ -171,7 +171,7 @@ bool preciceAdapter::FSI::FluidStructureInteraction::addReaders(std::string data
     {
         interface->addCouplingDataReader(
             dataName,
-            new Force(mesh_, solverType_, nameSolidForce_) /* TODO: Add any other arguments here */
+            new Force(mesh_, solverType_, nameForce_) /* TODO: Add any other arguments here */
         );
         DEBUG(adapterInfo("Added reader: Force."));
     }

--- a/FSI/FSI.H
+++ b/FSI/FSI.H
@@ -34,8 +34,8 @@ protected:
     //- Name of the pointDisplacement field
     std::string nameCellDisplacement_ = "cellDisplacement";
 
-    //- Name of the force field used by the solid
-    std::string nameSolidForce_ = "solidForce";
+    //- Name of the force field
+    std::string nameForce_ = "Force";
 
     /* TODO: Declare here any parameters that should be read from
     /  the configuration file. See CHT/CHT.H for reference.

--- a/FSI/Force.H
+++ b/FSI/Force.H
@@ -15,15 +15,12 @@ private:
     //- Force field
     Foam::volVectorField* Force_;
 
-    //- Solid force field
-    Foam::volVectorField* solidForce_;
-
 public:
     //- Constructor
     Force(
         const Foam::fvMesh& mesh,
         const std::string solverType,
-        const std::string nameSolidForce);
+        const std::string nameForce);
 
     //- Write the forces values into the buffer
     void write(double* buffer, bool meshConnectivity, const unsigned int dim) final;

--- a/docs/config.md
+++ b/docs/config.md
@@ -388,8 +388,8 @@ FSI
     // Displacement fields
     namePointDisplacement pointD;
     nameCellDisplacement D;
-    // Force field on the solid
-    forceFieldName solidForce;
+    // Force field
+    nameForce Force; // For solids4Foam: solidForce
 }
 ```
 


### PR DESCRIPTION
Closes #242, by merging the `solidForce` (with the previously configured name via the option `forceFieldName`), which was used by solid solvers, with the hard-coded `"Force"` field, which was used by fluid solvers.

Note that, for solid solver cases, one needs to adapt `preciceDict` to change `forceFieldName solidForce;` to `nameForce solidForce;`.

Checked cases:
- [x] `perpendicular-flap/fluid-openfoam`
- [x] `perpendicular-flap/solid-openfoam` (reminder: needs a `Warp by vector` filter in ParaView)
- [x] `perpendicular-flap/solid-solids4foam`

@solids4foam / @philipcardiff: Could you please also check whether this is in line with your changes at #236? Have I forgotten anything else? Since I don't have solids4foam installed on this machine, could you please also do a quick run?

@davidscn: Please do the usual sanity check. Even though this felt rather easy, I have a feeling that I forgot something.

TODO list:

- [x] I updated the documentation in `docs/`
- I added a changelog entry in `changelog-entries/` (create directory if missing) -> Does not apply, since the respective changes had not yet been released in v1.1.0. The changes for solids4foam are already mentioned.
