### PR TITLE
Fix iterator in FSI reader and writer for multiple patches

### DIFF
--- a/FSI/Displacement.C
+++ b/FSI/Displacement.C
@@ -48,6 +48,7 @@ void preciceAdapter::FSI::Displacement::write(double* buffer, bool meshConnectiv
 
     if (this->locationType_ == LocationType::faceCenters)
     {
+        int bufferIndex = 0;
         // For every boundary patch of the interface
         for (const label patchID : patchIDs_)
         {
@@ -56,7 +57,7 @@ void preciceAdapter::FSI::Displacement::write(double* buffer, bool meshConnectiv
             forAll(cellDisplacement_->boundaryField()[patchID], i)
             {
                 for (unsigned int d = 0; d < dim; ++d)
-                    buffer[i * dim + d] =
+                    buffer[bufferIndex++] =
                         cellDisplacement_->boundaryField()[patchID][i][d];
             }
         }
@@ -69,6 +70,7 @@ void preciceAdapter::FSI::Displacement::write(double* buffer, bool meshConnectiv
             "See https://github.com/precice/openfoam-adapter/issues/153.",
             "warning"));
 
+        int bufferIndex = 0;
         // For every boundary patch of the interface
         for (const label patchID : patchIDs_)
         {
@@ -80,7 +82,7 @@ void preciceAdapter::FSI::Displacement::write(double* buffer, bool meshConnectiv
                     mesh_.boundaryMesh()[patchID].meshPoints();
 
                 for (unsigned int d = 0; d < dim; ++d)
-                    buffer[i * dim + d] =
+                    buffer[bufferIndex++] =
                         pointDisplacement_->internalField()[meshPoints[i]][d];
             }
         }
@@ -91,6 +93,7 @@ void preciceAdapter::FSI::Displacement::write(double* buffer, bool meshConnectiv
 // return the displacement to use later in the velocity?
 void preciceAdapter::FSI::Displacement::read(double* buffer, const unsigned int dim)
 {
+    int bufferIndex = 0;
     for (unsigned int j = 0; j < patchIDs_.size(); j++)
     {
         // Get the ID of the current patch
@@ -98,14 +101,13 @@ void preciceAdapter::FSI::Displacement::read(double* buffer, const unsigned int 
 
         if (this->locationType_ == LocationType::faceCenters)
         {
-
             // the boundaryCellDisplacement is a vector and ordered according to the iterator j
             // and not according to the patchID
             // First, copy the buffer data into the center based vectorFields on each interface patch
             forAll(cellDisplacement_->boundaryField()[patchID], i)
             {
                 for (unsigned int d = 0; d < dim; ++d)
-                    cellDisplacement_->boundaryFieldRef()[patchID][i][d] = buffer[i * dim + d];
+                    cellDisplacement_->boundaryFieldRef()[patchID][i][d] = buffer[bufferIndex++];
             }
 
             if (pointDisplacement_ != nullptr)
@@ -132,7 +134,7 @@ void preciceAdapter::FSI::Displacement::read(double* buffer, const unsigned int 
             forAll(pointDisplacement_->boundaryFieldRef()[patchID], i)
             {
                 for (unsigned int d = 0; d < dim; ++d)
-                    pointDisplacementFluidPatch[i][d] = buffer[i * dim + d];
+                    pointDisplacementFluidPatch[i][d] = buffer[bufferIndex++];
             }
         }
     }

--- a/FSI/DisplacementDelta.C
+++ b/FSI/DisplacementDelta.C
@@ -49,6 +49,7 @@ void preciceAdapter::FSI::DisplacementDelta::write(double* buffer, bool meshConn
 // return the displacement to use later in the velocity?
 void preciceAdapter::FSI::DisplacementDelta::read(double* buffer, const unsigned int dim)
 {
+    int bufferIndex = 0;
     for (unsigned int j = 0; j < patchIDs_.size(); j++)
     {
         // Get the ID of the current patch
@@ -65,7 +66,7 @@ void preciceAdapter::FSI::DisplacementDelta::read(double* buffer, const unsigned
             forAll(cellDisplacement_->boundaryField()[patchID], i)
             {
                 for (unsigned int d = 0; d < dim; ++d)
-                    cellDisplacement_->boundaryFieldRef()[patchID][i][d] = buffer[i * dim + d];
+                    cellDisplacement_->boundaryFieldRef()[patchID][i][d] = buffer[bufferIndex++];
             }
             // Get a reference to the displacement on the point patch in order to overwrite it
             vectorField& pointDisplacementFluidPatch(
@@ -88,7 +89,7 @@ void preciceAdapter::FSI::DisplacementDelta::read(double* buffer, const unsigned
             forAll(pointDisplacement_->boundaryFieldRef()[patchID], i)
             {
                 for (unsigned int d = 0; d < dim; ++d)
-                    pointDisplacementFluidPatch[i][d] += buffer[i * dim + d];
+                    pointDisplacementFluidPatch[i][d] += buffer[bufferIndex++];
             }
         }
     }

--- a/FSI/Force.C
+++ b/FSI/Force.C
@@ -48,6 +48,7 @@ void preciceAdapter::FSI::Force::read(double* buffer, const unsigned int dim)
     // Here we assume that a force volVectorField exists, which is used by
     // the OpenFOAM solver
 
+    int bufferIndex = 0;
     // Set boundary forces
     for (unsigned int j = 0; j < patchIDs_.size(); j++)
     {
@@ -63,7 +64,7 @@ void preciceAdapter::FSI::Force::read(double* buffer, const unsigned int dim)
             forAll(force, i)
             {
                 for (unsigned int d = 0; d < dim; ++d)
-                    force[i][d] = buffer[i * dim + d];
+                    force[i][d] = buffer[bufferIndex++];
             }
         }
         else if (this->locationType_ == LocationType::faceNodes)

--- a/FSI/ForceBase.C
+++ b/FSI/ForceBase.C
@@ -148,6 +148,7 @@ void preciceAdapter::FSI::ForceBase::writeToBuffer(double* buffer,
     // Pressure boundary field
     const auto& pb = mesh_.lookupObject<volScalarField>("p").boundaryField();
 
+    int bufferIndex = 0;
     // For every boundary patch of the interface
     for (const label patchID : patchIDs_)
     {
@@ -183,7 +184,7 @@ void preciceAdapter::FSI::ForceBase::writeToBuffer(double* buffer,
         forAll(forceField.boundaryField()[patchID], i)
         {
             for (unsigned int d = 0; d < dim; ++d)
-                buffer[i * dim + d] =
+                buffer[bufferIndex++] =
                     forceField.boundaryField()[patchID][i][d];
         }
     }

--- a/changelog-entries/289.md
+++ b/changelog-entries/289.md
@@ -1,0 +1,1 @@
+- Fixed incorrect reading and writing of the FSI-related data buffers, if multiple patches are combined in an interface mesh.


### PR DESCRIPTION
The current FSI reader (Force/Stress/Displacement/DisplacementDelta) don't behave correctly in case of multiple patches: The previous implementation didn't take the size of the previous patch into account, i.e., was only iterating over the 'beginning' of the read and write buffer.
In most of our cases (actually all I know), we only use one patch per interface mesh, where this is not relevant. However, as soon as multiple patches are combined into one interface mesh, this becomes relevant and produces malicious results. In the CHT module, we do it actually correct.

Might be worth a bugfix release compatible with preCICE v2

FYI @LeonardWilleke

TODO list:

- <del> I updated the documentation in `docs/` </del>
- [x] I added a changelog entry in `changelog-entries/` (create directory if missing)
