### PR TITLE
Force: Distinguish between owning and non-owning

### DIFF
--- a/FSI/Force.C
+++ b/FSI/Force.C
@@ -31,7 +31,7 @@ preciceAdapter::FSI::Force::Force(
                 "fdim",
                 dimensionSet(1, 1, -2, 0, 0, 0, 0),
                 Foam::vector::zero)));
-        
+
         Force_ = ForceOwning_.get();
     }
 }
@@ -91,4 +91,3 @@ Foam::tmp<Foam::vectorField> preciceAdapter::FSI::Force::getFaceVectors(const un
     // Normal vectors multiplied by face area
     return mesh_.boundary()[patchID].Sf();
 }
-

--- a/FSI/Force.C
+++ b/FSI/Force.C
@@ -19,7 +19,7 @@ preciceAdapter::FSI::Force::Force(
     }
     else
     {
-        Force_ = new volVectorField(
+        ForceOwning_ = std::make_unique<volVectorField>(volVectorField(
             IOobject(
                 nameForce,
                 mesh_.time().timeName(),
@@ -30,7 +30,9 @@ preciceAdapter::FSI::Force::Force(
             dimensionedVector(
                 "fdim",
                 dimensionSet(1, 1, -2, 0, 0, 0, 0),
-                Foam::vector::zero));
+                Foam::vector::zero)));
+        
+        Force_ = ForceOwning_.get();
     }
 }
 
@@ -90,7 +92,3 @@ Foam::tmp<Foam::vectorField> preciceAdapter::FSI::Force::getFaceVectors(const un
     return mesh_.boundary()[patchID].Sf();
 }
 
-preciceAdapter::FSI::Force::~Force()
-{
-    delete Force_;
-}

--- a/FSI/Force.H
+++ b/FSI/Force.H
@@ -12,8 +12,11 @@ namespace FSI
 class Force : public ForceBase
 {
 private:
-    //- Force field
+    //- Force field (non-owning pointer, it may already be constructed by the solver)
     Foam::volVectorField* Force_;
+
+    //- Force field (owning pointer, we bind to Force_)
+    std::unique_ptr<Foam::volVectorField> ForceOwning_;
 
 public:
     //- Constructor
@@ -35,9 +38,6 @@ public:
 
     //- Returns the normal vectors multiplied by the face area
     Foam::tmp<Foam::vectorField> getFaceVectors(const unsigned int patchID) const final;
-
-    //- Destructor
-    ~Force();
 };
 
 }


### PR DESCRIPTION
In https://github.com/precice/openfoam-adapter/pull/252, I merged the force implementation for solid and for fluid solvers. Something I missed (and that @davidscn pointed out now) is that the destructor was trying to delete the pointer in both cases, leading to the segfault observed at the end of the simulation in #259.

This introduces a `std::unique_ptr` for the case we have to create something and still binds it to the raw `Force_` we were using before. It also deletes the now unused destructor.

Closes #259 

TODO list:

- I updated the documentation in `docs/` -> N/A
- I added a changelog entry in `changelog-entries/` (create directory if missing) -> N/A (introduced in develop)
