### PR TITLE
Add coupling region to volume coupling

### DIFF
--- a/Adapter.C
+++ b/Adapter.C
@@ -119,16 +119,23 @@ bool preciceAdapter::Adapter::configFileRead()
                         DEBUG(adapterInfo("      - " + patch));
                     }
 
-                    // TODO cellSets don't have to be specified?
-                    // should specifying cellSets only work for locationType volume?
-                    // should we allow *not* specifying cellSets for locationType volume (and assume it's the whole domain)
-                    // + not associating them to patches?
+                    // TODO: check if this works correctly
                     DEBUG(adapterInfo("    cellSets      : "));
-                    auto cellSets = interfaceDict.get<wordList>("cellSets");
+                    auto cellSets = interfaceDict.lookupOrDefault<wordList>("cellSets", wordList());
+                    
                     for (auto cellSet : cellSets)
                     {
                         interfaceConfig.cellSetNames.push_back(cellSet);
                         DEBUG(adapterInfo("      - " + cellSet));
+                    }
+
+                    if (!interfaceConfig.cellSetNames.empty() && interfaceConfig.locationsType != "volume")
+                    {
+                        DEBUG(adapterInfo("Cell sets are not supported for locationType != volume. \n"
+                                          "Please configure the desired interface with the locationsType volume. \n"
+                                          "Have a look in the adapter documentation for detailed information.",
+                                          "warning"));
+                        return false;
                     }
                     
                     DEBUG(adapterInfo("    writeData    : "));

--- a/Adapter.C
+++ b/Adapter.C
@@ -101,9 +101,9 @@ bool preciceAdapter::Adapter::configFileRead()
                     // By default, assume that no mesh connectivity is required (i.e. no nearest-projection mapping)
                     interfaceConfig.meshConnectivity = interfaceDict.lookupOrDefault<bool>("connectivity", false);
                     // Mesh connectivity only makes sense in case of faceNodes, check and raise a warning otherwise
-                    if (interfaceConfig.meshConnectivity && interfaceConfig.locationsType == "faceCenters")
+                    if (interfaceConfig.meshConnectivity && (interfaceConfig.locationsType == "faceCenters" || interfaceConfig.locationsType == "volume"))
                     {
-                        DEBUG(adapterInfo("Mesh connectivity is not supported for faceCenters. \n"
+                        DEBUG(adapterInfo("Mesh connectivity is not supported for faceCenters or volume. \n"
                                           "Please configure the desired interface with the locationsType faceNodes. \n"
                                           "Have a look in the adapter documentation for detailed information.",
                                           "warning"));
@@ -279,7 +279,7 @@ void preciceAdapter::Adapter::configure()
             std::string nameCellDisplacement = FSIenabled_ ? FSI_->getCellDisplacementFieldName() : "default";
             bool restartFromDeformed = FSIenabled_ ? FSI_->isRestartingFromDeformed() : false;
 
-            Interface* interface = new Interface(*precice_, mesh_, interfacesConfig_.at(i).meshName, interfacesConfig_.at(i).locationsType, interfacesConfig_.at(i).patchNames, interfacesConfig_.at(i).meshConnectivity, restartFromDeformed, namePointDisplacement, nameCellDisplacement);
+            Interface* interface = new Interface(*precice_, mesh_, interfacesConfig_.at(i).meshName, interfacesConfig_.at(i).locationsType, interfacesConfig_.at(i).patchNames, interfacesConfig_.at(i).cellSetNames, interfacesConfig_.at(i).meshConnectivity, restartFromDeformed, namePointDisplacement, nameCellDisplacement);
             interfaces_.push_back(interface);
             DEBUG(adapterInfo("Interface created on mesh " + interfacesConfig_.at(i).meshName));
 

--- a/Adapter.C
+++ b/Adapter.C
@@ -121,7 +121,7 @@ bool preciceAdapter::Adapter::configFileRead()
 
                     DEBUG(adapterInfo("    cellSets      : "));
                     auto cellSets = interfaceDict.lookupOrDefault<wordList>("cellSets", wordList());
-                    
+
                     for (auto cellSet : cellSets)
                     {
                         interfaceConfig.cellSetNames.push_back(cellSet);
@@ -136,7 +136,7 @@ bool preciceAdapter::Adapter::configFileRead()
                                           "warning"));
                         return false;
                     }
-                    
+
                     DEBUG(adapterInfo("    writeData    : "));
                     auto writeData = interfaceDict.get<wordList>("writeData");
                     for (auto writeDatum : writeData)

--- a/Adapter.C
+++ b/Adapter.C
@@ -119,7 +119,17 @@ bool preciceAdapter::Adapter::configFileRead()
                         DEBUG(adapterInfo("      - " + patch));
                     }
 
-                    // TODO add cellSetNames
+                    // TODO cellSets don't have to be specified?
+                    // should specifying cellSets only work for locationType volume?
+                    // should we allow *not* specifying cellSets for locationType volume (and assume it's the whole domain)
+                    // + not associating them to patches?
+                    DEBUG(adapterInfo("    cellSets      : "));
+                    auto cellSets = interfaceDict.get<wordList>("cellSets");
+                    for (auto cellSet : cellSets)
+                    {
+                        interfaceConfig.cellSetNames.push_back(cellSet);
+                        DEBUG(adapterInfo("      - " + cellSet));
+                    }
                     
                     DEBUG(adapterInfo("    writeData    : "));
                     auto writeData = interfaceDict.get<wordList>("writeData");

--- a/Adapter.C
+++ b/Adapter.C
@@ -119,7 +119,6 @@ bool preciceAdapter::Adapter::configFileRead()
                         DEBUG(adapterInfo("      - " + patch));
                     }
 
-                    // TODO: check if this works correctly
                     DEBUG(adapterInfo("    cellSets      : "));
                     auto cellSets = interfaceDict.lookupOrDefault<wordList>("cellSets", wordList());
                     

--- a/Adapter.C
+++ b/Adapter.C
@@ -101,9 +101,9 @@ bool preciceAdapter::Adapter::configFileRead()
                     // By default, assume that no mesh connectivity is required (i.e. no nearest-projection mapping)
                     interfaceConfig.meshConnectivity = interfaceDict.lookupOrDefault<bool>("connectivity", false);
                     // Mesh connectivity only makes sense in case of faceNodes, check and raise a warning otherwise
-                    if (interfaceConfig.meshConnectivity && (interfaceConfig.locationsType == "faceCenters" || interfaceConfig.locationsType == "volume"))
+                    if (interfaceConfig.meshConnectivity && (interfaceConfig.locationsType == "faceCenters" || interfaceConfig.locationsType == "volumeCenters" || interfaceConfig.locationsType == "volumeCentres"))
                     {
-                        DEBUG(adapterInfo("Mesh connectivity is not supported for faceCenters or volume. \n"
+                        DEBUG(adapterInfo("Mesh connectivity is not supported for faceCenters or volumeCenters. \n"
                                           "Please configure the desired interface with the locationsType faceNodes. \n"
                                           "Have a look in the adapter documentation for detailed information.",
                                           "warning"));
@@ -128,12 +128,12 @@ bool preciceAdapter::Adapter::configFileRead()
                         DEBUG(adapterInfo("      - " + cellSet));
                     }
 
-                    if (!interfaceConfig.cellSetNames.empty() && interfaceConfig.locationsType != "volume")
+                    if (!interfaceConfig.cellSetNames.empty() && !(interfaceConfig.locationsType == "volumeCenters" || interfaceConfig.locationsType == "volumeCentres"))
                     {
-                        DEBUG(adapterInfo("Cell sets are not supported for locationType != volume. \n"
-                                          "Please configure the desired interface with the locationsType volume. \n"
-                                          "Have a look in the adapter documentation for detailed information.",
-                                          "warning"));
+                        adapterInfo("Cell sets are not supported for locationType != volumeCenters. \n"
+                                    "Please configure the desired interface with the locationsType volumeCenters. \n"
+                                    "Have a look in the adapter documentation for detailed information.",
+                                    "warning");
                         return false;
                     }
 

--- a/Adapter.C
+++ b/Adapter.C
@@ -119,6 +119,8 @@ bool preciceAdapter::Adapter::configFileRead()
                         DEBUG(adapterInfo("      - " + patch));
                     }
 
+                    // TODO add cellSetNames
+                    
                     DEBUG(adapterInfo("    writeData    : "));
                     auto writeData = interfaceDict.get<wordList>("writeData");
                     for (auto writeDatum : writeData)

--- a/Adapter.H
+++ b/Adapter.H
@@ -41,6 +41,7 @@ private:
         std::string locationsType;
         bool meshConnectivity;
         std::vector<std::string> patchNames;
+        std::vector<std::string> cellSetNames;
         std::vector<std::string> writeData;
         std::vector<std::string> readData;
     };

--- a/CHT/Temperature.C
+++ b/CHT/Temperature.C
@@ -21,27 +21,27 @@ void preciceAdapter::CHT::Temperature::write(double* buffer, bool meshConnectivi
 
     if (this->locationType_ == LocationType::volumeCenters)
     {
-        if(cellSetNames_.empty())
+        if (cellSetNames_.empty())
         {
-            forAll(T_->internalField(), i)
+            for (const auto& cell : T_->internalField())
             {
-                buffer[bufferIndex++] = T_->internalField()[i];
+                buffer[bufferIndex++] = cell;
             }
         }
         else
         {
-            for (auto cellSetName : cellSetNames_) {
+            for (const auto& cellSetName : cellSetNames_)
+            {
                 cellSet overlapRegion(T_->mesh(), cellSetName);
-	            const labelList & cells = overlapRegion.toc();
+                const labelList& cells = overlapRegion.toc();
 
-                for(auto currentCell : cells)
+                for (const auto& currentCell : cells)
                 {
                     // Copy temperature into the buffer
                     buffer[bufferIndex++] = T_->ref()[currentCell];
                 }
             }
         }
-        
     }
 
     // For every boundary patch of the interface
@@ -87,27 +87,27 @@ void preciceAdapter::CHT::Temperature::read(double* buffer, const unsigned int d
 
     if (this->locationType_ == LocationType::volumeCenters)
     {
-        if(cellSetNames_.empty())
+        if (cellSetNames_.empty())
         {
-            forAll(T_->ref(), i)
+            for (auto& cell : T_->ref())
             {
-                T_->ref()[i] = buffer[bufferIndex++];
+                cell = buffer[bufferIndex++];
             }
         }
         else
         {
-            for (auto cellSetName : cellSetNames_) {
+            for (const auto& cellSetName : cellSetNames_)
+            {
                 cellSet overlapRegion(T_->mesh(), cellSetName);
-	            const labelList & cells = overlapRegion.toc();
+                const labelList& cells = overlapRegion.toc();
 
-                for(auto currentCell : cells)
+                for (const auto& currentCell : cells)
                 {
                     // Copy temperature into the buffer
                     T_->ref()[currentCell] = buffer[bufferIndex++];
                 }
             }
         }
-        
     }
 
     // For every boundary patch of the interface

--- a/CHT/Temperature.C
+++ b/CHT/Temperature.C
@@ -30,14 +30,14 @@ void preciceAdapter::CHT::Temperature::write(double* buffer, bool meshConnectivi
         }
         else
         {
-            for (uint j = 0; j < cellSetNames_.size(); j++) {
-                cellSet overlapRegion(T_->mesh(), cellSetNames_[j]);
+            for (auto cellSetName : cellSetNames_) {
+                cellSet overlapRegion(T_->mesh(), cellSetName);
 	            const labelList & cells = overlapRegion.toc();
 
-                for( int i=0; i < cells.size(); i++)
+                for(auto currentCell : cells)
                 {
                     // Copy temperature into the buffer
-                    buffer[bufferIndex++] = T_->ref()[cells[i]];
+                    buffer[bufferIndex++] = T_->ref()[currentCell];
                 }
             }
         }
@@ -96,14 +96,14 @@ void preciceAdapter::CHT::Temperature::read(double* buffer, const unsigned int d
         }
         else
         {
-            for (uint j = 0; j < cellSetNames_.size(); j++) {
-                cellSet overlapRegion(T_->mesh(), cellSetNames_[j]);
+            for (auto cellSetName : cellSetNames_) {
+                cellSet overlapRegion(T_->mesh(), cellSetName);
 	            const labelList & cells = overlapRegion.toc();
 
-                for( int i=0; i < cells.size(); i++)
+                for(auto currentCell : cells)
                 {
                     // Copy temperature into the buffer
-                    T_->ref()[cells[i]] = buffer[bufferIndex++];
+                    T_->ref()[currentCell] = buffer[bufferIndex++];
                 }
             }
         }

--- a/CHT/Temperature.C
+++ b/CHT/Temperature.C
@@ -21,10 +21,27 @@ void preciceAdapter::CHT::Temperature::write(double* buffer, bool meshConnectivi
 
     if (this->locationType_ == LocationType::volumeCenters)
     {
-        forAll(T_->internalField(), i)
+        if(cellSetNames_.empty())
         {
-            buffer[bufferIndex++] = T_->internalField()[i];
+            forAll(T_->internalField(), i)
+            {
+                buffer[bufferIndex++] = T_->internalField()[i];
+            }
         }
+        else
+        {
+            for (uint j = 0; j < cellSetNames_.size(); j++) {
+                cellSet overlapRegion(T_->mesh(), cellSetNames_[j]);
+	            const labelList & cells = overlapRegion.toc();
+
+                for( int i=0; i < cells.size(); i++)
+                {
+                    // Copy temperature into the buffer
+                    buffer[bufferIndex++] = T_->ref()[cells[i]];
+                }
+            }
+        }
+        
     }
 
     // For every boundary patch of the interface
@@ -70,10 +87,27 @@ void preciceAdapter::CHT::Temperature::read(double* buffer, const unsigned int d
 
     if (this->locationType_ == LocationType::volumeCenters)
     {
-        forAll(T_->ref(), i)
+        if(cellSetNames_.empty())
         {
-            T_->ref()[i] = buffer[bufferIndex++];
+            forAll(T_->ref(), i)
+            {
+                T_->ref()[i] = buffer[bufferIndex++];
+            }
         }
+        else
+        {
+            for (uint j = 0; j < cellSetNames_.size(); j++) {
+                cellSet overlapRegion(T_->mesh(), cellSetNames_[j]);
+	            const labelList & cells = overlapRegion.toc();
+
+                for( int i=0; i < cells.size(); i++)
+                {
+                    // Copy temperature into the buffer
+                    T_->ref()[cells[i]] = buffer[bufferIndex++];
+                }
+            }
+        }
+        
     }
 
     // For every boundary patch of the interface

--- a/CHT/Temperature.C
+++ b/CHT/Temperature.C
@@ -38,7 +38,7 @@ void preciceAdapter::CHT::Temperature::write(double* buffer, bool meshConnectivi
                 for (const auto& currentCell : cells)
                 {
                     // Copy temperature into the buffer
-                    buffer[bufferIndex++] = T_->ref()[currentCell];
+                    buffer[bufferIndex++] = T_->internalField()[currentCell];
                 }
             }
         }

--- a/CHT/Temperature.H
+++ b/CHT/Temperature.H
@@ -4,6 +4,7 @@
 #include "CouplingDataUser.H"
 
 #include "fvCFD.H"
+#include "cellSet.H"
 
 namespace preciceAdapter
 {

--- a/CouplingDataUser.C
+++ b/CouplingDataUser.C
@@ -29,6 +29,11 @@ void preciceAdapter::CouplingDataUser::setPatchIDs(std::vector<int> patchIDs)
     patchIDs_ = patchIDs;
 }
 
+void preciceAdapter::CouplingDataUser::setCellSetNames(std::vector<std::string> cellSetNames)
+{
+    cellSetNames_ = cellSetNames;
+}
+
 void preciceAdapter::CouplingDataUser::setLocationsType(LocationType locationsType)
 {
     locationType_ = locationsType;

--- a/CouplingDataUser.H
+++ b/CouplingDataUser.H
@@ -33,7 +33,7 @@ protected:
     //- OpenFOAM patches that form the interface
     std::vector<int> patchIDs_;
 
-    //- TODO
+    //- Names of the OpenFOAM cell sets to be coupled (for volume coupling)
     std::vector<std::string> cellSetNames_;
     
     //- data name

--- a/CouplingDataUser.H
+++ b/CouplingDataUser.H
@@ -35,7 +35,7 @@ protected:
 
     //- Names of the OpenFOAM cell sets to be coupled (for volume coupling)
     std::vector<std::string> cellSetNames_;
-    
+
     //- data name
     std::string dataName_;
 

--- a/CouplingDataUser.H
+++ b/CouplingDataUser.H
@@ -33,6 +33,9 @@ protected:
     //- OpenFOAM patches that form the interface
     std::vector<int> patchIDs_;
 
+    //- TODO
+    std::vector<std::string> cellSetNames_;
+    
     //- data name
     std::string dataName_;
 
@@ -57,6 +60,9 @@ public:
 
     //- Set the patch IDs that form the interface
     void setPatchIDs(std::vector<int> patchIDs);
+
+    //- Set the cellSetNames that form the overlapping cells of the interface
+    void setCellSetNames(std::vector<std::string> cellSetNames);
 
     //- Set the locations type of the interface
     void setLocationsType(LocationType locationsType);

--- a/FF/FF.C
+++ b/FF/FF.C
@@ -182,13 +182,6 @@ bool preciceAdapter::FF::FluidFluid::addReaders(std::string dataName, Interface*
             new Pressure(mesh_, nameP_));
         DEBUG(adapterInfo("Added reader: Pressure."));
     }
-    else if (dataName.find("p_rgh") == 0)
-    {
-        interface->addCouplingDataReader(
-            dataName,
-            new Pressure(mesh_, "p_rgh"));
-        DEBUG(adapterInfo("Added reader: Pressure."));
-    }
     else
     {
         found = false;

--- a/FF/FF.C
+++ b/FF/FF.C
@@ -161,13 +161,6 @@ bool preciceAdapter::FF::FluidFluid::addReaders(std::string dataName, Interface*
             new Velocity(mesh_, nameU_));
         DEBUG(adapterInfo("Added reader: Velocity."));
     }
-    else if (dataName.find("VolVelocity") == 0)
-    {
-        interface->addCouplingDataReader(
-            dataName,
-            new Velocity(mesh_, "U_vol"));
-        adapterInfo("Added reader: VolVelocity.");
-    }
     else if (dataName.find("PressureGradient") == 0)
     {
         interface->addCouplingDataReader(

--- a/FF/FF.C
+++ b/FF/FF.C
@@ -161,12 +161,12 @@ bool preciceAdapter::FF::FluidFluid::addReaders(std::string dataName, Interface*
             new Velocity(mesh_, nameU_));
         DEBUG(adapterInfo("Added reader: Velocity."));
     }
-    else if (dataName.find("U_vol") == 0)
+    else if (dataName.find("VolVelocity") == 0)
     {
         interface->addCouplingDataReader(
             dataName,
             new Velocity(mesh_, "U_vol"));
-        DEBUG(adapterInfo("Added reader: Velocity_Volume."));
+        adapterInfo("Added reader: VolVelocity.");
     }
     else if (dataName.find("PressureGradient") == 0)
     {

--- a/FF/FF.C
+++ b/FF/FF.C
@@ -161,6 +161,13 @@ bool preciceAdapter::FF::FluidFluid::addReaders(std::string dataName, Interface*
             new Velocity(mesh_, nameU_));
         DEBUG(adapterInfo("Added reader: Velocity."));
     }
+    else if (dataName.find("U_vol") == 0)
+    {
+        interface->addCouplingDataReader(
+            dataName,
+            new Velocity(mesh_, "U_vol"));
+        DEBUG(adapterInfo("Added reader: Velocity_Volume."));
+    }
     else if (dataName.find("PressureGradient") == 0)
     {
         interface->addCouplingDataReader(
@@ -173,6 +180,13 @@ bool preciceAdapter::FF::FluidFluid::addReaders(std::string dataName, Interface*
         interface->addCouplingDataReader(
             dataName,
             new Pressure(mesh_, nameP_));
+        DEBUG(adapterInfo("Added reader: Pressure."));
+    }
+    else if (dataName.find("p_rgh") == 0)
+    {
+        interface->addCouplingDataReader(
+            dataName,
+            new Pressure(mesh_, "p_rgh"));
         DEBUG(adapterInfo("Added reader: Pressure."));
     }
     else

--- a/FF/Pressure.C
+++ b/FF/Pressure.C
@@ -59,13 +59,8 @@ void preciceAdapter::FF::Pressure::write(double* buffer, bool meshConnectivity, 
 void preciceAdapter::FF::Pressure::read(double* buffer, const unsigned int dim)
 {
     int bufferIndex = 0;
-<<<<<<< HEAD
     
     if (this->locationType_ == LocationType::volumeCenters)
-=======
-
-    if (this->locationType_ == LocationType::volume)
->>>>>>> 16aab8a (foreach loops with references)
     {
         if (cellSetNames_.empty())
         {

--- a/FF/Pressure.C
+++ b/FF/Pressure.C
@@ -35,7 +35,7 @@ void preciceAdapter::FF::Pressure::write(double* buffer, bool meshConnectivity, 
                 for (const auto& currentCell : cells)
                 {
                     // Copy the pressure into the buffer
-                    buffer[bufferIndex++] = p_->ref()[currentCell];
+                    buffer[bufferIndex++] = p_->internalField()[currentCell];
                 }
             }
         }

--- a/FF/Pressure.C
+++ b/FF/Pressure.C
@@ -59,7 +59,7 @@ void preciceAdapter::FF::Pressure::write(double* buffer, bool meshConnectivity, 
 void preciceAdapter::FF::Pressure::read(double* buffer, const unsigned int dim)
 {
     int bufferIndex = 0;
-    
+
     if (this->locationType_ == LocationType::volumeCenters)
     {
         if (cellSetNames_.empty())

--- a/FF/Pressure.C
+++ b/FF/Pressure.C
@@ -27,14 +27,14 @@ void preciceAdapter::FF::Pressure::write(double* buffer, bool meshConnectivity, 
         }
         else
         {
-            for (uint j = 0; j < cellSetNames_.size(); j++) {
-                cellSet overlapRegion(p_->mesh(), cellSetNames_[j]);
+            for (auto cellSetName : cellSetNames_) {
+                cellSet overlapRegion(p_->mesh(), cellSetName);
 	            const labelList & cells = overlapRegion.toc();
 
-                for( int i=0; i < cells.size(); i++)
+                for(auto currentCell : cells)
                 {
                     // Copy the pressure into the buffer
-                    buffer[bufferIndex++] = p_->ref()[cells[i]];
+                    buffer[bufferIndex++] = p_->ref()[currentCell];
                 }
             }
         }
@@ -71,14 +71,14 @@ void preciceAdapter::FF::Pressure::read(double* buffer, const unsigned int dim)
         }
         else 
         {
-            for (uint j = 0; j < cellSetNames_.size(); j++) {
-                cellSet overlapRegion(p_->mesh(), cellSetNames_[j]);
+            for (auto cellSetName : cellSetNames_) {
+                cellSet overlapRegion(p_->mesh(), cellSetName);
 	            const labelList & cells = overlapRegion.toc();
 
-                for( int i=0; i < cells.size(); i++)
+                for(auto currentCell : cells)
                 {
                     // Copy the pressure into the buffer
-                    p_->ref()[cells[i]] = buffer[bufferIndex++];
+                    p_->ref()[currentCell] = buffer[bufferIndex++];
                 }
             }
         }

--- a/FF/Pressure.C
+++ b/FF/Pressure.C
@@ -18,27 +18,27 @@ void preciceAdapter::FF::Pressure::write(double* buffer, bool meshConnectivity, 
 
     if (this->locationType_ == LocationType::volumeCenters)
     {
-        if(cellSetNames_.empty())
+        if (cellSetNames_.empty())
         {
-            forAll(p_->internalField(), i)
+            for (const auto& cell : p_->internalField())
             {
-                buffer[bufferIndex++] = p_->internalField()[i];
+                buffer[bufferIndex++] = cell;
             }
         }
         else
         {
-            for (auto cellSetName : cellSetNames_) {
+            for (const auto& cellSetName : cellSetNames_)
+            {
                 cellSet overlapRegion(p_->mesh(), cellSetName);
-	            const labelList & cells = overlapRegion.toc();
+                const labelList& cells = overlapRegion.toc();
 
-                for(auto currentCell : cells)
+                for (const auto& currentCell : cells)
                 {
                     // Copy the pressure into the buffer
                     buffer[bufferIndex++] = p_->ref()[currentCell];
                 }
             }
         }
-        
     }
 
     // For every boundary patch of the interface
@@ -59,30 +59,35 @@ void preciceAdapter::FF::Pressure::write(double* buffer, bool meshConnectivity, 
 void preciceAdapter::FF::Pressure::read(double* buffer, const unsigned int dim)
 {
     int bufferIndex = 0;
+<<<<<<< HEAD
     
     if (this->locationType_ == LocationType::volumeCenters)
+=======
+
+    if (this->locationType_ == LocationType::volume)
+>>>>>>> 16aab8a (foreach loops with references)
     {
-        if(cellSetNames_.empty())
+        if (cellSetNames_.empty())
         {
-            forAll(p_->ref(), i)
+            for (auto& cell : p_->ref())
             {
-                p_->ref()[i] = buffer[bufferIndex++];
+                cell = buffer[bufferIndex++];
             }
         }
-        else 
+        else
         {
-            for (auto cellSetName : cellSetNames_) {
+            for (const auto& cellSetName : cellSetNames_)
+            {
                 cellSet overlapRegion(p_->mesh(), cellSetName);
-	            const labelList & cells = overlapRegion.toc();
+                const labelList& cells = overlapRegion.toc();
 
-                for(auto currentCell : cells)
+                for (const auto& currentCell : cells)
                 {
                     // Copy the pressure into the buffer
                     p_->ref()[currentCell] = buffer[bufferIndex++];
                 }
             }
         }
-        
     }
 
     // For every boundary patch of the interface

--- a/FF/Pressure.C
+++ b/FF/Pressure.C
@@ -43,6 +43,9 @@ void preciceAdapter::FF::Pressure::read(double* buffer, const unsigned int dim)
 {
     int bufferIndex = 0;
 
+    cellSet overlapRegion(p_, cellSetNames_[j]);
+	const labelList & cells = overlapRegion.toc();
+    
     if (this->locationType_ == LocationType::volumeCenters)
     {
         forAll(p_->ref(), i)

--- a/FF/Pressure.H
+++ b/FF/Pressure.H
@@ -4,6 +4,7 @@
 #include "CouplingDataUser.H"
 
 #include "fvCFD.H"
+#include "cellSet.H"
 
 namespace preciceAdapter
 {

--- a/FF/Velocity.C
+++ b/FF/Velocity.C
@@ -6,22 +6,21 @@ preciceAdapter::FF::Velocity::Velocity(
     const Foam::fvMesh& mesh,
     const std::string nameU)
 {
-    if (nameU.compare("U_vol") == 0) {
+    if (mesh.foundObject<volVectorField>(nameU))
+    {
+        U_ = const_cast<volVectorField*>(
+            &mesh.lookupObject<volVectorField>(nameU));
+    }
+    else
+    {
         U_ = new volVectorField(
-            IOobject
-            (
-                "U_vol",
+            IOobject(
+                nameU,
                 mesh.time().timeName(),
                 mesh,
                 IOobject::MUST_READ,
-                IOobject::AUTO_WRITE
-            ),
-            mesh
-        );
-    }
-    else {
-        U_ = const_cast<volVectorField*>(
-        &mesh.lookupObject<volVectorField>(nameU));
+                IOobject::AUTO_WRITE),
+            mesh);
     }
     dataType_ = vector;
 }

--- a/FF/Velocity.C
+++ b/FF/Velocity.C
@@ -18,18 +18,43 @@ void preciceAdapter::FF::Velocity::write(double* buffer, bool meshConnectivity, 
 
     if (this->locationType_ == LocationType::volumeCenters)
     {
-        forAll(U_->internalField(), i)
+        if(cellSetNames_.empty())
         {
-            // x-dimension
-            buffer[bufferIndex++] = U_->internalField()[i].x();
-
-            // y-dimension
-            buffer[bufferIndex++] = U_->internalField()[i].y();
-
-            if (dim == 3)
+            forAll(U_->internalField(), i)
             {
-                // z-dimension
-                buffer[bufferIndex++] = U_->internalField()[i].z();
+                // x-dimension
+                buffer[bufferIndex++] = U_->internalField()[i].x();
+
+                // y-dimension
+                buffer[bufferIndex++] = U_->internalField()[i].y();
+
+                if (dim == 3)
+                {
+                    // z-dimension
+                    buffer[bufferIndex++] = U_->internalField()[i].z();
+                }
+            }
+        }
+        else 
+        {
+            for (uint j = 0; j < cellSetNames_.size(); j++) {
+                cellSet overlapRegion(U_->mesh(), cellSetNames_[j]);
+	            const labelList & cells = overlapRegion.toc();
+
+                for( int i=0; i < cells.size(); i++)
+                {
+                    // x-dimension
+                    buffer[bufferIndex++] = U_->ref()[cells[i]].x();
+
+                    // y-dimension
+                    buffer[bufferIndex++] = U_->ref()[cells[i]].y();
+
+                    if (dim == 3)
+                    {
+                        // z-dimension
+                        buffer[bufferIndex++] = U_->ref()[cells[i]].z();
+                    }
+                }
             }
         }
     }
@@ -67,20 +92,46 @@ void preciceAdapter::FF::Velocity::read(double* buffer, const unsigned int dim)
 
     if (this->locationType_ == LocationType::volumeCenters)
     {
-        forAll(U_->ref(), i)
+        if(cellSetNames_.empty())
         {
-            // x-dimension
-            U_->ref()[i].x() = buffer[bufferIndex++];
-
-            // y-dimension
-            U_->ref()[i].y() = buffer[bufferIndex++];
-
-            if (dim == 3)
+            forAll(U_->ref(), i)
             {
-                // z-dimension
-                U_->ref()[i].z() = buffer[bufferIndex++];
+                // x-dimension
+                U_->ref()[i].x() = buffer[bufferIndex++];
+
+                // y-dimension
+                U_->ref()[i].y() = buffer[bufferIndex++];
+
+                if (dim == 3)
+                {
+                    // z-dimension
+                    U_->ref()[i].z() = buffer[bufferIndex++];
+                }
             }
         }
+        else
+        {
+            for (uint j = 0; j < cellSetNames_.size(); j++) {
+                cellSet overlapRegion(U_->mesh(), cellSetNames_[j]);
+	            const labelList & cells = overlapRegion.toc();
+
+                for( int i=0; i < cells.size(); i++)
+                {
+                    // x-dimension
+                    U_->ref()[cells[i]].x() = buffer[bufferIndex++];
+
+                    // y-dimension
+                    U_->ref()[cells[i]].y() = buffer[bufferIndex++];
+
+                    if (dim == 3)
+                    {
+                        // z-dimension
+                        U_->ref()[cells[i]].z() = buffer[bufferIndex++];
+                    }
+                }
+            }
+        }
+        
     }
 
     // For every boundary patch of the interface

--- a/FF/Velocity.C
+++ b/FF/Velocity.C
@@ -37,22 +37,22 @@ void preciceAdapter::FF::Velocity::write(double* buffer, bool meshConnectivity, 
         }
         else 
         {
-            for (uint j = 0; j < cellSetNames_.size(); j++) {
-                cellSet overlapRegion(U_->mesh(), cellSetNames_[j]);
+            for (auto cellSetName : cellSetNames_) {
+                cellSet overlapRegion(U_->mesh(), cellSetName);
 	            const labelList & cells = overlapRegion.toc();
 
-                for( int i=0; i < cells.size(); i++)
+                for(auto currentCell : cells)
                 {
                     // x-dimension
-                    buffer[bufferIndex++] = U_->ref()[cells[i]].x();
+                    buffer[bufferIndex++] = U_->ref()[currentCell].x();
 
                     // y-dimension
-                    buffer[bufferIndex++] = U_->ref()[cells[i]].y();
+                    buffer[bufferIndex++] = U_->ref()[currentCell].y();
 
                     if (dim == 3)
                     {
                         // z-dimension
-                        buffer[bufferIndex++] = U_->ref()[cells[i]].z();
+                        buffer[bufferIndex++] = U_->ref()[currentCell].z();
                     }
                 }
             }
@@ -111,22 +111,22 @@ void preciceAdapter::FF::Velocity::read(double* buffer, const unsigned int dim)
         }
         else
         {
-            for (uint j = 0; j < cellSetNames_.size(); j++) {
-                cellSet overlapRegion(U_->mesh(), cellSetNames_[j]);
+            for (auto cellSetName : cellSetNames_) {
+                cellSet overlapRegion(U_->mesh(), cellSetName);
 	            const labelList & cells = overlapRegion.toc();
 
-                for( int i=0; i < cells.size(); i++)
+                for(auto currentCell : cells)
                 {
                     // x-dimension
-                    U_->ref()[cells[i]].x() = buffer[bufferIndex++];
+                    U_->ref()[currentCell].x() = buffer[bufferIndex++];
 
                     // y-dimension
-                    U_->ref()[cells[i]].y() = buffer[bufferIndex++];
+                    U_->ref()[currentCell].y() = buffer[bufferIndex++];
 
                     if (dim == 3)
                     {
                         // z-dimension
-                        U_->ref()[cells[i]].z() = buffer[bufferIndex++];
+                        U_->ref()[currentCell].z() = buffer[bufferIndex++];
                     }
                 }
             }

--- a/FF/Velocity.C
+++ b/FF/Velocity.C
@@ -18,30 +18,31 @@ void preciceAdapter::FF::Velocity::write(double* buffer, bool meshConnectivity, 
 
     if (this->locationType_ == LocationType::volumeCenters)
     {
-        if(cellSetNames_.empty())
+        if (cellSetNames_.empty())
         {
-            forAll(U_->internalField(), i)
+            for (const auto& cell : U_->internalField())
             {
                 // x-dimension
-                buffer[bufferIndex++] = U_->internalField()[i].x();
+                buffer[bufferIndex++] = cell.x();
 
                 // y-dimension
-                buffer[bufferIndex++] = U_->internalField()[i].y();
+                buffer[bufferIndex++] = cell.y();
 
                 if (dim == 3)
                 {
                     // z-dimension
-                    buffer[bufferIndex++] = U_->internalField()[i].z();
+                    buffer[bufferIndex++] = cell.z();
                 }
             }
         }
-        else 
+        else
         {
-            for (auto cellSetName : cellSetNames_) {
+            for (const auto& cellSetName : cellSetNames_)
+            {
                 cellSet overlapRegion(U_->mesh(), cellSetName);
-	            const labelList & cells = overlapRegion.toc();
+                const labelList& cells = overlapRegion.toc();
 
-                for(auto currentCell : cells)
+                for (const auto& currentCell : cells)
                 {
                     // x-dimension
                     buffer[bufferIndex++] = U_->ref()[currentCell].x();
@@ -92,30 +93,31 @@ void preciceAdapter::FF::Velocity::read(double* buffer, const unsigned int dim)
 
     if (this->locationType_ == LocationType::volumeCenters)
     {
-        if(cellSetNames_.empty())
+        if (cellSetNames_.empty())
         {
-            forAll(U_->ref(), i)
+            for (auto& cell : U_->ref())
             {
                 // x-dimension
-                U_->ref()[i].x() = buffer[bufferIndex++];
+                cell.x() = buffer[bufferIndex++];
 
                 // y-dimension
-                U_->ref()[i].y() = buffer[bufferIndex++];
+                cell.y() = buffer[bufferIndex++];
 
                 if (dim == 3)
                 {
                     // z-dimension
-                    U_->ref()[i].z() = buffer[bufferIndex++];
+                    cell.z() = buffer[bufferIndex++];
                 }
             }
         }
         else
         {
-            for (auto cellSetName : cellSetNames_) {
+            for (const auto& cellSetName : cellSetNames_)
+            {
                 cellSet overlapRegion(U_->mesh(), cellSetName);
-	            const labelList & cells = overlapRegion.toc();
+                const labelList& cells = overlapRegion.toc();
 
-                for(auto currentCell : cells)
+                for (const auto& currentCell : cells)
                 {
                     // x-dimension
                     U_->ref()[currentCell].x() = buffer[bufferIndex++];
@@ -131,7 +133,6 @@ void preciceAdapter::FF::Velocity::read(double* buffer, const unsigned int dim)
                 }
             }
         }
-        
     }
 
     // For every boundary patch of the interface

--- a/FF/Velocity.C
+++ b/FF/Velocity.C
@@ -5,10 +5,24 @@ using namespace Foam;
 preciceAdapter::FF::Velocity::Velocity(
     const Foam::fvMesh& mesh,
     const std::string nameU)
-: U_(
-    const_cast<volVectorField*>(
-        &mesh.lookupObject<volVectorField>(nameU)))
 {
+    if (nameU.compare("U_vol") == 0) {
+        U_ = new volVectorField(
+            IOobject
+            (
+                "U_vol",
+                mesh.time().timeName(),
+                mesh,
+                IOobject::MUST_READ,
+                IOobject::AUTO_WRITE
+            ),
+            mesh
+        );
+    }
+    else {
+        U_ = const_cast<volVectorField*>(
+        &mesh.lookupObject<volVectorField>(nameU));
+    }
     dataType_ = vector;
 }
 

--- a/FF/Velocity.C
+++ b/FF/Velocity.C
@@ -45,15 +45,15 @@ void preciceAdapter::FF::Velocity::write(double* buffer, bool meshConnectivity, 
                 for (const auto& currentCell : cells)
                 {
                     // x-dimension
-                    buffer[bufferIndex++] = U_->ref()[currentCell].x();
+                    buffer[bufferIndex++] = U_->internalField()[currentCell].x();
 
                     // y-dimension
-                    buffer[bufferIndex++] = U_->ref()[currentCell].y();
+                    buffer[bufferIndex++] = U_->internalField()[currentCell].y();
 
                     if (dim == 3)
                     {
                         // z-dimension
-                        buffer[bufferIndex++] = U_->ref()[currentCell].z();
+                        buffer[bufferIndex++] = U_->internalField()[currentCell].z();
                     }
                 }
             }

--- a/FF/Velocity.H
+++ b/FF/Velocity.H
@@ -4,6 +4,7 @@
 #include "CouplingDataUser.H"
 
 #include "fvCFD.H"
+#include "cellSet.H"
 
 namespace preciceAdapter
 {

--- a/Interface.C
+++ b/Interface.C
@@ -1,17 +1,19 @@
 #include "Interface.H"
 #include "Utilities.H"
 #include "faceTriangulation.H"
+#include "cellSet.H"
 
 
 using namespace Foam;
 
-// TODO add cellSetNames to constructor + adjust meshConfig
+// TODO adjust meshConfig
 preciceAdapter::Interface::Interface(
     precice::Participant& precice,
     const fvMesh& mesh,
     std::string meshName,
     std::string locationsType,
     std::vector<std::string> patchNames,
+    std::vector<std::string> cellSetNames,
     bool meshConnectivity,
     bool restartFromDeformed,
     const std::string& namePointDisplacement,
@@ -19,6 +21,7 @@ preciceAdapter::Interface::Interface(
 : precice_(precice),
   meshName_(meshName),
   patchNames_(patchNames),
+  cellSetNames_(cellSetNames),
   meshConnectivity_(meshConnectivity),
   restartFromDeformed_(restartFromDeformed)
 {
@@ -330,11 +333,28 @@ void preciceAdapter::Interface::configureMesh(const fvMesh& mesh, const std::str
     }
     else if (locationType_ == LocationType::volumeCenters)
     {
+
+        // TODO is volume option added everywhere it's supposed to
+
         // The volume coupling implementation considers the mesh points in the volume and
         // on the boundary patches in order to take the boundary conditions into account
 
-        // Get the number of (volume centered) mesh points in the volume
-        numDataLocations_ = mesh.C().size();
+        // Get the cell labels of the overlapping region
+	    std::vector<labelList> overlapCells;
+        // For every cellSet that participates in the coupling
+	    for (uint j = 0; j < cellSetNames_.size(); j++)
+	    {
+		    // Create a cell set
+		    cellSet overlapRegion(mesh, cellSetNames_[j]);
+
+            // Add the cells ID's to the vector and count how many overlap cells does the interface has
+            overlapCells.push_back(overlapRegion.toc());
+            numDataLocations_ += overlapCells[j].size();
+	    }
+
+        // --FULL domain: get the number of (volume centered) mesh points in the volume
+        // numDataLocations_ = mesh.C().size();
+        // ----------------------------------
 
         // Count the data locations for all the patches
         // and add those to the previously determined number of mesh points in the volume
@@ -356,7 +376,8 @@ void preciceAdapter::Interface::configureMesh(const fvMesh& mesh, const std::str
         // Initialize the index of the vertices array
         int verticesIndex = 0;
 
-        // Get the locations of the volume centered mesh vertices
+        //--FULL domain: Get the locations of the volume centered mesh vertices
+        /*
         const vectorField& CellCenters = mesh.C();
 
         for (auto i = 0; i < CellCenters.size(); i++)
@@ -366,6 +387,22 @@ void preciceAdapter::Interface::configureMesh(const fvMesh& mesh, const std::str
             if (dim_ == 3)
             {
                 vertices[verticesIndex++] = CellCenters[i].z();
+            }
+        }*/
+        //--------------------------------------------
+
+        // for all the overlapping cells (cellSets)
+        for (uint j = 0; j < cellSetNames_.size(); j++)
+        {
+            // Get the cell centres of the current cellSet.
+            const labelList & cells = overlapCells.at(j);
+
+            // Get the coordinates of the cells of the current cellSet.
+            for (int i=0; i < cells.size(); i++)
+            {
+                vertices[verticesIndex++] = mesh.C().internalField()[cells[i]].x();
+                vertices[verticesIndex++] = mesh.C().internalField()[cells[i]].y();
+                vertices[verticesIndex++] = mesh.C().internalField()[cells[i]].z();
             }
         }
 
@@ -405,6 +442,9 @@ void preciceAdapter::Interface::addCouplingDataWriter(
     // Set the patchIDs of the patches that form the interface
     couplingDataWriter->setPatchIDs(patchIDs_);
 
+    // TODO
+    couplingDataWriter->setCellSetNames(cellSetNames_);
+
     // Set the location type in the CouplingDataUser class
     couplingDataWriter->setLocationsType(locationType_);
 
@@ -431,6 +471,9 @@ void preciceAdapter::Interface::addCouplingDataReader(
 
     // Set the location type in the CouplingDataUser class
     couplingDataReader->setLocationsType(locationType_);
+
+    // TODO
+    couplingDataReader->setCellSetNames(cellSetNames_);
 
     // Check, if the current location type is supported by the data type
     couplingDataReader->checkDataLocation(meshConnectivity_);

--- a/Interface.C
+++ b/Interface.C
@@ -348,7 +348,7 @@ void preciceAdapter::Interface::configureMesh(const fvMesh& mesh, const std::str
                 // Create a cell set
                 cellSet overlapRegion(mesh, cellSetNames_[j]);
 
-                // Add the cells ID's to the vector and count how many overlap cells does the interface has
+                // Add the cells IDs to the vector and count how many overlap cells the interface has
                 overlapCells.push_back(overlapRegion.toc());
                 numDataLocations_ += overlapCells[j].size();
             }
@@ -446,7 +446,7 @@ void preciceAdapter::Interface::addCouplingDataWriter(
     // Set the patchIDs of the patches that form the interface
     couplingDataWriter->setPatchIDs(patchIDs_);
 
-    // TODO
+    // Set the names of the cell sets to be coupled (for volume coupling)
     couplingDataWriter->setCellSetNames(cellSetNames_);
 
     // Set the location type in the CouplingDataUser class
@@ -476,7 +476,7 @@ void preciceAdapter::Interface::addCouplingDataReader(
     // Set the location type in the CouplingDataUser class
     couplingDataReader->setLocationsType(locationType_);
 
-    // TODO
+    // Set the names of the cell sets to be coupled (for volume coupling)
     couplingDataReader->setCellSetNames(cellSetNames_);
 
     // Check, if the current location type is supported by the data type

--- a/Interface.C
+++ b/Interface.C
@@ -332,9 +332,6 @@ void preciceAdapter::Interface::configureMesh(const fvMesh& mesh, const std::str
     }
     else if (locationType_ == LocationType::volumeCenters)
     {
-
-        // TODO is volume option added everywhere it's supposed to
-
         // The volume coupling implementation considers the mesh points in the volume and
         // on the boundary patches in order to take the boundary conditions into account
 

--- a/Interface.C
+++ b/Interface.C
@@ -5,6 +5,7 @@
 
 using namespace Foam;
 
+// TODO add cellSetNames to constructor + adjust meshConfig
 preciceAdapter::Interface::Interface(
     precice::Participant& precice,
     const fvMesh& mesh,

--- a/Interface.C
+++ b/Interface.C
@@ -6,7 +6,6 @@
 
 using namespace Foam;
 
-// TODO adjust meshConfig
 preciceAdapter::Interface::Interface(
     precice::Participant& precice,
     const fvMesh& mesh,
@@ -390,7 +389,10 @@ void preciceAdapter::Interface::configureMesh(const fvMesh& mesh, const std::str
                 {
                     vertices[verticesIndex++] = mesh.C().internalField()[cells[i]].x();
                     vertices[verticesIndex++] = mesh.C().internalField()[cells[i]].y();
-                    vertices[verticesIndex++] = mesh.C().internalField()[cells[i]].z();
+                    if (dim_ == 3)
+                    {
+                        vertices[verticesIndex++] = mesh.C().internalField()[cells[i]].z();
+                    }   
                 }
             }
         }

--- a/Interface.C
+++ b/Interface.C
@@ -341,7 +341,8 @@ void preciceAdapter::Interface::configureMesh(const fvMesh& mesh, const std::str
         // Get the cell labels of the overlapping region
         std::vector<labelList> overlapCells;
 
-        if (!cellSetNames_.empty()){
+        if (!cellSetNames_.empty())
+        {
             // For every cellSet that participates in the coupling
             for (uint j = 0; j < cellSetNames_.size(); j++)
             {
@@ -353,7 +354,8 @@ void preciceAdapter::Interface::configureMesh(const fvMesh& mesh, const std::str
                 numDataLocations_ += overlapCells[j].size();
             }
         }
-        else {
+        else
+        {
             numDataLocations_ = mesh.C().size();
         }
 
@@ -377,26 +379,28 @@ void preciceAdapter::Interface::configureMesh(const fvMesh& mesh, const std::str
         // Initialize the index of the vertices array
         int verticesIndex = 0;
 
-        if (!cellSetNames_.empty()){
+        if (!cellSetNames_.empty())
+        {
             // for all the overlapping cells (cellSets)
             for (uint j = 0; j < cellSetNames_.size(); j++)
             {
                 // Get the cell centres of the current cellSet.
-                const labelList & cells = overlapCells.at(j);
+                const labelList& cells = overlapCells.at(j);
 
                 // Get the coordinates of the cells of the current cellSet.
-                for (int i=0; i < cells.size(); i++)
+                for (int i = 0; i < cells.size(); i++)
                 {
                     vertices[verticesIndex++] = mesh.C().internalField()[cells[i]].x();
                     vertices[verticesIndex++] = mesh.C().internalField()[cells[i]].y();
                     if (dim_ == 3)
                     {
                         vertices[verticesIndex++] = mesh.C().internalField()[cells[i]].z();
-                    }   
+                    }
                 }
             }
         }
-        else {
+        else
+        {
             const vectorField& CellCenters = mesh.C();
 
             for (int i = 0; i < CellCenters.size(); i++)
@@ -409,7 +413,7 @@ void preciceAdapter::Interface::configureMesh(const fvMesh& mesh, const std::str
                 }
             }
         }
-        
+
         // Get the locations of the mesh vertices (here: face centers)
         // for all the patches
         for (uint j = 0; j < patchIDs_.size(); j++)

--- a/Interface.H
+++ b/Interface.H
@@ -33,6 +33,9 @@ protected:
     //- OpenFOAM patches that form the interface
     std::vector<int> patchIDs_;
 
+    //- TODO
+    std::vector<std::string> cellSetNames_;
+
     //- Number of data points (cell centers) on the interface
     int numDataLocations_ = 0;
 
@@ -63,6 +66,7 @@ protected:
                        const std::string& namePointDisplacement,
                        const std::string& nameCellDisplacement);
 
+// TODO add cellSetNames to constructor
 public:
     //- Constructor
     Interface(

--- a/Interface.H
+++ b/Interface.H
@@ -66,7 +66,6 @@ protected:
                        const std::string& namePointDisplacement,
                        const std::string& nameCellDisplacement);
 
-// TODO add cellSetNames to constructor
 public:
     //- Constructor
     Interface(
@@ -75,6 +74,7 @@ public:
         std::string meshName,
         std::string locationsType,
         std::vector<std::string> patchNames,
+        std::vector<std::string> cellSetNames,
         bool meshConnectivity,
         bool restartFromDeformed,
         const std::string& namePointDisplacement,

--- a/Interface.H
+++ b/Interface.H
@@ -33,7 +33,7 @@ protected:
     //- OpenFOAM patches that form the interface
     std::vector<int> patchIDs_;
 
-    //- TODO
+    //- Names of the OpenFOAM cell sets to be coupled (for volume coupling)
     std::vector<std::string> cellSetNames_;
 
     //- Number of data points (cell centers) on the interface

--- a/changelog-entries/270.md
+++ b/changelog-entries/270.md
@@ -1,0 +1,1 @@
+- Added volume coupling over one or multiple domain regions specified by OpenFOAM cellSets (for Pressure and Velocity (FF) and Temperature (FF))

--- a/docs/config.md
+++ b/docs/config.md
@@ -249,6 +249,7 @@ Reading volume-coupled variables in OpenFOAM is still experimental. This section
 {% endexperimental %}
 
 #### Volume coupling over a domain region
+
 We use OpenFOAM's `cellSets` to define one or multiple volume coupling regions. You can create one or multiple `cellSets` using `topoSetDict`, for example:
 
 ```C++
@@ -265,6 +266,7 @@ actions
 ```
 
 The `cellSets` you want to couple have to be listed by name in `preciceDict`'s `cellSets` field lie this:
+
 ```C++
 Interface1
 {

--- a/docs/config.md
+++ b/docs/config.md
@@ -231,7 +231,7 @@ We already have reasons to believe that a `fixedGradient` can have [side-effects
 In order to use volume coupling with OpenFOAM as a solely writing participant, it is enough to specify `volumeCenters` for the `locations` field. This will couple the whole internal field of the domain. Patches can be specified additionally, or the list of patch names can be left empty.
 
 If you want to use OpenFOAM as a reading participant in a volume coupling scenario and enforce a source term, it is necessary to use OpenFOAM's [finite volume options](https://www.openfoam.com/documentation/guides/latest/doc/guide-fvoptions.html) `fvOptions`. Otherwise, the value read in OpenFOAM would most likely be overwritten by the end of OpenFOAM's iteration due to the nature of OpenFOAM's workflow.
-The `fvOptions` construct provides many different options for sources, but we have benefitted specifically from [coded sources]{https://www.openfoam.com/documentation/guides/latest/doc/guide-fvoptions-sources-coded.html}.
+The `fvOptions` construct provides many different options for sources, but we have benefitted specifically from [coded sources](https://www.openfoam.com/documentation/guides/latest/doc/guide-fvoptions-sources-coded.html).
 
 Using a `codedSource` for reading fields and enforcing source terms in OpenFOAM would currently only work for `Velocity`. It is necessary for the user to specify an alternative name for `U` in `preciceDict`:
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Have a look at the file `CONTRIBUTING.md` for a few hints and guidelines. -->

Based on [PR#88](https://github.com/precice/openfoam-adapter/pull/88).

Adds the option to configure one or multiple coupling regions defined by OpenFOAM `cellSets`.

Relevant tutorial case: [volume-coupled flow](https://github.com/precice/tutorials/pull/350)

TODO list:

- [x] I updated the documentation in `docs/`
- [x] I added a changelog entry in `changelog-entries/` (create directory if missing)
