### PR TITLE
Allow overriding of the ADAPTER_PREP_FLAGS variable

### DIFF
--- a/Allwmake
+++ b/Allwmake
@@ -6,7 +6,7 @@ set -e -u
 # Optional: Preprocessor flags
 # "-DADAPTER_DEBUG_MODE" enables debug messages
 # "-DADAPTER_ENABLE_TIMINGS" enables time measurements
-ADAPTER_PREP_FLAGS=""
+ADAPTER_PREP_FLAGS="${ADAPTER_PREP_FLAGS:-}"
 
 # Build command and options
 # In order to compile with multiple threads, set the environment variable WM_NCOMPPROCS,

--- a/docs/get.md
+++ b/docs/get.md
@@ -16,7 +16,7 @@ To build the adapter, you need to install a few dependencies and then execute th
 
 The adapter also requires [pkg-config](https://linux.die.net/man/1/pkg-config) to [link to preCICE](https://precice.org/installation-linking.html). This is a very common dependency on Linux and is usually already installed.
 
-You can set compile flags by either changing the `ADAPTER_PREP_FLAGS` variable in the `Allwmake` script, or you can influence the value of `ADAPTER_PREP_FLAGS` by setting it as an environment variable.
+You can set compile flags by either changing the `ADAPTER_PREP_FLAGS` variable in the `Allwmake` script, or directly setting the value of `ADAPTER_PREP_FLAGS`  as an environment variable.
 To do so, `export ADAPTER_PREP_FLAGS="-D<desired> -D<options>"` before compiling the adapter.
 
 Adding the `-DADAPTER_DEBUG_MODE` flag to the `ADAPTER_PREP_FLAGS` activates additional debug messages. You may also change the target directory or specify the number of threads to use for the compilation. See the comments in `Allwmake` for more.

--- a/docs/get.md
+++ b/docs/get.md
@@ -16,6 +16,9 @@ To build the adapter, you need to install a few dependencies and then execute th
 
 The adapter also requires [pkg-config](https://linux.die.net/man/1/pkg-config) to [link to preCICE](https://precice.org/installation-linking.html). This is a very common dependency on Linux and is usually already installed.
 
+You can set compile flags by either changing the `ADAPTER_PREP_FLAGS` variable in the `Allwmake` script, or you can influence the value of `ADAPTER_PREP_FLAGS` by setting it as an environment variable.
+To do so, `export ADAPTER_PREP_FLAGS="-D<desired> -D<options>"` before compiling the adapter.
+
 Adding the `-DADAPTER_DEBUG_MODE` flag to the `ADAPTER_PREP_FLAGS` activates additional debug messages. You may also change the target directory or specify the number of threads to use for the compilation. See the comments in `Allwmake` for more.
 
 Adding the `-DADAPTER_ENABLE_TIMINGS` flag to the `ADAPTER_PREP_FLAGS` activates time measurements for several regions of the adapter, printed at the end of the simulation output (available since v1.2.0).


### PR DESCRIPTION
Currently the ADAPTER_PREP_FLAGS needs to be changed in the source code. This patch allows users to `export ADAPTER_PREP_FLAGS=` to alter the value of the variable through the environment without having to change the code.

<!-- Thank you for your contribution! Have a look at the file `CONTRIBUTING.md` for a few hints and guidelines. -->

TODO list:

- [x] I updated the documentation in `docs/`
- [ ] I added a changelog entry in `changelog-entries/` (create directory if missing)
