### PR TITLE
OpenFOAM 10: Fixes adapter not reading coupling data

### DIFF
--- a/Adapter.C
+++ b/Adapter.C
@@ -687,7 +687,7 @@ void preciceAdapter::Adapter::adjustSolverTimeStepAndReadData()
     // which also triggers the functionObject's adjustTimeStep())
     // TODO: Keep this in mind if any relevant problem appears.
     const_cast<Time&>(runTime_).setDeltaTNoAdjust(timestepSolver_);
-
+    readCouplingData(runTime_.deltaT().value());
     return;
 }
 


### PR DESCRIPTION
Added missing call to readCouplingData(), which ensures that data is read from the precice buffer.

This fixes the issue of perpendicular-flap tutorial showing no displacement of the interface on openfoam's side.