### PR TITLE
Re-arrange `if` logic for Pstream initialization

### DIFF
--- a/preciceAdapterFunctionObject.C
+++ b/preciceAdapterFunctionObject.C
@@ -51,7 +51,7 @@ Foam::functionObjects::preciceAdapterFunctionObject::preciceAdapterFunctionObjec
   adapter_(runTime, mesh_)
 {
 
-#if (defined OPENFOAM_PLUS && (OPENFOAM_PLUS >= 1712)) || (defined OPENFOAM && (OPENFOAM >= 1806))
+#if (defined OPENFOAM_PLUS && (OPENFOAM_PLUS >= 1712)) || (defined OPENFOAM && (OPENFOAM >= 1806) && (OPENFOAM < 2306))
     // Patch for issue #27: warning "MPI was already finalized" while
     // running in serial. This only affects openfoam.com, while initNull()
     // does not exist in openfoam.org.

--- a/preciceAdapterFunctionObject.C
+++ b/preciceAdapterFunctionObject.C
@@ -51,7 +51,7 @@ Foam::functionObjects::preciceAdapterFunctionObject::preciceAdapterFunctionObjec
   adapter_(runTime, mesh_)
 {
 
-#if (defined OPENFOAM_PLUS && (OPENFOAM_PLUS >= 1712)) || (defined OPENFOAM && (OPENFOAM >= 1806) && (OPENFOAM < 2306))
+#if (defined OPENFOAM && (OPENFOAM >= 1806)) || (defined OPENFOAM_PLUS && (OPENFOAM_PLUS >= 1712))
     // Patch for issue #27: warning "MPI was already finalized" while
     // running in serial. This only affects openfoam.com, while initNull()
     // does not exist in openfoam.org.


### PR DESCRIPTION
I compiled a [recent develop](https://develop.openfoam.com/Development/openfoam/-/commit/5894e6ee8b7942fe356fdeba72dd8a588d12f881) snapshot of OpenFOAM 2306 on a cluster machine in order to test it against #291 to save potential future efforts. Compiling works flawless.

However, the teardown of a coupling participant fails when executed in _serial_  (parallel execution via MPI worked fine) with the following stacktrace:

```bash
[stack trace]
=============
#1  Foam::sigSegv::sigHandler(int) in ~/tmp/openfoam/platforms/linux64GccDPInt32Opt/lib/libOpenFOAM.so
#2  ? in /lib/x86_64-linux-gnu/libpthread.so.0
#3  Foam::UPstream::freeCommunicatorComponents(int) in ~/tmp/openfoam/platforms/linux64GccDPInt32Opt/lib/sys-openmpi/libPstream.so
#4  Foam::UPstream::shutdown(int) in ~/tmp/openfoam/platforms/linux64GccDPInt32Opt/lib/sys-openmpi/libPstream.so
#5  Foam::argList::~argList() in ~/tmp/openfoam/platforms/linux64GccDPInt32Opt/lib/libOpenFOAM.so
#6  ? in ~/tmp/openfoam/platforms/linux64GccDPInt32Opt/bin/laplacianFoam
#7  __libc_start_main in /lib/x86_64-linux-gnu/libc.so.6
#8  ? in ~/tmp/openfoam/platforms/linux64GccDPInt32Opt/bin/laplacianFoam
=============
Segmentation fault
```

Seems to be related to https://github.com/precice/precice/issues/128#issuecomment-402549649 and skipping the `Pstream` initialization does the job, i.e., the workaround is apparently not required any more. Would be great to get a confirmation from @olesenm on this.