### PR TITLE
Add citing guidelines in README and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ See the [adapter documentation](https://precice.org/adapter-openfoam-overview.ht
 
 Please [report any issues](https://github.com/precice/openfoam-adapter/issues) here and give us feedback through [one of our community channels](https://precice.org/community-channels.html).
 
+This project is actively maintained on [precice/openfoam-adapter](https://github.com/precice/openfoam-adapter). Current maintainers: [@MakisH](https://github.com/MakisH/) and [@DavidSCN](https://github.com/DavidSCN).
+
 ## Contributing
 
 We welcome contributions! Have a look at open [good first issues](https://github.com/precice/openfoam-adapter/issues?q=is%3Aopen+is%3Aissue+label%3A%22good+first+issue%22) and [where we need help](https://github.com/precice/openfoam-adapter/issues?q=is%3Aopen+is%3Aissue+label%3A%22help+wanted%22).
@@ -23,30 +25,11 @@ Check the file `CONTRIBUTING.md` for a few tips and guidelines.
 
 ## Citing
 
-Whenever using or referring to this adapter in academic publications, please cite it [1]. See the option "Cite this repository" in the "About" section, as well as the [preCICE literature guide](https://precice.org/fundamentals-literature-guide.html) for more information.
-
-## History
-
-This project is actively maintained on [precice/openfoam-adapter](https://github.com/precice/openfoam-adapter). Current maintainers: [@MakisH](https://github.com/MakisH/) and [@DavidSCN](https://github.com/DavidSCN).
-
-This adapter was developed as part of [Gerasimos Chourdakis' master's thesis](https://mediatum.ub.tum.de/1462269) [2].
-It is based on [previous work](https://github.com/ludcila/CHT-preCICE) by Lucia Cheung ([master's thesis](https://www5.in.tum.de/pub/Cheung2016_Thesis.pdf) [3], in cooperation with [SimScale](https://www.simscale.com/)).
-
-The fluid-structure interaction module was developed in close collaboration between Gerasimos Chourdakis and Derek Risseeuw (TU Delft), in the context of the [master's thesis of the latter](http://resolver.tudelft.nl/uuid:70beddde-e870-4c62-9a2f-8758b4e49123) [4]. We would also like to thank David Schneider (Univ. Siegen / TUM) and Maximilian Müller (TU Braunschweig) for sharing the code and experience of their similar previous work.
-
-The fluid-fluid coupling module was added by Gerasimos Chourdakis, in the context of his dissertation. [#67](https://github.com/precice/openfoam-adapter/pull/67)
-
-The adapter is [easily extensible](https://precice.org/adapter-openfoam-extend.html).
+Whenever using or referring to this adapter in academic publications, please cite it [1]. See the option "Cite this repository" in the "About" section, as well as the [preCICE literature guide](https://precice.org/fundamentals-literature-guide.html) and the [adapter overview page](https://precice.org/adapter-openfoam-overview.html) for more information.
 
 ## References
 
 [1] Chourdakis, G., Schneider, D., & Uekermann, B. (2023). OpenFOAM-preCICE: Coupling OpenFOAM with External Solvers for Multi-Physics Simulations. OpenFOAM® Journal, 3, 1–25. [DOI: 10.51560/ofj.v3.88](https://doi.org/10.51560/ofj.v3.88)
-
-[2] Gerasimos Chourdakis. A general OpenFOAM adapter for the coupling library preCICE. Master's thesis, Department of Informatics, Technical University of Munich, 2017.
-
-[3] Lucia Cheung Yau. Conjugate heat transfer with the multiphysics coupling library preCICE. Master’s thesis, Department of Informatics, Technical University of Munich, 2016.
-
-[4] Derek Risseeuw. Fluid Structure Interaction Modelling of Flapping Wings. Master's thesis, Faculty of Aerospace Engineering, Delft University of Technology, 2019.
 
 ## Disclaimer
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Check the file `CONTRIBUTING.md` for a few tips and guidelines.
 
 ## Citing
 
-Whenever using or referring to this adapter in academic publications, please cite it. See the option "Cite this repository" in the "About" section, as well as the [preCICE literature guide](https://precice.org/fundamentals-literature-guide.html) for a reference paper [4].
+Whenever using or referring to this adapter in academic publications, please cite it [4]. See the option "Cite this repository" in the "About" section, as well as the [preCICE literature guide](https://precice.org/fundamentals-literature-guide.html) for more information.
 
 ## History
 

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ The adapter is [easily extensible](https://precice.org/adapter-openfoam-extend.h
 
 ## References
 
-[1] Chourdakis, G., Schneider, D., & Uekermann, B. (2023). OpenFOAM-preCICE: Coupling OpenFOAM with External Solvers for Multi-Physics Simulations. OpenFOAM® Journal, 3, 1–25. https://doi.org/10.51560/ofj.v3.88
+[1] Chourdakis, G., Schneider, D., & Uekermann, B. (2023). OpenFOAM-preCICE: Coupling OpenFOAM with External Solvers for Multi-Physics Simulations. OpenFOAM® Journal, 3, 1–25. [DOI: 10.51560/ofj.v3.88](https://doi.org/10.51560/ofj.v3.88)
 
 [2] Gerasimos Chourdakis. A general OpenFOAM adapter for the coupling library preCICE. Master's thesis, Department of Informatics, Technical University of Munich, 2017.
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Check the file `CONTRIBUTING.md` for a few tips and guidelines.
 
 ## Citing
 
-Whenever using or referring to this adapter in academic publications, please cite it. See the [CITATION.cff](./CITATION.cff) file, as well as the [preCICE literature guide](https://precice.org/fundamentals-literature-guide.html) for a reference paper.
+Whenever using or referring to this adapter in academic publications, please cite it. See the option "Cite this repository" in the "About" section, as well as the [preCICE literature guide](https://precice.org/fundamentals-literature-guide.html) for a reference paper.
 
 ## History
 

--- a/README.md
+++ b/README.md
@@ -21,6 +21,10 @@ We welcome contributions! Have a look at open [good first issues](https://github
 
 Check the file `CONTRIBUTING.md` for a few tips and guidelines.
 
+## Citing
+
+Whenever using or referring to this adapter in academic publications, please cite it. See the [CITATION.cff](./CITATION.cff) file, as well as the [preCICE literature guide](https://precice.org/fundamentals-literature-guide.html) for a reference paper.
+
 ## History
 
 This project is actively maintained on [precice/openfoam-adapter](https://github.com/precice/openfoam-adapter). Current maintainers: [@MakisH](https://github.com/MakisH/) and [@DavidSCN](https://github.com/DavidSCN).

--- a/README.md
+++ b/README.md
@@ -23,16 +23,16 @@ Check the file `CONTRIBUTING.md` for a few tips and guidelines.
 
 ## Citing
 
-Whenever using or referring to this adapter in academic publications, please cite it [4]. See the option "Cite this repository" in the "About" section, as well as the [preCICE literature guide](https://precice.org/fundamentals-literature-guide.html) for more information.
+Whenever using or referring to this adapter in academic publications, please cite it [1]. See the option "Cite this repository" in the "About" section, as well as the [preCICE literature guide](https://precice.org/fundamentals-literature-guide.html) for more information.
 
 ## History
 
 This project is actively maintained on [precice/openfoam-adapter](https://github.com/precice/openfoam-adapter). Current maintainers: [@MakisH](https://github.com/MakisH/) and [@DavidSCN](https://github.com/DavidSCN).
 
-This adapter was developed as part of [Gerasimos Chourdakis' master's thesis](https://mediatum.ub.tum.de/1462269) [1].
-It is based on [previous work](https://github.com/ludcila/CHT-preCICE) by Lucia Cheung ([master's thesis](https://www5.in.tum.de/pub/Cheung2016_Thesis.pdf) [2], in cooperation with [SimScale](https://www.simscale.com/)).
+This adapter was developed as part of [Gerasimos Chourdakis' master's thesis](https://mediatum.ub.tum.de/1462269) [2].
+It is based on [previous work](https://github.com/ludcila/CHT-preCICE) by Lucia Cheung ([master's thesis](https://www5.in.tum.de/pub/Cheung2016_Thesis.pdf) [3], in cooperation with [SimScale](https://www.simscale.com/)).
 
-The fluid-structure interaction module was developed in close collaboration between Gerasimos Chourdakis and Derek Risseeuw (TU Delft), in the context of the [master's thesis of the latter](http://resolver.tudelft.nl/uuid:70beddde-e870-4c62-9a2f-8758b4e49123) [3]. We would also like to thank David Schneider (Univ. Siegen / TUM) and Maximilian Müller (TU Braunschweig) for sharing the code and experience of their similar previous work.
+The fluid-structure interaction module was developed in close collaboration between Gerasimos Chourdakis and Derek Risseeuw (TU Delft), in the context of the [master's thesis of the latter](http://resolver.tudelft.nl/uuid:70beddde-e870-4c62-9a2f-8758b4e49123) [4]. We would also like to thank David Schneider (Univ. Siegen / TUM) and Maximilian Müller (TU Braunschweig) for sharing the code and experience of their similar previous work.
 
 The fluid-fluid coupling module was added by Gerasimos Chourdakis, in the context of his dissertation. [#67](https://github.com/precice/openfoam-adapter/pull/67)
 
@@ -40,13 +40,13 @@ The adapter is [easily extensible](https://precice.org/adapter-openfoam-extend.h
 
 ## References
 
-[1] Gerasimos Chourdakis. A general OpenFOAM adapter for the coupling library preCICE. Master's thesis, Department of Informatics, Technical University of Munich, 2017.
+[1] Chourdakis, G., Schneider, D., & Uekermann, B. (2023). OpenFOAM-preCICE: Coupling OpenFOAM with External Solvers for Multi-Physics Simulations. OpenFOAM® Journal, 3, 1–25. https://doi.org/10.51560/ofj.v3.88
 
-[2] Lucia Cheung Yau. Conjugate heat transfer with the multiphysics coupling library preCICE. Master’s thesis, Department of Informatics, Technical University of Munich, 2016.
+[2] Gerasimos Chourdakis. A general OpenFOAM adapter for the coupling library preCICE. Master's thesis, Department of Informatics, Technical University of Munich, 2017.
 
-[3] Derek Risseeuw. Fluid Structure Interaction Modelling of Flapping Wings. Master's thesis, Faculty of Aerospace Engineering, Delft University of Technology, 2019.
+[3] Lucia Cheung Yau. Conjugate heat transfer with the multiphysics coupling library preCICE. Master’s thesis, Department of Informatics, Technical University of Munich, 2016.
 
-[4] Chourdakis, G., Schneider, D., & Uekermann, B. (2023). OpenFOAM-preCICE: Coupling OpenFOAM with External Solvers for Multi-Physics Simulations. OpenFOAM® Journal, 3, 1–25. https://doi.org/10.51560/ofj.v3.88
+[4] Derek Risseeuw. Fluid Structure Interaction Modelling of Flapping Wings. Master's thesis, Faculty of Aerospace Engineering, Delft University of Technology, 2019.
 
 ## Disclaimer
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Check the file `CONTRIBUTING.md` for a few tips and guidelines.
 
 ## Citing
 
-Whenever using or referring to this adapter in academic publications, please cite it. See the option "Cite this repository" in the "About" section, as well as the [preCICE literature guide](https://precice.org/fundamentals-literature-guide.html) for a reference paper.
+Whenever using or referring to this adapter in academic publications, please cite it. See the option "Cite this repository" in the "About" section, as well as the [preCICE literature guide](https://precice.org/fundamentals-literature-guide.html) for a reference paper [4].
 
 ## History
 
@@ -45,6 +45,8 @@ The adapter is [easily extensible](https://precice.org/adapter-openfoam-extend.h
 [2] Lucia Cheung Yau. Conjugate heat transfer with the multiphysics coupling library preCICE. Master’s thesis, Department of Informatics, Technical University of Munich, 2016.
 
 [3] Derek Risseeuw. Fluid Structure Interaction Modelling of Flapping Wings. Master's thesis, Faculty of Aerospace Engineering, Delft University of Technology, 2019.
+
+[4] Chourdakis, G., Schneider, D., & Uekermann, B. (2023). OpenFOAM-preCICE: Coupling OpenFOAM with External Solvers for Multi-Physics Simulations. OpenFOAM® Journal, 3, 1–25. https://doi.org/10.51560/ofj.v3.88
 
 ## Disclaimer
 

--- a/changelog-entries/287.md
+++ b/changelog-entries/287.md
@@ -1,0 +1,1 @@
+- Added citing guidelines, refering to the [new reference article at the OpenFOAM Journal](https://doi.org/10.51560/ofj.v3.88). [#287](https://github.com/precice/openfoam-adapter/pull/287)

--- a/changelog-entries/287.md
+++ b/changelog-entries/287.md
@@ -1,1 +1,1 @@
-- Added citing guidelines, refering to the [new reference article at the OpenFOAM Journal](https://doi.org/10.51560/ofj.v3.88). [#287](https://github.com/precice/openfoam-adapter/pull/287)
+- Added citing guidelines, referring to the [new reference article at the OpenFOAM Journal](https://doi.org/10.51560/ofj.v3.88). [#287](https://github.com/precice/openfoam-adapter/pull/287)

--- a/docs/README.md
+++ b/docs/README.md
@@ -43,7 +43,7 @@ our [training session from the 15th OpenFOAM Workshop](https://mediatum.ub.tum.d
 
 ## Cite
 
-Please cite this adapter using our [reference paper at the OpenFOAM Journal](https://doi.org/10.51560/ofj.v3.88) [1]. See the [preCICE literature guide](https://precice.org/fundamentals-literature-guide.html) for more details.
+Please cite this adapter using our [reference paper in the OpenFOAM Journal](https://doi.org/10.51560/ofj.v3.88) [1]. See the [preCICE literature guide](https://precice.org/fundamentals-literature-guide.html) for more details.
 
 For the design of the adapter as an OpenFOAM adapter (and especially the function object approach), see the Master's thesis of Gerasimos Chourdakis [2]. For CHT-specific topics, you may want to additionally look into the Master's thesis of Lucia Cheung Yau [3] and for the FSI module into the Master's thesis of Derek Risseeuw [4].
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -45,7 +45,18 @@ our [training session from the 15th OpenFOAM Workshop](https://mediatum.ub.tum.d
 
 Please cite this adapter using our [reference paper in the OpenFOAM Journal](https://doi.org/10.51560/ofj.v3.88) [1]. See the [preCICE literature guide](https://precice.org/fundamentals-literature-guide.html) for more details.
 
-For the design of the adapter as an OpenFOAM adapter (and especially the function object approach), see the Master's thesis of Gerasimos Chourdakis [2]. For CHT-specific topics, you may want to additionally look into the Master's thesis of Lucia Cheung Yau [3] and for the FSI module into the Master's thesis of Derek Risseeuw [4].
+## History
+
+This project is actively maintained on [precice/openfoam-adapter](https://github.com/precice/openfoam-adapter). Current maintainers: [@MakisH](https://github.com/MakisH/) and [@DavidSCN](https://github.com/DavidSCN).
+
+This adapter was developed as part of [Gerasimos Chourdakis' master's thesis](https://mediatum.ub.tum.de/1462269) [2].
+It is based on [previous work](https://github.com/ludcila/CHT-preCICE) by Lucia Cheung ([master's thesis](https://www5.in.tum.de/pub/Cheung2016_Thesis.pdf) [3], in cooperation with [SimScale](https://www.simscale.com/)).
+
+The fluid-structure interaction module was developed in close collaboration between Gerasimos Chourdakis and Derek Risseeuw (TU Delft), in the context of the [master's thesis of the latter](http://resolver.tudelft.nl/uuid:70beddde-e870-4c62-9a2f-8758b4e49123) [4]. We would also like to thank David Schneider (Univ. Siegen / TUM) and Maximilian Müller (TU Braunschweig) for sharing the code and experience of their similar previous work.
+
+The fluid-fluid coupling module was added by Gerasimos Chourdakis, in the context of his dissertation. [#67](https://github.com/precice/openfoam-adapter/pull/67)
+
+The adapter is [easily extensible](https://precice.org/adapter-openfoam-extend.html).
 
 ### Related literature
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -43,21 +43,19 @@ our [training session from the 15th OpenFOAM Workshop](https://mediatum.ub.tum.d
 
 ## Cite
 
-We are currently working on an up-to-date reference paper. Until then, please cite this adapter using [1]:
+Please cite this adapter using our [reference paper at the OpenFOAM Journal](https://doi.org/10.51560/ofj.v3.88) [1]. See the [preCICE literature guide](https://precice.org/fundamentals-literature-guide.html) for more details.
 
-```text
-Gerasimos Chourdakis. A general OpenFOAM adapter for the coupling library preCICE. Master's thesis, Department of Informatics, Technical University of Munich, 2017.
-```
-
-For CHT-specific topics, you may want to additionally look into [2] and for FSI into [3].
+For the design of the adapter as an OpenFOAM adapter (and especially the function object approach), see the Master's thesis of Gerasimos Chourdakis [2]. For CHT-specific topics, you may want to additionally look into the Master's thesis of Lucia Cheung Yau [3] and for the FSI module into the Master's thesis of Derek Risseeuw [4].
 
 ### Related literature
 
-[1] Gerasimos Chourdakis. [A general OpenFOAM adapter for the coupling library preCICE](https://mediatum.ub.tum.de/1462269). Master's thesis, Department of Informatics, Technical University of Munich, 2017.
+[1] Chourdakis, G., Schneider, D., & Uekermann, B. (2023). OpenFOAM-preCICE: Coupling OpenFOAM with External Solvers for Multi-Physics Simulations. OpenFOAM® Journal, 3, 1–25. [DOI: 10.51560/ofj.v3.88](https://doi.org/10.51560/ofj.v3.88)
 
-[2] Lucia Cheung Yau. [Conjugate heat transfer with the multiphysics coupling library preCICE](http://www5.in.tum.de/pub/Cheung2016_Thesis.pdf). Master’s thesis, Department of Informatics, Technical University of Munich, 2016.
+[2] Gerasimos Chourdakis. A general OpenFOAM adapter for the coupling library preCICE. Master's thesis, Department of Informatics, Technical University of Munich, 2017.
 
-[3] Derek Risseeuw. [Fluid Structure Interaction Modelling of Flapping Wings](https://repository.tudelft.nl/islandora/object/uuid:70beddde-e870-4c62-9a2f-8758b4e49123). Master's thesis, Faculty of Aerospace Engineering, Delft University of Technology, 2019.
+[3] Lucia Cheung Yau. Conjugate heat transfer with the multiphysics coupling library preCICE. Master’s thesis, Department of Informatics, Technical University of Munich, 2016.
+
+[4] Derek Risseeuw. Fluid Structure Interaction Modelling of Flapping Wings. Master's thesis, Faculty of Aerospace Engineering, Delft University of Technology, 2019.
 
 {% disclaimer %}
 This offering is not approved or endorsed by OpenCFD Limited, producer and distributor of the OpenFOAM software via www.openfoam.com, and owner of the OPENFOAM®  and OpenCFD®  trade marks.


### PR DESCRIPTION
This adds a citing section in our README.md:

![Screenshot from 2023-04-11 16-38-53](https://user-images.githubusercontent.com/4943683/231185118-3c8d6805-ed01-430c-bbe0-74e57d8d511c.png)

___

It also updates the [adapter overview page](https://precice.org/adapter-openfoam-overview.html):

![Screenshot from 2023-04-11 16-54-20](https://user-images.githubusercontent.com/4943683/231185462-f369349c-6f5e-4c8e-883f-e10216c390c9.png)

___

A question now is if we still need the rest of the references and history in the main `README.md`. @davidscn what do you think? Anything else to update?

- [x] I updated the documentation in `docs/`
- [x] I added a changelog entry in `changelog-entries/` (create directory if missing)
