### PR TITLE
Switch to 'new' instead of make_shared

### DIFF
--- a/FSI/Force.C
+++ b/FSI/Force.C
@@ -19,7 +19,7 @@ preciceAdapter::FSI::Force::Force(
     }
     else
     {
-        ForceOwning_ = std::make_unique<volVectorField>(volVectorField(
+        ForceOwning_.reset(new volVectorField(
             IOobject(
                 nameForce,
                 mesh_.time().timeName(),

--- a/changelog-entries/264.md
+++ b/changelog-entries/264.md
@@ -1,0 +1,1 @@
+- Replaced `make_shared` by `new` in order to remain C++11 compatible [#264](https://github.com/precice/openfoam-adapter/pull/264).


### PR DESCRIPTION
In order to stick to C++11. Related to #263.

- [x] I updated the documentation in `docs/`
- [x] I added a changelog entry in `changelog-entries/` (create directory if missing)
