### PR TITLE
Add clang-format pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,6 +6,10 @@ repos:
   - id: format-precice-config
   - id: check-image-prefix
     args: [ --prefix=docs-adapter-openfoam- ]
+- repo: https://github.com/pre-commit/mirrors-clang-format
+  rev: 'v11.1.0'
+  hooks:
+  - id: clang-format
 - repo: https://github.com/igorshubovych/markdownlint-cli
   rev: v0.30.0
   hooks:

--- a/changelog-entries/331.md
+++ b/changelog-entries/331.md
@@ -1,0 +1,1 @@
+- Added clang-format to the pre-commit hook [#331](https://github.com/precice/openfoam-adapter/pull/331).


### PR DESCRIPTION
Somehow this was missing so far, even though pre-commit was already set up in this repo.

TODO list:

- I updated the documentation in `docs/` -> The `CONTRIBUTING.md` already referes to pre-commit for formatting.
- [x] I added a changelog entry in `changelog-entries/` (create directory if missing)
