### PR TITLE
Markdown-lint: Disable MD034

### DIFF
--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -1,4 +1,5 @@
 {
     "MD013": false,
-    "MD033": false
+    "MD033": false,
+    "MD034": false
 }


### PR DESCRIPTION
The markdown-lint GitHub Action started complaining about raw links (unclear why now).
Since we do have raw links in the usual OpenFOAM copyright disclaimer, I suggest disabling the rule.

TODO list:

- I updated the documentation in `docs/` -> N/A
- I added a changelog entry in `changelog-entries/` (create directory if missing) -> Too trivial
