### PR TITLE
Update Actions set-output syntax

### DIFF
--- a/.github/workflows/build-custom.yml
+++ b/.github/workflows/build-custom.yml
@@ -82,69 +82,69 @@ jobs:
           OpenFOAMv2212)
             wget -q -O - https://dl.openfoam.com/add-debian-repo.sh | sudo bash
             sudo apt-get install openfoam2212-dev
-            echo "::set-output name=openfoam_exec::/usr/bin/openfoam2212";;
+            echo "{openfoam_exec}={/usr/bin/openfoam2212}" >> $GITHUB_OUTPUT
           OpenFOAMv2206)
             wget -q -O - https://dl.openfoam.com/add-debian-repo.sh | sudo bash
             sudo apt-get install openfoam2206-dev
-            echo "::set-output name=openfoam_exec::/usr/bin/openfoam2206";;
+            echo "{openfoam_exec}={/usr/bin/openfoam2206}" >> $GITHUB_OUTPUT
           OpenFOAMv2112)
             wget -q -O - https://dl.openfoam.com/add-debian-repo.sh | sudo bash
             sudo apt-get install openfoam2112-dev
-            echo "::set-output name=openfoam_exec::/usr/bin/openfoam2112";;
+            echo "{openfoam_exec}={/usr/bin/openfoam2112}" >> $GITHUB_OUTPUT
           OpenFOAMv2106)
             wget -q -O - https://dl.openfoam.com/add-debian-repo.sh | sudo bash
             sudo apt-get install openfoam2106-dev
-            echo "::set-output name=openfoam_exec::/usr/bin/openfoam2106";;
+            echo "{openfoam_exec}={/usr/bin/openfoam2106}" >> $GITHUB_OUTPUT
           OpenFOAMv2012)
             wget -q -O - https://dl.openfoam.com/add-debian-repo.sh | sudo bash
             sudo apt-get install openfoam2012-dev
-            echo "::set-output name=openfoam_exec::/usr/bin/openfoam2012";;
+            echo "{openfoam_exec}={/usr/bin/openfoam2012}" >> $GITHUB_OUTPUT
           OpenFOAMv2006)
             wget -q -O - https://dl.openfoam.com/add-debian-repo.sh | sudo bash
             sudo apt-get install openfoam2006-dev
-            echo "::set-output name=openfoam_exec::/usr/bin/openfoam2006";;
+            echo "{openfoam_exec}={/usr/bin/openfoam2006}" >> $GITHUB_OUTPUT
           OpenFOAMv1912)
             wget -q -O - https://dl.openfoam.com/add-debian-repo.sh | sudo bash
             sudo apt-get install openfoam1912-dev
-            echo "::set-output name=openfoam_exec::/usr/bin/openfoam1912";;
+            echo "{openfoam_exec}={/usr/bin/openfoam1912}" >> $GITHUB_OUTPUT
           OpenFOAM10)
             sudo sh -c "wget -O - https://dl.openfoam.org/gpg.key | apt-key add -"
             sudo add-apt-repository http://dl.openfoam.org/ubuntu
             sudo apt-get update
             sudo apt-get -y install openfoam10
-            echo "::set-output name=openfoam_exec::. /opt/openfoam10/etc/bashrc &&";;
+            echo "{openfoam_exec}={. /opt/openfoam10/etc/bashrc &&}" >> $GITHUB_OUTPUT
           OpenFOAM9)
             sudo sh -c "wget -O - https://dl.openfoam.org/gpg.key | apt-key add -"
             sudo add-apt-repository http://dl.openfoam.org/ubuntu
             sudo apt-get update
             sudo apt-get -y install openfoam9
-            echo "::set-output name=openfoam_exec::. /opt/openfoam9/etc/bashrc &&";;
+            echo "{openfoam_exec}={. /opt/openfoam9/etc/bashrc &&}" >> $GITHUB_OUTPUT
           OpenFOAM8)
             sudo sh -c "wget -O - https://dl.openfoam.org/gpg.key | apt-key add -"
             sudo add-apt-repository http://dl.openfoam.org/ubuntu
             sudo apt-get update
             sudo apt-get -y install openfoam8
-            echo "::set-output name=openfoam_exec::. /opt/openfoam8/etc/bashrc &&";;
+            echo "{openfoam_exec}={. /opt/openfoam8/etc/bashrc &&}" >> $GITHUB_OUTPUT
           OpenFOAM7)
             sudo sh -c "wget -O - https://dl.openfoam.org/gpg.key | apt-key add -"
             sudo add-apt-repository http://dl.openfoam.org/ubuntu
             sudo apt-get update
             sudo apt-get -y install openfoam7
-            echo "::set-output name=openfoam_exec::. /opt/openfoam7/etc/bashrc &&";;
+            echo "{openfoam_exec}={. /opt/openfoam7/etc/bashrc &&}" >> $GITHUB_OUTPUT
           OpenFOAM6)
             echo "OpenFOAM 6 is only available on Ubuntu 18.04 or older."
             sudo sh -c "wget -O - https://dl.openfoam.org/gpg.key | apt-key add -"
             sudo add-apt-repository http://dl.openfoam.org/ubuntu
             sudo apt-get update
             sudo apt-get -y install openfoam6
-            echo "::set-output name=openfoam_exec::. /opt/openfoam6/etc/bashrc &&";;
+            echo "{openfoam_exec}={. /opt/openfoam6/etc/bashrc &&}" >> $GITHUB_OUTPUT
           OpenFOAM5)
             echo "OpenFOAM 5 is only available on Ubuntu 18.04 or older."
             sudo sh -c "wget -O - https://dl.openfoam.org/gpg.key | apt-key add -"
             sudo add-apt-repository http://dl.openfoam.org/ubuntu
             sudo apt-get update
             sudo apt-get -y install openfoam5
-            echo "::set-output name=openfoam_exec::. /opt/openfoam5/etc/bashrc &&";;
+            echo "{openfoam_exec}={. /opt/openfoam5/etc/bashrc &&}" >> $GITHUB_OUTPUT
           *)
             echo "I cannot find ${{ github.event.inputs.refAdapter }} in my known options."
             exit 1;;

--- a/.github/workflows/build-custom.yml
+++ b/.github/workflows/build-custom.yml
@@ -82,69 +82,69 @@ jobs:
           OpenFOAMv2212)
             wget -q -O - https://dl.openfoam.com/add-debian-repo.sh | sudo bash
             sudo apt-get install openfoam2212-dev
-            echo "{openfoam_exec}={/usr/bin/openfoam2212}" >> $GITHUB_OUTPUT
+            echo "{openfoam_exec}={/usr/bin/openfoam2212}" >> $GITHUB_OUTPUT;;
           OpenFOAMv2206)
             wget -q -O - https://dl.openfoam.com/add-debian-repo.sh | sudo bash
             sudo apt-get install openfoam2206-dev
-            echo "{openfoam_exec}={/usr/bin/openfoam2206}" >> $GITHUB_OUTPUT
+            echo "{openfoam_exec}={/usr/bin/openfoam2206}" >> $GITHUB_OUTPUT;;
           OpenFOAMv2112)
             wget -q -O - https://dl.openfoam.com/add-debian-repo.sh | sudo bash
             sudo apt-get install openfoam2112-dev
-            echo "{openfoam_exec}={/usr/bin/openfoam2112}" >> $GITHUB_OUTPUT
+            echo "{openfoam_exec}={/usr/bin/openfoam2112}" >> $GITHUB_OUTPUT;;
           OpenFOAMv2106)
             wget -q -O - https://dl.openfoam.com/add-debian-repo.sh | sudo bash
             sudo apt-get install openfoam2106-dev
-            echo "{openfoam_exec}={/usr/bin/openfoam2106}" >> $GITHUB_OUTPUT
+            echo "{openfoam_exec}={/usr/bin/openfoam2106}" >> $GITHUB_OUTPUT;;
           OpenFOAMv2012)
             wget -q -O - https://dl.openfoam.com/add-debian-repo.sh | sudo bash
             sudo apt-get install openfoam2012-dev
-            echo "{openfoam_exec}={/usr/bin/openfoam2012}" >> $GITHUB_OUTPUT
+            echo "{openfoam_exec}={/usr/bin/openfoam2012}" >> $GITHUB_OUTPUT;;
           OpenFOAMv2006)
             wget -q -O - https://dl.openfoam.com/add-debian-repo.sh | sudo bash
             sudo apt-get install openfoam2006-dev
-            echo "{openfoam_exec}={/usr/bin/openfoam2006}" >> $GITHUB_OUTPUT
+            echo "{openfoam_exec}={/usr/bin/openfoam2006}" >> $GITHUB_OUTPUT;;
           OpenFOAMv1912)
             wget -q -O - https://dl.openfoam.com/add-debian-repo.sh | sudo bash
             sudo apt-get install openfoam1912-dev
-            echo "{openfoam_exec}={/usr/bin/openfoam1912}" >> $GITHUB_OUTPUT
+            echo "{openfoam_exec}={/usr/bin/openfoam1912}" >> $GITHUB_OUTPUT;;
           OpenFOAM10)
             sudo sh -c "wget -O - https://dl.openfoam.org/gpg.key | apt-key add -"
             sudo add-apt-repository http://dl.openfoam.org/ubuntu
             sudo apt-get update
             sudo apt-get -y install openfoam10
-            echo "{openfoam_exec}={. /opt/openfoam10/etc/bashrc &&}" >> $GITHUB_OUTPUT
+            echo "{openfoam_exec}={. /opt/openfoam10/etc/bashrc &&}" >> $GITHUB_OUTPUT;;
           OpenFOAM9)
             sudo sh -c "wget -O - https://dl.openfoam.org/gpg.key | apt-key add -"
             sudo add-apt-repository http://dl.openfoam.org/ubuntu
             sudo apt-get update
             sudo apt-get -y install openfoam9
-            echo "{openfoam_exec}={. /opt/openfoam9/etc/bashrc &&}" >> $GITHUB_OUTPUT
+            echo "{openfoam_exec}={. /opt/openfoam9/etc/bashrc &&}" >> $GITHUB_OUTPUT;;
           OpenFOAM8)
             sudo sh -c "wget -O - https://dl.openfoam.org/gpg.key | apt-key add -"
             sudo add-apt-repository http://dl.openfoam.org/ubuntu
             sudo apt-get update
             sudo apt-get -y install openfoam8
-            echo "{openfoam_exec}={. /opt/openfoam8/etc/bashrc &&}" >> $GITHUB_OUTPUT
+            echo "{openfoam_exec}={. /opt/openfoam8/etc/bashrc &&}" >> $GITHUB_OUTPUT;;
           OpenFOAM7)
             sudo sh -c "wget -O - https://dl.openfoam.org/gpg.key | apt-key add -"
             sudo add-apt-repository http://dl.openfoam.org/ubuntu
             sudo apt-get update
             sudo apt-get -y install openfoam7
-            echo "{openfoam_exec}={. /opt/openfoam7/etc/bashrc &&}" >> $GITHUB_OUTPUT
+            echo "{openfoam_exec}={. /opt/openfoam7/etc/bashrc &&}" >> $GITHUB_OUTPUT;;
           OpenFOAM6)
             echo "OpenFOAM 6 is only available on Ubuntu 18.04 or older."
             sudo sh -c "wget -O - https://dl.openfoam.org/gpg.key | apt-key add -"
             sudo add-apt-repository http://dl.openfoam.org/ubuntu
             sudo apt-get update
             sudo apt-get -y install openfoam6
-            echo "{openfoam_exec}={. /opt/openfoam6/etc/bashrc &&}" >> $GITHUB_OUTPUT
+            echo "{openfoam_exec}={. /opt/openfoam6/etc/bashrc &&}" >> $GITHUB_OUTPUT;;
           OpenFOAM5)
             echo "OpenFOAM 5 is only available on Ubuntu 18.04 or older."
             sudo sh -c "wget -O - https://dl.openfoam.org/gpg.key | apt-key add -"
             sudo add-apt-repository http://dl.openfoam.org/ubuntu
             sudo apt-get update
             sudo apt-get -y install openfoam5
-            echo "{openfoam_exec}={. /opt/openfoam5/etc/bashrc &&}" >> $GITHUB_OUTPUT
+            echo "{openfoam_exec}={. /opt/openfoam5/etc/bashrc &&}" >> $GITHUB_OUTPUT;;
           *)
             echo "I cannot find ${{ github.event.inputs.refAdapter }} in my known options."
             exit 1;;


### PR DESCRIPTION
Based on the deprecation described in https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

Triggered a [custom build](https://github.com/precice/openfoam-adapter/actions/runs/4213332611) to check.

TODO list:

- I updated the documentation in `docs/` -> N/A
- I added a changelog entry in `changelog-entries/` (create directory if missing) -> Not user-facing or of any other significance.
