### PR TITLE
Release v1.3.1

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,6 +6,10 @@ repos:
   - id: format-precice-config
   - id: check-image-prefix
     args: [ --prefix=docs-adapter-openfoam- ]
+- repo: https://github.com/pre-commit/mirrors-clang-format
+  rev: 'v11.1.0'
+  hooks:
+  - id: clang-format
 - repo: https://github.com/igorshubovych/markdownlint-cli
   rev: v0.30.0
   hooks:

--- a/Allwmake
+++ b/Allwmake
@@ -20,7 +20,7 @@ adapter_build_command(){
 ADAPTER_TARGET_DIR="${FOAM_USER_LIBBIN:-}"
 
 # More information for compatibility with OpenFOAM
-DOC_COMPATIBILITY="https://www.precice.org/adapter-openfoam-support.html"
+DOC_COMPATIBILITY="https://precice.org/adapter-openfoam-support.html"
 
 ################################################################################
 # Function to print to screen and copy to a logfile

--- a/FF/Velocity.C
+++ b/FF/Velocity.C
@@ -8,20 +8,19 @@ preciceAdapter::FF::Velocity::Velocity(
     const std::string nameU,
     const std::string namePhi,
     bool fluxCorrection)
-: U_(
-    const_cast<volVectorField*>(
-        &mesh.lookupObject<volVectorField>(nameU))),
-  phi_(const_cast<surfaceScalarField*>(
-      &mesh.lookupObject<surfaceScalarField>(namePhi))),
+: phi_(const_cast<surfaceScalarField*>(
+    &mesh.lookupObject<surfaceScalarField>(namePhi))),
   fluxCorrection_(fluxCorrection)
 {
     if (mesh.foundObject<volVectorField>(nameU))
     {
+        adapterInfo("Using existing velocity object " + nameU, "debug");
         U_ = const_cast<volVectorField*>(
             &mesh.lookupObject<volVectorField>(nameU));
     }
     else
     {
+        adapterInfo("Creating a new velocity object " + nameU, "debug");
         U_ = new volVectorField(
             IOobject(
                 nameU,

--- a/changelog-entries/330.md
+++ b/changelog-entries/330.md
@@ -1,0 +1,1 @@
+- Fixed looking for velocity object that should first be created by the adapter [#330](https://github.com/precice/openfoam-adapter/pull/330).

--- a/changelog-entries/331.md
+++ b/changelog-entries/331.md
@@ -1,0 +1,1 @@
+- Added clang-format to the pre-commit hook [#331](https://github.com/precice/openfoam-adapter/pull/331).

--- a/docs/config.md
+++ b/docs/config.md
@@ -7,7 +7,7 @@ summary: "Write a system/preciceDict, set compatible boundary conditions, and ac
 
 In order to run a coupled simulation, you need to:
 
-1. prepare a preCICE configuration file (described in the [preCICE configuration](https://www.precice.org/configuration-overview.html)),
+1. prepare a preCICE configuration file (described in the [preCICE configuration](https://precice.org/configuration-overview.html)),
 2. prepare an adapter's configuration file,
 3. set the coupling boundaries in the OpenFOAM case,
 4. load the adapter, and


### PR DESCRIPTION
Bugfix release, mainly fixing the [volume-coupled-flow tutorial](https://precice.org/tutorials-volume-coupled-flow.html) and the pre-commit hook.

Pending:

- [ ] https://github.com/precice/openfoam-adapter/pull/332
- [ ] Some kind of documentation for the types of gradients (https://github.com/precice/tutorials/issues/543)

TODO list:

- [ ] I updated the documentation in `docs/`
- [ ] I added a changelog entry in `changelog-entries/` (create directory if missing)
