### PR TITLE
Pass the correct number of entries to `writeData`

### DIFF
--- a/CHT/HeatFlux.C
+++ b/CHT/HeatFlux.C
@@ -18,7 +18,7 @@ preciceAdapter::CHT::HeatFlux::HeatFlux(
     dataType_ = scalar;
 }
 
-void preciceAdapter::CHT::HeatFlux::write(double* buffer, bool meshConnectivity, const unsigned int dim)
+std::size_t preciceAdapter::CHT::HeatFlux::write(double* buffer, bool meshConnectivity, const unsigned int dim)
 {
     int bufferIndex = 0;
 
@@ -68,6 +68,7 @@ void preciceAdapter::CHT::HeatFlux::write(double* buffer, bool meshConnectivity,
             }
         }
     }
+    return bufferIndex;
 }
 
 void preciceAdapter::CHT::HeatFlux::read(double* buffer, const unsigned int dim)

--- a/CHT/HeatFlux.H
+++ b/CHT/HeatFlux.H
@@ -33,7 +33,7 @@ public:
 
     //- Compute heat flux values from the temperature field
     //  and write them into the buffer
-    void write(double* buffer, bool meshConnectivity, const unsigned int dim) final;
+    std::size_t write(double* buffer, bool meshConnectivity, const unsigned int dim) final;
 
     //- Read heat flux values from the buffer and assign them to
     //  the gradient of the temperature field

--- a/CHT/HeatTransferCoefficient.C
+++ b/CHT/HeatTransferCoefficient.C
@@ -20,7 +20,7 @@ preciceAdapter::CHT::HeatTransferCoefficient::HeatTransferCoefficient(
 }
 
 
-void preciceAdapter::CHT::HeatTransferCoefficient::write(double* buffer, bool meshConnectivity, const unsigned int dim)
+std::size_t preciceAdapter::CHT::HeatTransferCoefficient::write(double* buffer, bool meshConnectivity, const unsigned int dim)
 {
     int bufferIndex = 0;
 
@@ -69,6 +69,7 @@ void preciceAdapter::CHT::HeatTransferCoefficient::write(double* buffer, bool me
             }
         }
     }
+    return bufferIndex;
 }
 
 

--- a/CHT/HeatTransferCoefficient.H
+++ b/CHT/HeatTransferCoefficient.H
@@ -35,7 +35,7 @@ public:
         const std::string nameT);
 
     //- Write the heat transfer coefficient values into the buffer
-    void write(double* buffer, bool meshConnectivity, const unsigned int dim) final;
+    std::size_t write(double* buffer, bool meshConnectivity, const unsigned int dim) final;
 
     //- Read the heat transfer coefficient values from the buffer
     void read(double* buffer, const unsigned int dim) final;

--- a/CHT/SinkTemperature.C
+++ b/CHT/SinkTemperature.C
@@ -14,7 +14,7 @@ preciceAdapter::CHT::SinkTemperature::SinkTemperature(
     dataType_ = scalar;
 }
 
-void preciceAdapter::CHT::SinkTemperature::write(double* buffer, bool meshConnectivity, const unsigned int dim)
+std::size_t preciceAdapter::CHT::SinkTemperature::write(double* buffer, bool meshConnectivity, const unsigned int dim)
 {
     int bufferIndex = 0;
 
@@ -63,6 +63,7 @@ void preciceAdapter::CHT::SinkTemperature::write(double* buffer, bool meshConnec
         // Clear the temporary internal field object
         patchInternalFieldTmp.clear();
     }
+    return bufferIndex;
 }
 
 void preciceAdapter::CHT::SinkTemperature::read(double* buffer, const unsigned int dim)

--- a/CHT/SinkTemperature.H
+++ b/CHT/SinkTemperature.H
@@ -26,7 +26,7 @@ public:
         const std::string nameT);
 
     //- Write the sink temperature values into the buffer
-    void write(double* buffer, bool meshConnectivity, const unsigned int dim);
+    std::size_t write(double* buffer, bool meshConnectivity, const unsigned int dim);
 
     //- Read the sink temperature values from the buffer
     void read(double* buffer, const unsigned int dim);

--- a/CHT/Temperature.C
+++ b/CHT/Temperature.C
@@ -15,7 +15,7 @@ preciceAdapter::CHT::Temperature::Temperature(
     dataType_ = scalar;
 }
 
-void preciceAdapter::CHT::Temperature::write(double* buffer, bool meshConnectivity, const unsigned int dim)
+std::size_t preciceAdapter::CHT::Temperature::write(double* buffer, bool meshConnectivity, const unsigned int dim)
 {
     int bufferIndex = 0;
 
@@ -79,6 +79,7 @@ void preciceAdapter::CHT::Temperature::write(double* buffer, bool meshConnectivi
             }
         }
     }
+    return bufferIndex;
 }
 
 void preciceAdapter::CHT::Temperature::read(double* buffer, const unsigned int dim)

--- a/CHT/Temperature.H
+++ b/CHT/Temperature.H
@@ -27,7 +27,7 @@ public:
         const std::string nameT);
 
     //- Write the temperature values into the buffer
-    void write(double* buffer, bool meshConnectivity, const unsigned int dim);
+    std::size_t write(double* buffer, bool meshConnectivity, const unsigned int dim);
 
     //- Read the temperature values from the buffer
     void read(double* buffer, const unsigned int dim);

--- a/CouplingDataUser.H
+++ b/CouplingDataUser.H
@@ -74,7 +74,8 @@ public:
     virtual void initialize();
 
     //- Write the coupling data to the buffer
-    virtual void write(double* dataBuffer, bool meshConnectivity, const unsigned int dim) = 0;
+    // Returns the number of entries that were filles in the buffer (nComp * vertices)
+    virtual std::size_t write(double* dataBuffer, bool meshConnectivity, const unsigned int dim) = 0;
 
     //- Read the coupling data from the buffer
     virtual void read(double* dataBuffer, const unsigned int dim) = 0;

--- a/FF/Pressure.C
+++ b/FF/Pressure.C
@@ -13,7 +13,7 @@ preciceAdapter::FF::Pressure::Pressure(
     dataType_ = scalar;
 }
 
-void preciceAdapter::FF::Pressure::write(double* buffer, bool meshConnectivity, const unsigned int dim)
+std::size_t preciceAdapter::FF::Pressure::write(double* buffer, bool meshConnectivity, const unsigned int dim)
 {
     int bufferIndex = 0;
 
@@ -55,6 +55,7 @@ void preciceAdapter::FF::Pressure::write(double* buffer, bool meshConnectivity, 
                 p_->boundaryFieldRef()[patchID][i];
         }
     }
+    return bufferIndex;
 }
 
 void preciceAdapter::FF::Pressure::read(double* buffer, const unsigned int dim)

--- a/FF/Pressure.H
+++ b/FF/Pressure.H
@@ -26,7 +26,7 @@ public:
         const std::string nameP);
 
     //- Write the pressure values into the buffer
-    void write(double* buffer, bool meshConnectivity, const unsigned int dim);
+    std::size_t write(double* buffer, bool meshConnectivity, const unsigned int dim);
 
     //- Read the pressure values from the buffer
     void read(double* buffer, const unsigned int dim);

--- a/FF/PressureGradient.C
+++ b/FF/PressureGradient.C
@@ -12,7 +12,7 @@ preciceAdapter::FF::PressureGradient::PressureGradient(
     dataType_ = scalar;
 }
 
-void preciceAdapter::FF::PressureGradient::write(double* buffer, bool meshConnectivity, const unsigned int dim)
+std::size_t preciceAdapter::FF::PressureGradient::write(double* buffer, bool meshConnectivity, const unsigned int dim)
 {
     int bufferIndex = 0;
 
@@ -33,6 +33,7 @@ void preciceAdapter::FF::PressureGradient::write(double* buffer, bool meshConnec
                 -gradientPatch[i];
         }
     }
+    return bufferIndex;
 }
 
 void preciceAdapter::FF::PressureGradient::read(double* buffer, const unsigned int dim)

--- a/FF/PressureGradient.H
+++ b/FF/PressureGradient.H
@@ -25,7 +25,7 @@ public:
         const std::string nameP);
 
     //- Write the pressure gradient values into the buffer
-    void write(double* buffer, bool meshConnectivity, const unsigned int dim);
+    std::size_t write(double* buffer, bool meshConnectivity, const unsigned int dim);
 
     //- Read the pressure gradient values from the buffer
     void read(double* buffer, const unsigned int dim);

--- a/FF/Temperature.C
+++ b/FF/Temperature.C
@@ -12,7 +12,7 @@ preciceAdapter::FF::Temperature::Temperature(
     dataType_ = scalar;
 }
 
-void preciceAdapter::FF::Temperature::write(double* buffer, bool meshConnectivity, const unsigned int dim)
+std::size_t preciceAdapter::FF::Temperature::write(double* buffer, bool meshConnectivity, const unsigned int dim)
 {
     int bufferIndex = 0;
 
@@ -31,6 +31,7 @@ void preciceAdapter::FF::Temperature::write(double* buffer, bool meshConnectivit
                 T_->boundaryFieldRef()[patchID][i];
         }
     }
+    return bufferIndex;
 }
 
 void preciceAdapter::FF::Temperature::read(double* buffer, const unsigned int dim)

--- a/FF/Temperature.H
+++ b/FF/Temperature.H
@@ -25,7 +25,7 @@ public:
         const std::string nameT);
 
     //- Write the temperature values into the buffer
-    void write(double* buffer, bool meshConnectivity, const unsigned int dim);
+    std::size_t write(double* buffer, bool meshConnectivity, const unsigned int dim);
 
     //- Read the temperature values from the buffer
     void read(double* buffer, const unsigned int dim);

--- a/FF/TemperatureGradient.C
+++ b/FF/TemperatureGradient.C
@@ -13,7 +13,7 @@ preciceAdapter::FF::TemperatureGradient::TemperatureGradient(
     dataType_ = scalar;
 }
 
-void preciceAdapter::FF::TemperatureGradient::write(double* buffer, bool meshConnectivity, const unsigned int dim)
+std::size_t preciceAdapter::FF::TemperatureGradient::write(double* buffer, bool meshConnectivity, const unsigned int dim)
 {
     int bufferIndex = 0;
 
@@ -34,6 +34,7 @@ void preciceAdapter::FF::TemperatureGradient::write(double* buffer, bool meshCon
                 gradientPatch[i];
         }
     }
+    return bufferIndex;
 }
 
 void preciceAdapter::FF::TemperatureGradient::read(double* buffer, const unsigned int dim)

--- a/FF/TemperatureGradient.H
+++ b/FF/TemperatureGradient.H
@@ -25,7 +25,7 @@ public:
         const std::string nameT);
 
     //- Write the Temperature gradient values into the buffer
-    void write(double* buffer, bool meshConnectivity, const unsigned int dim);
+    std::size_t write(double* buffer, bool meshConnectivity, const unsigned int dim);
 
     //- Read the Temperature gradient values from the buffer
     void read(double* buffer, const unsigned int dim);

--- a/FF/Velocity.C
+++ b/FF/Velocity.C
@@ -34,7 +34,7 @@ preciceAdapter::FF::Velocity::Velocity(
     dataType_ = vector;
 }
 
-void preciceAdapter::FF::Velocity::write(double* buffer, bool meshConnectivity, const unsigned int dim)
+std::size_t preciceAdapter::FF::Velocity::write(double* buffer, bool meshConnectivity, const unsigned int dim)
 {
     int bufferIndex = 0;
 
@@ -118,6 +118,7 @@ void preciceAdapter::FF::Velocity::write(double* buffer, bool meshConnectivity, 
             }
         }
     }
+    return bufferIndex;
 }
 
 void preciceAdapter::FF::Velocity::read(double* buffer, const unsigned int dim)

--- a/FF/Velocity.H
+++ b/FF/Velocity.H
@@ -32,7 +32,7 @@ public:
         bool fluxCorrection = false);
 
     //- Write the velocity values into the buffer
-    void write(double* buffer, bool meshConnectivity, const unsigned int dim);
+    std::size_t write(double* buffer, bool meshConnectivity, const unsigned int dim);
 
     //- Read the velocity values from the buffer
     void read(double* buffer, const unsigned int dim);

--- a/FF/VelocityGradient.C
+++ b/FF/VelocityGradient.C
@@ -13,7 +13,7 @@ preciceAdapter::FF::VelocityGradient::VelocityGradient(
     dataType_ = vector;
 }
 
-void preciceAdapter::FF::VelocityGradient::write(double* buffer, bool meshConnectivity, const unsigned int dim)
+std::size_t preciceAdapter::FF::VelocityGradient::write(double* buffer, bool meshConnectivity, const unsigned int dim)
 {
     int bufferIndex = 0;
 
@@ -46,6 +46,7 @@ void preciceAdapter::FF::VelocityGradient::write(double* buffer, bool meshConnec
             }
         }
     }
+    return bufferIndex;
 }
 
 void preciceAdapter::FF::VelocityGradient::read(double* buffer, const unsigned int dim)

--- a/FF/VelocityGradient.H
+++ b/FF/VelocityGradient.H
@@ -25,7 +25,7 @@ public:
         const std::string nameU);
 
     //- Write the velocity gradient values into the buffer
-    void write(double* buffer, bool meshConnectivity, const unsigned int dim) final;
+    std::size_t write(double* buffer, bool meshConnectivity, const unsigned int dim) final;
 
     //- Read the velocity gradient values from the buffer
     void read(double* buffer, const unsigned int dim) final;

--- a/FSI/Displacement.C
+++ b/FSI/Displacement.C
@@ -36,7 +36,7 @@ void preciceAdapter::FSI::Displacement::initialize()
 }
 
 
-void preciceAdapter::FSI::Displacement::write(double* buffer, bool meshConnectivity, const unsigned int dim)
+std::size_t preciceAdapter::FSI::Displacement::write(double* buffer, bool meshConnectivity, const unsigned int dim)
 {
     /* TODO: Implement
      * We need two nested for-loops for each patch,
@@ -46,9 +46,9 @@ void preciceAdapter::FSI::Displacement::write(double* buffer, bool meshConnectiv
 
     // Copy the displacement field from OpenFOAM to the buffer
 
+    int bufferIndex = 0;
     if (this->locationType_ == LocationType::faceCenters)
     {
-        int bufferIndex = 0;
         // For every boundary patch of the interface
         for (const label patchID : patchIDs_)
         {
@@ -70,7 +70,6 @@ void preciceAdapter::FSI::Displacement::write(double* buffer, bool meshConnectiv
             "See https://github.com/precice/openfoam-adapter/issues/153.",
             "warning"));
 
-        int bufferIndex = 0;
         // For every boundary patch of the interface
         for (const label patchID : patchIDs_)
         {
@@ -87,6 +86,7 @@ void preciceAdapter::FSI::Displacement::write(double* buffer, bool meshConnectiv
             }
         }
     }
+    return bufferIndex;
 }
 
 

--- a/FSI/Displacement.H
+++ b/FSI/Displacement.H
@@ -36,7 +36,7 @@ public:
         const std::string nameCellDisplacement);
 
     //- Write the displacement values into the buffer
-    void write(double* buffer, bool meshConnectivity, const unsigned int dim) final;
+    std::size_t write(double* buffer, bool meshConnectivity, const unsigned int dim) final;
 
     //- Read the displacement values from the buffer
     void read(double* buffer, const unsigned int dim) final;

--- a/FSI/DisplacementDelta.C
+++ b/FSI/DisplacementDelta.C
@@ -34,7 +34,7 @@ void preciceAdapter::FSI::DisplacementDelta::initialize()
 }
 
 
-void preciceAdapter::FSI::DisplacementDelta::write(double* buffer, bool meshConnectivity, const unsigned int dim)
+std::size_t preciceAdapter::FSI::DisplacementDelta::write(double* buffer, bool meshConnectivity, const unsigned int dim)
 {
     /* TODO: Implement
      * We need two nested for-loops for each patch,
@@ -44,6 +44,7 @@ void preciceAdapter::FSI::DisplacementDelta::write(double* buffer, bool meshConn
     FatalErrorInFunction
         << "Writing displacementDeltas is not supported."
         << exit(FatalError);
+    return 0;
 }
 
 // return the displacement to use later in the velocity?

--- a/FSI/DisplacementDelta.H
+++ b/FSI/DisplacementDelta.H
@@ -36,7 +36,7 @@ public:
         const std::string nameCellDisplacement);
 
     //- Write the displacementDelta values into the buffer
-    void write(double* buffer, bool meshConnectivity, const unsigned int dim) final;
+    std::size_t write(double* buffer, bool meshConnectivity, const unsigned int dim) final;
 
     //- Read the displacementDelta values from the buffer
     void read(double* buffer, const unsigned int dim) final;

--- a/FSI/Force.C
+++ b/FSI/Force.C
@@ -36,9 +36,9 @@ preciceAdapter::FSI::Force::Force(
     }
 }
 
-void preciceAdapter::FSI::Force::write(double* buffer, bool meshConnectivity, const unsigned int dim)
+std::size_t preciceAdapter::FSI::Force::write(double* buffer, bool meshConnectivity, const unsigned int dim)
 {
-    this->writeToBuffer(buffer, *Force_, dim);
+    return this->writeToBuffer(buffer, *Force_, dim);
 }
 
 void preciceAdapter::FSI::Force::read(double* buffer, const unsigned int dim)

--- a/FSI/Force.H
+++ b/FSI/Force.H
@@ -26,7 +26,7 @@ public:
         const std::string nameForce);
 
     //- Write the forces values into the buffer
-    void write(double* buffer, bool meshConnectivity, const unsigned int dim) final;
+    std::size_t write(double* buffer, bool meshConnectivity, const unsigned int dim) final;
 
     //- Read the forces values from the buffer
     void read(double* buffer, const unsigned int dim) final;

--- a/FSI/ForceBase.C
+++ b/FSI/ForceBase.C
@@ -130,9 +130,9 @@ Foam::tmp<Foam::volScalarField> preciceAdapter::FSI::ForceBase::mu() const
     }
 }
 
-void preciceAdapter::FSI::ForceBase::writeToBuffer(double* buffer,
-                                                   volVectorField& forceField,
-                                                   const unsigned int dim) const
+std::size_t preciceAdapter::FSI::ForceBase::writeToBuffer(double* buffer,
+                                                          volVectorField& forceField,
+                                                          const unsigned int dim) const
 {
     // Compute forces. See the Forces function object.
     // Stress tensor boundary field
@@ -188,6 +188,7 @@ void preciceAdapter::FSI::ForceBase::writeToBuffer(double* buffer,
                     forceField.boundaryField()[patchID][i][d];
         }
     }
+    return bufferIndex;
 }
 
 void preciceAdapter::FSI::ForceBase::readFromBuffer(double* buffer) const

--- a/FSI/ForceBase.H
+++ b/FSI/ForceBase.H
@@ -39,7 +39,7 @@ public:
         const Foam::fvMesh& mesh,
         const std::string solverType);
 
-    void writeToBuffer(double* buffer,
+    std::size_t writeToBuffer(double* buffer,
                        Foam::volVectorField& forceField,
                        const unsigned int dim) const;
 

--- a/FSI/ForceBase.H
+++ b/FSI/ForceBase.H
@@ -40,8 +40,8 @@ public:
         const std::string solverType);
 
     std::size_t writeToBuffer(double* buffer,
-                       Foam::volVectorField& forceField,
-                       const unsigned int dim) const;
+                              Foam::volVectorField& forceField,
+                              const unsigned int dim) const;
 
     void readFromBuffer(double* buffer) const;
 

--- a/FSI/Stress.C
+++ b/FSI/Stress.C
@@ -23,7 +23,7 @@ preciceAdapter::FSI::Stress::Stress(
 
 std::size_t preciceAdapter::FSI::Stress::write(double* buffer, bool meshConnectivity, const unsigned int dim)
 {
-   return this->writeToBuffer(buffer, *Stress_, dim);
+    return this->writeToBuffer(buffer, *Stress_, dim);
 }
 
 void preciceAdapter::FSI::Stress::read(double* buffer, const unsigned int dim)

--- a/FSI/Stress.C
+++ b/FSI/Stress.C
@@ -21,9 +21,9 @@ preciceAdapter::FSI::Stress::Stress(
             Foam::vector::zero));
 }
 
-void preciceAdapter::FSI::Stress::write(double* buffer, bool meshConnectivity, const unsigned int dim)
+std::size_t preciceAdapter::FSI::Stress::write(double* buffer, bool meshConnectivity, const unsigned int dim)
 {
-    this->writeToBuffer(buffer, *Stress_, dim);
+   return this->writeToBuffer(buffer, *Stress_, dim);
 }
 
 void preciceAdapter::FSI::Stress::read(double* buffer, const unsigned int dim)

--- a/FSI/Stress.H
+++ b/FSI/Stress.H
@@ -27,7 +27,7 @@ public:
         const std::string solverType);
 
     //- Write the stress values into the buffer
-    void write(double* buffer, bool meshConnectivity, const unsigned int dim) final;
+    std::size_t write(double* buffer, bool meshConnectivity, const unsigned int dim) final;
 
     //- Read the stress values from the buffer
     void read(double* buffer, const unsigned int dim) final;

--- a/Interface.C
+++ b/Interface.C
@@ -545,12 +545,16 @@ void preciceAdapter::Interface::readCouplingData(double relativeReadTime)
 
         // Make preCICE read vector or scalar data
         // and fill the adapter's buffer
+        std::size_t nReadData = vertexIDs_.size() * precice_.getDataDimensions(meshName_,couplingDataReader->dataName());
+        // We could add a sanity check here
+        // nReadData == vertexIDs_.size() * (1 + (dim_ - 1) * static_cast<int>(couplingDataReader->hasVectorData()));
+
         precice_.readData(
             meshName_,
             couplingDataReader->dataName(),
             vertexIDs_,
             relativeReadTime,
-            dataBuffer_);
+            {dataBuffer_.data(), nReadData});
 
         // Read the received data from the buffer
         couplingDataReader->read(dataBuffer_.data(), dim_);

--- a/Interface.C
+++ b/Interface.C
@@ -571,14 +571,14 @@ void preciceAdapter::Interface::writeCouplingData()
             couplingDataWriter = couplingDataWriters_.at(i);
 
         // Write the data into the adapter's buffer
-        couplingDataWriter->write(dataBuffer_.data(), meshConnectivity_, dim_);
+        auto nWrittenData = couplingDataWriter->write(dataBuffer_.data(), meshConnectivity_, dim_);
 
         // Make preCICE write vector or scalar data
         precice_.writeData(
             meshName_,
             couplingDataWriter->dataName(),
             vertexIDs_,
-            dataBuffer_);
+            {dataBuffer_.data(), nWrittenData});
     }
     // }
 }

--- a/Interface.C
+++ b/Interface.C
@@ -545,7 +545,7 @@ void preciceAdapter::Interface::readCouplingData(double relativeReadTime)
 
         // Make preCICE read vector or scalar data
         // and fill the adapter's buffer
-        std::size_t nReadData = vertexIDs_.size() * precice_.getDataDimensions(meshName_,couplingDataReader->dataName());
+        std::size_t nReadData = vertexIDs_.size() * precice_.getDataDimensions(meshName_, couplingDataReader->dataName());
         // We could add a sanity check here
         // nReadData == vertexIDs_.size() * (1 + (dim_ - 1) * static_cast<int>(couplingDataReader->hasVectorData()));
 


### PR DESCRIPTION
Closes #303 

I added now a return type to `CouplingDataUser::write()` to tell writeData how many data entries are actually relevant. Adding this return type is also a nice consistency check for the `CouplingDataUser::write()` function and not uncommon for such functions.

TODO list:

- [ ] I updated the documentation in `docs/`
- [ ] I added a changelog entry in `changelog-entries/` (create directory if missing)
