### PR TITLE
Test the system tests

### DIFF
--- a/FSI/ForceBase.C
+++ b/FSI/ForceBase.C
@@ -160,7 +160,7 @@ std::size_t preciceAdapter::FSI::ForceBase::writeToBuffer(double* buffer,
         if (solverType_.compare("incompressible") == 0)
         {
             forceField.boundaryFieldRef()[patchID] =
-                surface * pb[patchID] * rhob[patchID];
+                pb[patchID] * rhob[patchID];
         }
         else if (solverType_.compare("compressible") == 0)
         {


### PR DESCRIPTION
This is meant as a demonstration of using the system tests on adapter pull requests.

I introduced a bug in the force generation, which should make the perpendicular-flap test fail, but the flow-over-heated-plate test pass. These tests are defined in https://github.com/precice/tutorials/blob/develop/tools/tests/tests.yaml

Documentation: https://precice.org/dev-docs-system-tests.html

To trigger the tests, add the `trigger-system-tests` label.