### PR TITLE
Remove unnecessary `timestepPrecice_`

### DIFF
--- a/Adapter.H
+++ b/Adapter.H
@@ -124,9 +124,6 @@ private:
 
     // Timesteps
 
-    //- Timestep dictated by preCICE
-    double timestepPrecice_;
-
     //- Timestep used by the solver
     double timestepSolver_;
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Have a look at the file `CONTRIBUTING.md` for a few hints and guidelines. -->
This is a pure refactoring to simplify the code if determining the time step size.
