### PR TITLE
Skip velocity object from the initializer list

### DIFF
--- a/FF/Velocity.C
+++ b/FF/Velocity.C
@@ -8,20 +8,19 @@ preciceAdapter::FF::Velocity::Velocity(
     const std::string nameU,
     const std::string namePhi,
     bool fluxCorrection)
-: U_(
-    const_cast<volVectorField*>(
-        &mesh.lookupObject<volVectorField>(nameU))),
-  phi_(const_cast<surfaceScalarField*>(
+: phi_(const_cast<surfaceScalarField*>(
       &mesh.lookupObject<surfaceScalarField>(namePhi))),
   fluxCorrection_(fluxCorrection)
 {
     if (mesh.foundObject<volVectorField>(nameU))
     {
+        adapterInfo("Using existing velocity object " + nameU, "debug");
         U_ = const_cast<volVectorField*>(
             &mesh.lookupObject<volVectorField>(nameU));
     }
     else
     {
+        adapterInfo("Creating a new velocity object " + nameU, "debug");
         U_ = new volVectorField(
             IOobject(
                 nameU,

--- a/FF/Velocity.C
+++ b/FF/Velocity.C
@@ -9,7 +9,7 @@ preciceAdapter::FF::Velocity::Velocity(
     const std::string namePhi,
     bool fluxCorrection)
 : phi_(const_cast<surfaceScalarField*>(
-      &mesh.lookupObject<surfaceScalarField>(namePhi))),
+    &mesh.lookupObject<surfaceScalarField>(namePhi))),
   fluxCorrection_(fluxCorrection)
 {
     if (mesh.foundObject<volVectorField>(nameU))

--- a/changelog-entries/330.md
+++ b/changelog-entries/330.md
@@ -1,0 +1,1 @@
+- Fixed looking for velocity object that should first be created by the adapter [#330](https://github.com/precice/openfoam-adapter/pull/330).


### PR DESCRIPTION
@Fujikawas noticed that the [volume-coupled flow tutorial](https://precice.org/tutorials-volume-coupled-flow.html) was failing early on, complaining that it could not find `U_vol` when adding coupling data readers.

In the original implementation (https://github.com/precice/openfoam-adapter/pull/270), the velocity was not initialized in the initializer list of the `Velocity` constructor, but it was deferred to the body, where it was created if needed. This is actually needed when reading source terms, since we need a temporary object to read data from preCICE.

In the follow-up extension https://github.com/precice/openfoam-adapter/pull/281, the OpenFOAM velocity object was added to the initializer list, at which point it tries to find an object that (intentionally) does not exist at that point. @thesamriel do I overlook any other reason this was added again into the initializer list?

TODO list:

- I updated the documentation in `docs/` -> N/A
- [x] I added a changelog entry in `changelog-entries/` (create directory if missing)
