### PR TITLE
Introduce tolerances for triggering dt related warnings

### DIFF
--- a/Adapter.C
+++ b/Adapter.C
@@ -651,7 +651,7 @@ void preciceAdapter::Adapter::adjustSolverTimeStepAndReadData()
        If the solver tries to use a bigger timestep, then it needs to use
        the same timestep as the one determined by preCICE.
     */
-    double tolerance = 1e-12;
+    double tolerance = 1e-14;
     if (timestepPrecice_ - timestepSolverDetermined > tolerance)
     {
         // Add a bool 'subCycling = true' which is checked in the storeMeshPoints() function.


### PR DESCRIPTION
See #311 for details. preCICE v3 operates now with a higher precision for handling time-step sizes (by default e-14), such that the comparisons up to machine precision are triggered unintentionally. With this changes, we have now a comparison with tolerances.

Resolves #311  


