### PR TITLE
Reduce build targets to save building time

### DIFF
--- a/CHT/ModuleCHT.C
+++ b/CHT/ModuleCHT.C
@@ -1,0 +1,7 @@
+// Central inlude file to reduce the number of build targets and build time
+#include "Temperature.C"
+#include "KappaEffective.C"
+#include "HeatFlux.C"
+#include "HeatTransferCoefficient.C"
+#include "SinkTemperature.C"
+#include "CHT.C"

--- a/FF/ModuleFF.C
+++ b/FF/ModuleFF.C
@@ -1,0 +1,6 @@
+// Central inlude file to reduce the number of build targets and build time
+#include "FF.C"
+#include "Velocity.C"
+#include "VelocityGradient.C"
+#include "Pressure.C"
+#include "PressureGradient.C"

--- a/FSI/ModuleFSI.C
+++ b/FSI/ModuleFSI.C
@@ -1,0 +1,7 @@
+// Central inlude file to reduce the number of build targets and build time
+#include "FSI.C"
+#include "ForceBase.C"
+#include "Force.C"
+#include "Stress.C"
+#include "Displacement.C"
+#include "DisplacementDelta.C"

--- a/Make/files
+++ b/Make/files
@@ -4,26 +4,9 @@ Interface.C
 
 CouplingDataUser.C
 
-CHT/Temperature.C
-CHT/KappaEffective.C
-CHT/HeatFlux.C
-CHT/HeatTransferCoefficient.C
-CHT/SinkTemperature.C
-
-CHT/CHT.C
-
-FSI/FSI.C
-FSI/ForceBase.C
-FSI/Force.C
-FSI/Stress.C
-FSI/Displacement.C
-FSI/DisplacementDelta.C
-
-FF/FF.C
-FF/Velocity.C
-FF/VelocityGradient.C
-FF/Pressure.C
-FF/PressureGradient.C
+CHT/ModuleCHT.C
+FSI/ModuleFSI.C
+FF/ModuleFF.C
 
 Adapter.C
 

--- a/changelog-entries/301.md
+++ b/changelog-entries/301.md
@@ -1,0 +1,1 @@
+- Reduced building time by grouping together compilation units of each module [#301](https://github.com/precice/openfoam-adapter/pull/301)


### PR DESCRIPTION
With the current approach of having a coupling data user subclass in a separate `.C` file and specifying all of them in the `Make/files` as build targets, and since we are adding new such targets, the building time of the adapter gets longer and longer.

While the code of the adapter is not that long or complex, the compiler has to process all the included OpenFOAM headers for each build target.

To reduce the build time, I suggest grouping some of these build targets, at least per module.

On my system (one sample per measurement):

- Without parallelization (`$WM_NCOMPPROCS=0`), I get:
    - 128s and 695MB max RAM usage with develop
    - 59s and 695MB max RAM usage with this PR
- With parallelization (`$WM_NCOMPPROCS=8`), I get:
    - 60s and 695MB max RAM usage with develop
    - 26s and 695MB max RAM usage with this PR 

So, just by grouping the modules together, we get 2x speedup, without increasing the RAM usage. We could probably do even better. However, putting everything into one build target, only reduces the total time to 23s, so it does not make much sense to group targets further.

Measurements with `/usr/bin/time ./Allwmake`. I assume that the max RAM usage is per thread / for the parent thread. Since more or less the same headers are used everywhere, the memory usage stays the same between develop and this PR.

Compilation error messages still refer to the exact files affected.

The names are a bit arbitrary now. `Include{CHT,FSI,FF}.C` would probably be clearer than `Module{CHT,FSI,FF}.C` (since we already have `CHT.C`, `FSI.C`, `FF.C`).

I would only (update and) merge this after #255 and #281 are merged.

TODO list:

- I updated the documentation in `docs/` -> N/A
- [x] I added a changelog entry in `changelog-entries/` (create directory if missing)
