### PR TITLE
Fix connectivity definition in the adapter

### DIFF
--- a/Interface.C
+++ b/Interface.C
@@ -249,10 +249,6 @@ void preciceAdapter::Interface::configureMesh(const fvMesh& mesh, const std::str
                 {
                     vertices[verticesIndex++] = faceNodes[i][d];
                 }
-                if (meshConnectivity_)
-                {
-                    verticesMap.emplace(std::make_tuple(faceNodes[i][0], faceNodes[i][1], faceNodes[i][2]), -1);
-                }
             }
         }
 
@@ -261,11 +257,9 @@ void preciceAdapter::Interface::configureMesh(const fvMesh& mesh, const std::str
 
         if (meshConnectivity_)
         {
-            // Build the map between OpenFOAM vertices and preCICE vertex IDs
-            verticesIndex = 0;
-            for (auto& key : verticesMap)
+            for (std::size_t i = 0; i < vertexIDs_.size(); ++i)
             {
-                key.second = vertexIDs_[verticesIndex++];
+                verticesMap.emplace(std::make_tuple(vertices[3 * i], vertices[3 * i + 1], vertices[3 * i + 2]), vertexIDs_[i]);
             }
 
             for (uint j = 0; j < patchIDs_.size(); j++)


### PR DESCRIPTION
Closes #313 

This was already anticipated in https://github.com/precice/openfoam-adapter/pull/297#discussion_r1273447571
`std::map` is sorted according to the key, which leads to wrong key-value pairs in the previous implementation, as the keys are resorted before we insert the (not resorted) values.

- [ ] I updated the documentation in `docs/`
- [ ] I added a changelog entry in `changelog-entries/` (create directory if missing)
