### PR TITLE
Build for OpenFOAM v11

### DIFF
--- a/Adapter.H
+++ b/Adapter.H
@@ -316,53 +316,53 @@ private:
 
     // Add mesh checkpoint fields, depending on the type
     //- Add a surfaceScalarField mesh field
-    void addMeshCheckpointField(surfaceScalarField& field);
+    void addMeshCheckpointField(Foam::surfaceScalarField& field);
 
     //- Add a surfaceVectorField mesh field
-    void addMeshCheckpointField(surfaceVectorField& field);
+    void addMeshCheckpointField(Foam::surfaceVectorField& field);
 
     //- Add a volVectorField mesh field
-    void addMeshCheckpointField(volVectorField& field);
+    void addMeshCheckpointField(Foam::volVectorField& field);
 
     // TODO V0 and V00 checkpointed field.
     //- Add the V0 and V00 checkpoint fields
-    void addVolCheckpointField(volScalarField::Internal& field);
+    void addVolCheckpointField(Foam::volScalarField::Internal& field);
     // void addVolCheckpointFieldBuffer(volScalarField::Internal & field);
 
     // Add checkpoint fields, depending on the type
 
     //- Add a volScalarField to checkpoint
-    void addCheckpointField(volScalarField* field);
+    void addCheckpointField(Foam::volScalarField* field);
 
     //- Add a volVectorField to checkpoint
-    void addCheckpointField(volVectorField* field);
+    void addCheckpointField(Foam::volVectorField* field);
 
     //- Add a surfaceScalarField to checkpoint
-    void addCheckpointField(surfaceScalarField* field);
+    void addCheckpointField(Foam::surfaceScalarField* field);
 
     //- Add a surfaceVectorField to checkpoint
-    void addCheckpointField(surfaceVectorField* field);
+    void addCheckpointField(Foam::surfaceVectorField* field);
 
     //- Add a pointScalarField to checkpoint
-    void addCheckpointField(pointScalarField* field);
+    void addCheckpointField(Foam::pointScalarField* field);
 
     //- Add a pointVectorField to checkpoint
-    void addCheckpointField(pointVectorField* field);
+    void addCheckpointField(Foam::pointVectorField* field);
 
     // NOTE: Add here methods to add other object types to checkpoint,
     // if needed.
 
     //- Add a volTensorField to checkpoint
-    void addCheckpointField(volTensorField* field);
+    void addCheckpointField(Foam::volTensorField* field);
 
     //- Add a surfaceTensorField to checkpoint
-    void addCheckpointField(surfaceTensorField* field);
+    void addCheckpointField(Foam::surfaceTensorField* field);
 
     //- Add a pointTensorField to checkpoint
-    void addCheckpointField(pointTensorField* field);
+    void addCheckpointField(Foam::pointTensorField* field);
 
     //- Add a volSymmTensorField to checkpoint
-    void addCheckpointField(volSymmTensorField* field);
+    void addCheckpointField(Foam::volSymmTensorField* field);
 
     //- Read the checkpoint - restore the mesh fields and time
     void readMeshCheckpoint();

--- a/CHT/CHT.H
+++ b/CHT/CHT.H
@@ -48,14 +48,14 @@ protected:
     std::string determineSolverType();
 
     //- Read the CHT-related options from the adapter's configuration file
-    bool readConfig(const IOdictionary& adapterConfig);
+    bool readConfig(const Foam::IOdictionary& adapterConfig);
 
 public:
     //- Constructor
     ConjugateHeatTransfer(const Foam::fvMesh& mesh);
 
     //- Configure
-    bool configure(const IOdictionary& adapterConfig);
+    bool configure(const Foam::IOdictionary& adapterConfig);
 
     //- Add coupling data writers
     bool addWriters(std::string dataName, Interface* interface);

--- a/CHT/CHT.H
+++ b/CHT/CHT.H
@@ -8,8 +8,6 @@
 #include "CHT/SinkTemperature.H"
 #include "CHT/HeatTransferCoefficient.H"
 
-#include "fvCFD.H"
-
 namespace preciceAdapter
 {
 namespace CHT

--- a/CHT/HeatFlux.C
+++ b/CHT/HeatFlux.C
@@ -1,7 +1,7 @@
 #include "HeatFlux.H"
 #include "primitivePatchInterpolation.H"
 
-#include "fvCFD.H"
+#include "constrainPressure.H"
 
 using namespace Foam;
 

--- a/CHT/HeatTransferCoefficient.C
+++ b/CHT/HeatTransferCoefficient.C
@@ -1,6 +1,5 @@
 #include "HeatTransferCoefficient.H"
 
-#include "fvCFD.H"
 #include "mixedFvPatchFields.H"
 #include "primitivePatchInterpolation.H"
 

--- a/CHT/SinkTemperature.H
+++ b/CHT/SinkTemperature.H
@@ -3,7 +3,7 @@
 
 #include "CouplingDataUser.H"
 #include "mixedFvPatchFields.H"
-#include "fvCFD.H"
+#include "findRefCell.H"
 
 namespace preciceAdapter
 {

--- a/CHT/Temperature.H
+++ b/CHT/Temperature.H
@@ -3,7 +3,7 @@
 
 #include "CouplingDataUser.H"
 
-#include "fvCFD.H"
+#include "findRefCell.H"
 
 namespace preciceAdapter
 {

--- a/FF/FF.H
+++ b/FF/FF.H
@@ -8,8 +8,6 @@
 #include "FF/PressureGradient.H"
 #include "FF/VelocityGradient.H"
 
-#include "fvCFD.H"
-
 namespace preciceAdapter
 {
 namespace FF

--- a/FF/FF.H
+++ b/FF/FF.H
@@ -35,14 +35,14 @@ protected:
     std::string determineSolverType();
 
     //- Read the FF-related options from the adapter's configuration file
-    bool readConfig(const IOdictionary& adapterConfig);
+    bool readConfig(const Foam::IOdictionary& adapterConfig);
 
 public:
     //- Constructor
     FluidFluid(const Foam::fvMesh& mesh);
 
     //- Configure
-    bool configure(const IOdictionary& adapterConfig);
+    bool configure(const Foam::IOdictionary& adapterConfig);
 
     //- Add coupling data writers
     bool addWriters(std::string dataName, Interface* interface);

--- a/FF/Pressure.H
+++ b/FF/Pressure.H
@@ -3,7 +3,7 @@
 
 #include "CouplingDataUser.H"
 
-#include "fvCFD.H"
+#include "findRefCell.H"
 
 namespace preciceAdapter
 {

--- a/FF/PressureGradient.H
+++ b/FF/PressureGradient.H
@@ -3,7 +3,8 @@
 
 #include "CouplingDataUser.H"
 
-#include "fvCFD.H"
+#include "findRefCell.H"
+#include "constrainPressure.H"
 
 namespace preciceAdapter
 {

--- a/FF/Velocity.H
+++ b/FF/Velocity.H
@@ -3,7 +3,8 @@
 
 #include "CouplingDataUser.H"
 
-#include "fvCFD.H"
+#include "findRefCell.H"
+#include "constrainHbyA.H"
 
 namespace preciceAdapter
 {

--- a/FF/VelocityGradient.H
+++ b/FF/VelocityGradient.H
@@ -3,7 +3,9 @@
 
 #include "CouplingDataUser.H"
 
-#include "fvCFD.H"
+#include "findRefCell.H"
+#include "constrainPressure.H"
+#include "constrainHbyA.H"
 
 namespace preciceAdapter
 {

--- a/FSI/Displacement.H
+++ b/FSI/Displacement.H
@@ -3,7 +3,7 @@
 
 #include "CouplingDataUser.H"
 
-#include "fvCFD.H"
+#include "findRefCell.H"
 #include "fixedValuePointPatchFields.H"
 #include "primitivePatchInterpolation.H"
 

--- a/FSI/DisplacementDelta.H
+++ b/FSI/DisplacementDelta.H
@@ -3,7 +3,7 @@
 
 #include "CouplingDataUser.H"
 
-#include "fvCFD.H"
+#include "findRefCell.H"
 #include "fixedValuePointPatchFields.H"
 #include "primitivePatchInterpolation.H"
 

--- a/FSI/FSI.H
+++ b/FSI/FSI.H
@@ -49,7 +49,7 @@ protected:
     std::string determineSolverType();
 
     //- Read the FSI-related options from the adapter's configuration file
-    bool readConfig(const IOdictionary& adapterConfig);
+    bool readConfig(const Foam::IOdictionary& adapterConfig);
 
 public:
     //- Constructor
@@ -57,7 +57,7 @@ public:
     FluidStructureInteraction(const Foam::fvMesh& mesh, const Foam::Time& runTime);
 
     //- Configure
-    bool configure(const IOdictionary& adapterConfig);
+    bool configure(const Foam::IOdictionary& adapterConfig);
 
     //- Add coupling data writers
     bool addWriters(std::string dataName, Interface* interface);

--- a/FSI/FSI.H
+++ b/FSI/FSI.H
@@ -8,8 +8,6 @@
 #include "FSI/Force.H"
 #include "FSI/Stress.H"
 
-#include "fvCFD.H"
-
 namespace preciceAdapter
 {
 namespace FSI

--- a/FSI/ForceBase.H
+++ b/FSI/ForceBase.H
@@ -4,7 +4,7 @@
 
 #include "CouplingDataUser.H"
 
-#include "fvCFD.H"
+#include "fvcGrad.H"
 
 #include "pointFields.H"
 #include "vectorField.H"

--- a/Interface.H
+++ b/Interface.H
@@ -3,7 +3,10 @@
 
 #include <string>
 #include <vector>
-#include "fvCFD.H"
+#include <array>
+#include "argList.H"
+#include "timeSelector.H"
+#include "findRefCell.H"
 #include "CouplingDataUser.H"
 #include "precice/SolverInterface.hpp"
 

--- a/Make/options
+++ b/Make/options
@@ -1,13 +1,12 @@
 EXE_INC = \
     -I$(LIB_SRC)/finiteVolume/lnInclude \
     -I$(LIB_SRC)/meshTools/lnInclude \
-    -I$(LIB_SRC)/physicalProperties/lnInclude \
-    -I$(LIB_SRC)/thermophysicalModels/basic/lnInclude \
-    -I$(LIB_SRC)/ThermophysicalTransportModels/lnInclude \
-    -I$(LIB_SRC)/physicalProperties/lnInclude \
-    -I$(LIB_SRC)/MomentumTransportModels/momentumTransportModels/lnInclude \
     -I$(LIB_SRC)/MomentumTransportModels/compressible/lnInclude \
     -I$(LIB_SRC)/MomentumTransportModels/incompressible/lnInclude \
+    -I$(LIB_SRC)/MomentumTransportModels/momentumTransportModels/lnInclude \
+    -I$(LIB_SRC)/physicalProperties/lnInclude \
+    -I$(LIB_SRC)/thermophysicalModels/basic/lnInclude \
+    -I$(LIB_SRC)/ThermophysicalTransportModels/thermophysicalTransportModel/lnInclude \
     -I$(LIB_SRC)/triSurface/lnInclude \
     $(ADAPTER_PKG_CONFIG_CFLAGS) \
     -I../ \
@@ -20,7 +19,7 @@ LIB_LIBS = \
     -lmomentumTransportModels \
     -lincompressibleMomentumTransportModels \
     -lcompressibleMomentumTransportModels \
-    -lthermophysicalTransportModels \
-    -limmiscibleIncompressibleTwoPhaseMixture \
+    -lthermophysicalTransportModel \
+    -lfluidThermophysicalModels \
     $(ADAPTER_PKG_CONFIG_LIBS) \
     -lprecice

--- a/preciceAdapterFunctionObject.H
+++ b/preciceAdapterFunctionObject.H
@@ -140,13 +140,6 @@ public:
         return wordList::null();
     }
 
-    //- Return the list of fields required
-    //  (pure virtual since OpenFOAM 10)
-    virtual wordList fields() const
-    {
-        return wordList::null();
-    }
-
     /*
         // NOTE: If you add a new module that needs to execute methods
         // whenever the mesh is updated or its points moved,

--- a/primitivePatchInterpolation.H
+++ b/primitivePatchInterpolation.H
@@ -1,0 +1,28 @@
+// copied from OpenFOAMv10 which is missing 
+// on newer versions
+
+#ifndef primitivePatchInterpolation_H
+#define primitivePatchInterpolation_H
+
+#include "PrimitivePatchInterpolation.H"
+#include "PrimitivePatch.H"
+#include "face.H"
+#include "SubList.H"
+#include "pointField.H"
+
+// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
+
+namespace Foam
+{
+    typedef PrimitivePatchInterpolation
+    <
+        PrimitivePatch<SubList<face>, const pointField&>
+    >
+    primitivePatchInterpolation;
+}
+
+// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
+
+#endif
+
+// ************************************************************************* //


### PR DESCRIPTION
The source is updated to be compiled for OF-11,

- Fixing: #306 
- Recovering the `primitivePatchInterpolation.h` which was [removed](https://github.com/OpenFOAM/OpenFOAM-dev/commit/edbff308b4a71a9bdb05a2bb26d24147962afded) [this may need some other changes ]
- and update the namespaces and some build options dependencies