### PR TITLE
Fix comment about WM_NCOMPPROCS in Allwmake

### DIFF
--- a/Allwmake
+++ b/Allwmake
@@ -10,7 +10,7 @@ ADAPTER_PREP_FLAGS=""
 
 # Build command and options
 # In order to compile with multiple threads, set the environment variable WM_NCOMPPROCS,
-# e.g., add "export WM_NCOMP_PROCS=4" to your ~/.bashrc
+# e.g., add "export WM_NCOMPPROCS=4" to your ~/.bashrc
 # Make sure that these options are supported by your OpenFOAM version.
 adapter_build_command(){
     wmake libso


### PR DESCRIPTION
This is trivial: WM_NCOMP_PROCS -> WM_NCOMPPROCS

<!-- Thank you for your contribution! Have a look at the file `CONTRIBUTING.md` for a few hints and guidelines. -->

TODO list:

- [ ] I updated the documentation in `docs/`
- [ ] I added a changelog entry in `changelog-entries/` (create directory if missing)
