### PR TITLE
Fix different dimensions error  / Checkpointing issue #158

### DIFF
--- a/Adapter.C
+++ b/Adapter.C
@@ -896,12 +896,12 @@ void preciceAdapter::Adapter::setupCheckpointing()
     DEBUG(adapterInfo("Adding in checkpointed fields..."));
 
 #undef doLocalCode
-#define doLocalCode(GeomField)                                           \
-    /* Checkpoint registered GeomField objects */                        \
-    for (const word& obj : mesh_.sortedNames<GeomField>())               \
-    {                                                                    \
-        std::string objStr = obj;                                        \
-        DEBUG(adapterInfo("Checkpoint " + objStr + " : " #GeomField));      \
+#define doLocalCode(GeomField)                                                   \
+    /* Checkpoint registered GeomField objects */                                \
+    for (const word& obj : mesh_.sortedNames<GeomField>())                       \
+    {                                                                            \
+        std::string objStr = obj;                                                \
+        DEBUG(adapterInfo("Checkpoint " + objStr + " : " #GeomField));           \
         addCheckpointField(objStr, mesh_.thisDb().getObjectPtr<GeomField>(obj)); \
     }
 
@@ -934,39 +934,41 @@ void preciceAdapter::Adapter::pruneCheckpointedFields()
     std::vector<word> fieldNames;
     std::vector<std::string> toRemove;
 #undef doLocalCode
-#define doLocalCode(GeomField, GeomFieldMap, GeomFieldCopiesMap)           \
-    fieldNames.clear();                                                    \
-    toRemove.clear();                                                      \
-    for (const word& obj : mesh_.sortedNames<GeomField>())                 \
-    {                                                                      \
-        fieldNames.push_back(obj);                                         \
-    }                                                                      \
-    for (const auto& kv : GeomFieldMap){                                   \
-        obj = kv.first;                                                    \
-        if (std::find(fieldNames.begin(), fieldNames.end(), obj) == fieldNames.end())  \
-        {                                                                  \
-            toRemove.push_back(static_cast<std::string>(obj));             \
-        }                                                                  \
-    }                                                                      \
-    for (const auto& obj : toRemove) {                                     \
-        GeomFieldMap.erase(obj);                                           \
-        delete GeomFieldCopiesMap[obj];                                    \
-        GeomFieldCopiesMap.erase(obj);                                     \
+#define doLocalCode(GeomField, GeomFieldMap, GeomFieldCopiesMap)                                       \
+    fieldNames.clear();                                                                                \
+    toRemove.clear();                                                                                  \
+    for (const word& obj : mesh_.sortedNames<GeomField>())                                             \
+    {                                                                                                  \
+        fieldNames.push_back(obj);                                                                     \
+    }                                                                                                  \
+    for (const auto& kv : GeomFieldMap)                                                                \
+    {                                                                                                  \
+        obj = kv.first;                                                                                \
+        if (std::find(fieldNames.begin(), fieldNames.end(), obj) == fieldNames.end())                  \
+        {                                                                                              \
+            toRemove.push_back(static_cast<std::string>(obj));                                         \
+        }                                                                                              \
+    }                                                                                                  \
+    for (const auto& obj : toRemove)                                                                   \
+    {                                                                                                  \
+        GeomFieldMap.erase(obj);                                                                       \
+        delete GeomFieldCopiesMap[obj];                                                                \
+        GeomFieldCopiesMap.erase(obj);                                                                 \
         DEBUG(adapterInfo("Removed " #GeomField " : " + obj + " from the checkpointed fields list.")); \
     }
 
-doLocalCode(volScalarField, volScalarFields_, volScalarFieldCopies_);
-doLocalCode(volVectorField, volVectorFields_, volVectorFieldCopies_);
-doLocalCode(volTensorField, volTensorFields_, volTensorFieldCopies_);
-doLocalCode(volSymmTensorField, volSymmTensorFields_, volSymmTensorFieldCopies_);
+    doLocalCode(volScalarField, volScalarFields_, volScalarFieldCopies_);
+    doLocalCode(volVectorField, volVectorFields_, volVectorFieldCopies_);
+    doLocalCode(volTensorField, volTensorFields_, volTensorFieldCopies_);
+    doLocalCode(volSymmTensorField, volSymmTensorFields_, volSymmTensorFieldCopies_);
 
-doLocalCode(surfaceScalarField, surfaceScalarFields_, surfaceScalarFieldCopies_);
-doLocalCode(surfaceVectorField, surfaceVectorFields_, surfaceVectorFieldCopies_);
-doLocalCode(surfaceTensorField, surfaceTensorFields_, surfaceTensorFieldCopies_);
+    doLocalCode(surfaceScalarField, surfaceScalarFields_, surfaceScalarFieldCopies_);
+    doLocalCode(surfaceVectorField, surfaceVectorFields_, surfaceVectorFieldCopies_);
+    doLocalCode(surfaceTensorField, surfaceTensorFields_, surfaceTensorFieldCopies_);
 
-doLocalCode(pointScalarField, pointScalarFields_, pointScalarFieldCopies_);
-doLocalCode(pointVectorField, pointVectorFields_, pointVectorFieldCopies_);
-doLocalCode(pointTensorField, pointTensorFields_, pointTensorFieldCopies_);
+    doLocalCode(pointScalarField, pointScalarFields_, pointScalarFieldCopies_);
+    doLocalCode(pointVectorField, pointVectorFields_, pointVectorFieldCopies_);
+    doLocalCode(pointTensorField, pointTensorFields_, pointTensorFieldCopies_);
 
 #undef doLocalCode
 }
@@ -1363,7 +1365,6 @@ void preciceAdapter::Adapter::writeCheckpoint()
         volVectorField* fieldCopy = volVectorFieldCopies_.at(key);
         *fieldCopy = *field;
         DEBUG(adapterInfo("Checkpointed " + key));
-
     }
 
     for (const auto& kv : volTensorFields_)
@@ -1373,7 +1374,6 @@ void preciceAdapter::Adapter::writeCheckpoint()
         volTensorField* fieldCopy = volTensorFieldCopies_.at(key);
         *fieldCopy = *field;
         DEBUG(adapterInfo("Checkpointed " + key));
-
     }
 
     for (const auto& kv : volSymmTensorFields_)
@@ -1383,7 +1383,6 @@ void preciceAdapter::Adapter::writeCheckpoint()
         volSymmTensorField* fieldCopy = volSymmTensorFieldCopies_.at(key);
         *fieldCopy = *field;
         DEBUG(adapterInfo("Checkpointed " + key));
-
     }
 
     for (const auto& kv : surfaceScalarFields_)
@@ -1393,7 +1392,6 @@ void preciceAdapter::Adapter::writeCheckpoint()
         surfaceScalarField* fieldCopy = surfaceScalarFieldCopies_.at(key);
         *fieldCopy = *field;
         DEBUG(adapterInfo("Checkpointed " + key));
-
     }
 
     for (const auto& kv : surfaceVectorFields_)
@@ -1403,7 +1401,6 @@ void preciceAdapter::Adapter::writeCheckpoint()
         surfaceVectorField* fieldCopy = surfaceVectorFieldCopies_.at(key);
         *fieldCopy = *field;
         DEBUG(adapterInfo("Checkpointed " + key));
-
     }
 
     for (const auto& kv : surfaceTensorFields_)
@@ -1413,7 +1410,6 @@ void preciceAdapter::Adapter::writeCheckpoint()
         surfaceTensorField* fieldCopy = surfaceTensorFieldCopies_.at(key);
         *fieldCopy = *field;
         DEBUG(adapterInfo("Checkpointed " + key));
-
     }
 
     for (const auto& kv : pointScalarFields_)
@@ -1423,7 +1419,6 @@ void preciceAdapter::Adapter::writeCheckpoint()
         pointScalarField* fieldCopy = pointScalarFieldCopies_.at(key);
         *fieldCopy = *field;
         DEBUG(adapterInfo("Checkpointed " + key));
-
     }
 
     for (const auto& kv : pointVectorFields_)
@@ -1433,7 +1428,6 @@ void preciceAdapter::Adapter::writeCheckpoint()
         pointVectorField* fieldCopy = pointVectorFieldCopies_.at(key);
         *fieldCopy = *field;
         DEBUG(adapterInfo("Checkpointed " + key));
-
     }
 
     for (const auto& kv : pointTensorFields_)
@@ -1443,7 +1437,6 @@ void preciceAdapter::Adapter::writeCheckpoint()
         pointTensorField* fieldCopy = pointTensorFieldCopies_.at(key);
         *fieldCopy = *field;
         DEBUG(adapterInfo("Checkpointed " + key));
-
     }
     // NOTE: Add here other types to write, if needed.
 

--- a/Adapter.C
+++ b/Adapter.C
@@ -899,8 +899,9 @@ void preciceAdapter::Adapter::setupCheckpointing()
     /* Checkpoint registered GeomField objects */                        \
     for (const word& obj : mesh_.sortedNames<GeomField>())               \
     {                                                                    \
-        addCheckpointField(mesh_.thisDb().getObjectPtr<GeomField>(obj)); \
-        DEBUG(adapterInfo("Checkpoint " + obj + " : " #GeomField));      \
+        std::string objStr = obj;                                        \
+        DEBUG(adapterInfo("Checkpoint " + objStr + " : " #GeomField));      \
+        addCheckpointField(objStr, mesh_.thisDb().getObjectPtr<GeomField>(obj)); \
     }
 
     doLocalCode(volScalarField);
@@ -921,6 +922,40 @@ void preciceAdapter::Adapter::setupCheckpointing()
 #undef doLocalCode
 
     ACCUMULATE_TIMER(timeInCheckpointingSetup_);
+}
+
+void preciceAdapter::Adapter::printFieldCounts()
+{
+std::string fields;
+int count = 0;
+
+#undef doLocalCode
+#define doLocalCode(GeomField)                                           \
+    for (const word& obj : mesh_.sortedNames<GeomField>())               \
+    {                                                                    \
+        fields += obj + " ";                                             \
+        count++;                                                         \
+    }                                                                    \
+    DEBUG(adapterInfo(std::to_string(count) + " : " #GeomField + " : " + fields));
+    fields = "";
+    count = 0;
+
+    doLocalCode(volScalarField);
+    doLocalCode(volVectorField);
+    doLocalCode(volTensorField);
+    doLocalCode(volSymmTensorField);
+
+    doLocalCode(surfaceScalarField);
+    doLocalCode(surfaceVectorField);
+    doLocalCode(surfaceTensorField);
+
+    doLocalCode(pointScalarField);
+    doLocalCode(pointVectorField);
+    doLocalCode(pointTensorField);
+
+    // NOTE: Add here other object types to checkpoint, if needed.
+
+#undef doLocalCode
 }
 
 
@@ -960,96 +995,96 @@ void preciceAdapter::Adapter::addVolCheckpointField(volScalarField::Internal& fi
 }
 
 
-void preciceAdapter::Adapter::addCheckpointField(volScalarField* field)
+void preciceAdapter::Adapter::addCheckpointField(const std::string& name, volScalarField* field)
 {
     if (field)
     {
-        volScalarFields_.push_back(field);
-        volScalarFieldCopies_.push_back(new volScalarField(*field));
+        volScalarFields_[name] = field;
+        volScalarFieldCopies_[name] = new volScalarField(*field);
     }
 }
 
-void preciceAdapter::Adapter::addCheckpointField(volVectorField* field)
+void preciceAdapter::Adapter::addCheckpointField(const std::string& name, volVectorField* field)
 {
     if (field)
     {
-        volVectorFields_.push_back(field);
-        volVectorFieldCopies_.push_back(new volVectorField(*field));
+        volVectorFields_[name] = field;
+        volVectorFieldCopies_[name] = new volVectorField(*field);
     }
 }
 
-void preciceAdapter::Adapter::addCheckpointField(surfaceScalarField* field)
+void preciceAdapter::Adapter::addCheckpointField(const std::string& name, surfaceScalarField* field)
 {
     if (field)
     {
-        surfaceScalarFields_.push_back(field);
-        surfaceScalarFieldCopies_.push_back(new surfaceScalarField(*field));
+        surfaceScalarFields_[name] = field;
+        surfaceScalarFieldCopies_[name] = new surfaceScalarField(*field);
     }
 }
 
-void preciceAdapter::Adapter::addCheckpointField(surfaceVectorField* field)
+void preciceAdapter::Adapter::addCheckpointField(const std::string& name, surfaceVectorField* field)
 {
     if (field)
     {
-        surfaceVectorFields_.push_back(field);
-        surfaceVectorFieldCopies_.push_back(new surfaceVectorField(*field));
+        surfaceVectorFields_[name] = field;
+        surfaceVectorFieldCopies_[name] = new surfaceVectorField(*field);
     }
 }
 
-void preciceAdapter::Adapter::addCheckpointField(pointScalarField* field)
+void preciceAdapter::Adapter::addCheckpointField(const std::string& name, pointScalarField* field)
 {
     if (field)
     {
-        pointScalarFields_.push_back(field);
-        pointScalarFieldCopies_.push_back(new pointScalarField(*field));
+        pointScalarFields_[name] = field;
+        pointScalarFieldCopies_[name] = new pointScalarField(*field);
     }
 }
 
-void preciceAdapter::Adapter::addCheckpointField(pointVectorField* field)
+void preciceAdapter::Adapter::addCheckpointField(const std::string& name, pointVectorField* field)
 {
     if (field)
     {
-        pointVectorFields_.push_back(field);
-        pointVectorFieldCopies_.push_back(new pointVectorField(*field));
+        pointVectorFields_[name] = field;
+        pointVectorFieldCopies_[name] = new pointVectorField(*field);
         // TODO: Old time
         // pointVectorFieldsOld_.push_back(const_cast<pointVectorField&>(field->oldTime())));
         // pointVectorFieldCopiesOld_.push_back(new pointVectorField(field->oldTime()));
     }
 }
 
-void preciceAdapter::Adapter::addCheckpointField(volTensorField* field)
+void preciceAdapter::Adapter::addCheckpointField(const std::string& name, volTensorField* field)
 {
     if (field)
     {
-        volTensorFields_.push_back(field);
-        volTensorFieldCopies_.push_back(new volTensorField(*field));
+        volTensorFields_[name] = field;
+        volTensorFieldCopies_[name] = new volTensorField(*field);
     }
 }
 
-void preciceAdapter::Adapter::addCheckpointField(surfaceTensorField* field)
+void preciceAdapter::Adapter::addCheckpointField(const std::string& name, surfaceTensorField* field)
 {
     if (field)
     {
-        surfaceTensorFields_.push_back(field);
-        surfaceTensorFieldCopies_.push_back(new surfaceTensorField(*field));
+        surfaceTensorFields_[name] = field;
+        surfaceTensorFieldCopies_[name] = new surfaceTensorField(*field);
     }
 }
 
-void preciceAdapter::Adapter::addCheckpointField(pointTensorField* field)
+void preciceAdapter::Adapter::addCheckpointField(const std::string& name, pointTensorField* field)
 {
     if (field)
     {
-        pointTensorFields_.push_back(field);
-        pointTensorFieldCopies_.push_back(new pointTensorField(*field));
+        pointTensorFields_[name] = field;
+        pointTensorFieldCopies_[name] = new pointTensorField(*field);
     }
 }
 
-void preciceAdapter::Adapter::addCheckpointField(volSymmTensorField* field)
+void preciceAdapter::Adapter::addCheckpointField(const std::string& name, volSymmTensorField* field)
 {
     if (field)
     {
-        volSymmTensorFields_.push_back(field);
-        volSymmTensorFieldCopies_.push_back(new volSymmTensorField(*field));
+        volSymmTensorFields_[name] = field;
+        volSymmTensorFieldCopies_[name] = new volSymmTensorField(*field);
     }
 }
 
@@ -1067,6 +1102,8 @@ void preciceAdapter::Adapter::readCheckpoint()
     //  for efficiency.
     DEBUG(adapterInfo("Reading a checkpoint..."));
 
+    printFieldCounts();
+
     // Reload the runTime
     reloadCheckpointTime();
 
@@ -1076,170 +1113,199 @@ void preciceAdapter::Adapter::readCheckpoint()
         reloadMeshPoints();
     }
 
-    // Reload all the fields of type volScalarField
-    for (uint i = 0; i < volScalarFields_.size(); i++)
-    {
-        // Load the volume field
-        *(volScalarFields_.at(i)) == *(volScalarFieldCopies_.at(i));
-        // TODO: Do we need this?
-        // *(volScalarFields_.at(i))->boundaryField() = *(volScalarFieldCopies_.at(i))->boundaryField();
 
-        int nOldTimes(volScalarFields_.at(i)->nOldTimes());
+    for (const auto& kv : volScalarFields_)
+    {
+        const std::string& key = kv.first;
+        volScalarField* field = kv.second;
+        volScalarField* fieldCopy = volScalarFieldCopies_.at(key);
+
+        // Load the volume field
+        *field = *fieldCopy;
+        // TODO: Do we need this?
+        // field->boundaryField() = fieldCopy->boundaryField();
+
+        int nOldTimes = field->nOldTimes();
         if (nOldTimes >= 1)
         {
-            volScalarFields_.at(i)->oldTime() == volScalarFieldCopies_.at(i)->oldTime();
+            field->oldTime() = fieldCopy->oldTime();
         }
         if (nOldTimes == 2)
         {
-            volScalarFields_.at(i)->oldTime().oldTime() == volScalarFieldCopies_.at(i)->oldTime().oldTime();
+            field->oldTime().oldTime() = fieldCopy->oldTime().oldTime();
         }
     }
 
     // Reload all the fields of type volVectorField
-    for (uint i = 0; i < volVectorFields_.size(); i++)
+    for (const auto& kv : volVectorFields_)
     {
+        const std::string& key = kv.first;
+        volVectorField* field = kv.second;
+        volVectorField* fieldCopy = volVectorFieldCopies_.at(key);
+
         // Load the volume field
-        *(volVectorFields_.at(i)) == *(volVectorFieldCopies_.at(i));
+        *field = *fieldCopy;
 
-        int nOldTimes(volVectorFields_.at(i)->nOldTimes());
+        int nOldTimes = field->nOldTimes();
         if (nOldTimes >= 1)
         {
-            volVectorFields_.at(i)->oldTime() == volVectorFieldCopies_.at(i)->oldTime();
+            field->oldTime() = fieldCopy->oldTime();
         }
         if (nOldTimes == 2)
         {
-            volVectorFields_.at(i)->oldTime().oldTime() == volVectorFieldCopies_.at(i)->oldTime().oldTime();
+            field->oldTime().oldTime() = fieldCopy->oldTime().oldTime();
         }
     }
 
-    // Reload all the fields of type surfaceScalarField
-    for (uint i = 0; i < surfaceScalarFields_.size(); i++)
+    for (const auto& kv : surfaceScalarFields_)
     {
-        *(surfaceScalarFields_.at(i)) == *(surfaceScalarFieldCopies_.at(i));
+        const std::string& key = kv.first;
+        Foam::surfaceScalarField* field = kv.second;
+        Foam::surfaceScalarField* fieldCopy = surfaceScalarFieldCopies_.at(key);
 
-        int nOldTimes(surfaceScalarFields_.at(i)->nOldTimes());
+        *field = *fieldCopy;
+
+        int nOldTimes = field->nOldTimes();
         if (nOldTimes >= 1)
         {
-            surfaceScalarFields_.at(i)->oldTime() == surfaceScalarFieldCopies_.at(i)->oldTime();
+            field->oldTime() = fieldCopy->oldTime();
         }
         if (nOldTimes == 2)
         {
-            surfaceScalarFields_.at(i)->oldTime().oldTime() == surfaceScalarFieldCopies_.at(i)->oldTime().oldTime();
+            field->oldTime().oldTime() = fieldCopy->oldTime().oldTime();
         }
     }
 
-    // Reload all the fields of type surfaceVectorField
-    for (uint i = 0; i < surfaceVectorFields_.size(); i++)
+    for (const auto& kv : surfaceVectorFields_)
     {
-        *(surfaceVectorFields_.at(i)) == *(surfaceVectorFieldCopies_.at(i));
+        const std::string& key = kv.first;
+        Foam::surfaceVectorField* field = kv.second;
+        Foam::surfaceVectorField* fieldCopy = surfaceVectorFieldCopies_.at(key);
 
-        int nOldTimes(surfaceVectorFields_.at(i)->nOldTimes());
+        *field = *fieldCopy;
+
+        int nOldTimes = field->nOldTimes();
         if (nOldTimes >= 1)
         {
-            surfaceVectorFields_.at(i)->oldTime() == surfaceVectorFieldCopies_.at(i)->oldTime();
+            field->oldTime() = fieldCopy->oldTime();
         }
         if (nOldTimes == 2)
         {
-            surfaceVectorFields_.at(i)->oldTime().oldTime() == surfaceVectorFieldCopies_.at(i)->oldTime().oldTime();
+            field->oldTime().oldTime() = fieldCopy->oldTime().oldTime();
         }
     }
 
-    // Reload all the fields of type pointScalarField
-    for (uint i = 0; i < pointScalarFields_.size(); i++)
+    for (const auto& kv : pointScalarFields_)
     {
-        *(pointScalarFields_.at(i)) == *(pointScalarFieldCopies_.at(i));
+        const std::string& key = kv.first;
+        Foam::pointScalarField* field = kv.second;
+        Foam::pointScalarField* fieldCopy = pointScalarFieldCopies_.at(key);
 
-        int nOldTimes(pointScalarFields_.at(i)->nOldTimes());
+        *field = *fieldCopy;
+
+        int nOldTimes = field->nOldTimes();
         if (nOldTimes >= 1)
         {
-            pointScalarFields_.at(i)->oldTime() == pointScalarFieldCopies_.at(i)->oldTime();
+            field->oldTime() = fieldCopy->oldTime();
         }
         if (nOldTimes == 2)
         {
-            pointScalarFields_.at(i)->oldTime().oldTime() == pointScalarFieldCopies_.at(i)->oldTime().oldTime();
+            field->oldTime().oldTime() = fieldCopy->oldTime().oldTime();
         }
     }
 
-    // Reload all the fields of type pointVectorField
-    for (uint i = 0; i < pointVectorFields_.size(); i++)
+    for (const auto& kv : pointVectorFields_)
     {
-        // Load the volume field
-        *(pointVectorFields_.at(i)) == *(pointVectorFieldCopies_.at(i));
+        const std::string& key = kv.first;
+        Foam::pointVectorField* field = kv.second;
+        Foam::pointVectorField* fieldCopy = pointVectorFieldCopies_.at(key);
 
-        int nOldTimes(pointVectorFields_.at(i)->nOldTimes());
+        *field = *fieldCopy;
+
+        int nOldTimes = field->nOldTimes();
         if (nOldTimes >= 1)
         {
-            pointVectorFields_.at(i)->oldTime() == pointVectorFieldCopies_.at(i)->oldTime();
+            field->oldTime() = fieldCopy->oldTime();
         }
         if (nOldTimes == 2)
         {
-            pointVectorFields_.at(i)->oldTime().oldTime() == pointVectorFieldCopies_.at(i)->oldTime().oldTime();
+            field->oldTime().oldTime() = fieldCopy->oldTime().oldTime();
         }
     }
 
-    // TODO Evaluate if all the tensor fields need to be in here.
-    // Reload all the fields of type volTensorField
-    for (uint i = 0; i < volTensorFields_.size(); i++)
+    for (const auto& kv : volTensorFields_)
     {
-        *(volTensorFields_.at(i)) == *(volTensorFieldCopies_.at(i));
+        const std::string& key = kv.first;
+        Foam::volTensorField* field = kv.second;
+        Foam::volTensorField* fieldCopy = volTensorFieldCopies_.at(key);
 
-        int nOldTimes(volTensorFields_.at(i)->nOldTimes());
+        *field = *fieldCopy;
+
+        int nOldTimes = field->nOldTimes();
         if (nOldTimes >= 1)
         {
-            volTensorFields_.at(i)->oldTime() == volTensorFieldCopies_.at(i)->oldTime();
+            field->oldTime() = fieldCopy->oldTime();
         }
         if (nOldTimes == 2)
         {
-            volTensorFields_.at(i)->oldTime().oldTime() == volTensorFieldCopies_.at(i)->oldTime().oldTime();
+            field->oldTime().oldTime() = fieldCopy->oldTime().oldTime();
         }
     }
 
-    // Reload all the fields of type surfaceTensorField
-    for (uint i = 0; i < surfaceTensorFields_.size(); i++)
+    for (const auto& kv : surfaceTensorFields_)
     {
-        *(surfaceTensorFields_.at(i)) == *(surfaceTensorFieldCopies_.at(i));
+        const std::string& key = kv.first;
+        Foam::surfaceTensorField* field = kv.second;
+        Foam::surfaceTensorField* fieldCopy = surfaceTensorFieldCopies_.at(key);
 
-        int nOldTimes(surfaceTensorFields_.at(i)->nOldTimes());
+        *field = *fieldCopy;
+
+        int nOldTimes = field->nOldTimes();
         if (nOldTimes >= 1)
         {
-            surfaceTensorFields_.at(i)->oldTime() == surfaceTensorFieldCopies_.at(i)->oldTime();
+            field->oldTime() = fieldCopy->oldTime();
         }
         if (nOldTimes == 2)
         {
-            surfaceTensorFields_.at(i)->oldTime().oldTime() == surfaceTensorFieldCopies_.at(i)->oldTime().oldTime();
+            field->oldTime().oldTime() = fieldCopy->oldTime().oldTime();
         }
     }
 
-    // Reload all the fields of type pointTensorField
-    for (uint i = 0; i < pointTensorFields_.size(); i++)
+    for (const auto& kv : pointTensorFields_)
     {
-        *(pointTensorFields_.at(i)) == *(pointTensorFieldCopies_.at(i));
+        const std::string& key = kv.first;
+        Foam::pointTensorField* field = kv.second;
+        Foam::pointTensorField* fieldCopy = pointTensorFieldCopies_.at(key);
 
-        int nOldTimes(pointTensorFields_.at(i)->nOldTimes());
+        *field = *fieldCopy;
+
+        int nOldTimes = field->nOldTimes();
         if (nOldTimes >= 1)
         {
-            pointTensorFields_.at(i)->oldTime() == pointTensorFieldCopies_.at(i)->oldTime();
+            field->oldTime() = fieldCopy->oldTime();
         }
         if (nOldTimes == 2)
         {
-            pointTensorFields_.at(i)->oldTime().oldTime() == pointTensorFieldCopies_.at(i)->oldTime().oldTime();
+            field->oldTime().oldTime() = fieldCopy->oldTime().oldTime();
         }
     }
 
-    // TODO volSymmTensorField is new.
-    // Reload all the fields of type volSymmTensorField
-    for (uint i = 0; i < volSymmTensorFields_.size(); i++)
+    for (const auto& kv : volSymmTensorFields_)
     {
-        *(volSymmTensorFields_.at(i)) == *(volSymmTensorFieldCopies_.at(i));
+        const std::string& key = kv.first;
+        Foam::volSymmTensorField* field = kv.second;
+        Foam::volSymmTensorField* fieldCopy = volSymmTensorFieldCopies_.at(key);
 
-        int nOldTimes(volSymmTensorFields_.at(i)->nOldTimes());
+        *field = *fieldCopy;
+
+        int nOldTimes = field->nOldTimes();
         if (nOldTimes >= 1)
         {
-            volSymmTensorFields_.at(i)->oldTime() == volSymmTensorFieldCopies_.at(i)->oldTime();
+            field->oldTime() = fieldCopy->oldTime();
         }
         if (nOldTimes == 2)
         {
-            volSymmTensorFields_.at(i)->oldTime().oldTime() == volSymmTensorFieldCopies_.at(i)->oldTime().oldTime();
+            field->oldTime().oldTime() = fieldCopy->oldTime().oldTime();
         }
     }
 
@@ -1262,6 +1328,8 @@ void preciceAdapter::Adapter::writeCheckpoint()
 
     DEBUG(adapterInfo("Writing a checkpoint..."));
 
+    printFieldCounts();
+
     // Store the runTime
     storeCheckpointTime();
 
@@ -1271,64 +1339,103 @@ void preciceAdapter::Adapter::writeCheckpoint()
         storeMeshPoints();
     }
 
-    // Store all the fields of type volScalarField
-    for (uint i = 0; i < volScalarFields_.size(); i++)
+    for (const auto& kv : volScalarFields_)
     {
-        *(volScalarFieldCopies_.at(i)) == *(volScalarFields_.at(i));
+        const std::string& key = kv.first;
+        volScalarField* field = kv.second;
+        volScalarField* fieldCopy = volScalarFieldCopies_.at(key);
+        *fieldCopy = *field;
+        DEBUG(adapterInfo("Checkpointed " + key));
     }
 
-    // Store all the fields of type volVectorField
-    for (uint i = 0; i < volVectorFields_.size(); i++)
+    for (const auto& kv : volVectorFields_)
     {
-        *(volVectorFieldCopies_.at(i)) == *(volVectorFields_.at(i));
+        const std::string& key = kv.first;
+        volVectorField* field = kv.second;
+        volVectorField* fieldCopy = volVectorFieldCopies_.at(key);
+        *fieldCopy = *field;
+        DEBUG(adapterInfo("Checkpointed " + key));
+
     }
 
-    // Store all the fields of type volTensorField
-    for (uint i = 0; i < volTensorFields_.size(); i++)
+    for (const auto& kv : volTensorFields_)
     {
-        *(volTensorFieldCopies_.at(i)) == *(volTensorFields_.at(i));
+        const std::string& key = kv.first;
+        volTensorField* field = kv.second;
+        volTensorField* fieldCopy = volTensorFieldCopies_.at(key);
+        *fieldCopy = *field;
+        DEBUG(adapterInfo("Checkpointed " + key));
+
     }
 
-    // Store all the fields of type volSymmTensorField
-    for (uint i = 0; i < volSymmTensorFields_.size(); i++)
+    for (const auto& kv : volSymmTensorFields_)
     {
-        *(volSymmTensorFieldCopies_.at(i)) == *(volSymmTensorFields_.at(i));
+        const std::string& key = kv.first;
+        volSymmTensorField* field = kv.second;
+        volSymmTensorField* fieldCopy = volSymmTensorFieldCopies_.at(key);
+        *fieldCopy = *field;
+        DEBUG(adapterInfo("Checkpointed " + key));
+
     }
 
-    // Store all the fields of type surfaceScalarField
-    for (uint i = 0; i < surfaceScalarFields_.size(); i++)
+    for (const auto& kv : surfaceScalarFields_)
     {
-        *(surfaceScalarFieldCopies_.at(i)) == *(surfaceScalarFields_.at(i));
+        const std::string& key = kv.first;
+        surfaceScalarField* field = kv.second;
+        surfaceScalarField* fieldCopy = surfaceScalarFieldCopies_.at(key);
+        *fieldCopy = *field;
+        DEBUG(adapterInfo("Checkpointed " + key));
+
     }
 
-    // Store all the fields of type surfaceVectorField
-    for (uint i = 0; i < surfaceVectorFields_.size(); i++)
+    for (const auto& kv : surfaceVectorFields_)
     {
-        *(surfaceVectorFieldCopies_.at(i)) == *(surfaceVectorFields_.at(i));
+        const std::string& key = kv.first;
+        surfaceVectorField* field = kv.second;
+        surfaceVectorField* fieldCopy = surfaceVectorFieldCopies_.at(key);
+        *fieldCopy = *field;
+        DEBUG(adapterInfo("Checkpointed " + key));
+
     }
 
-    // Store all the fields of type surfaceTensorField
-    for (uint i = 0; i < surfaceTensorFields_.size(); i++)
+    for (const auto& kv : surfaceTensorFields_)
     {
-        *(surfaceTensorFieldCopies_.at(i)) == *(surfaceTensorFields_.at(i));
+        const std::string& key = kv.first;
+        surfaceTensorField* field = kv.second;
+        surfaceTensorField* fieldCopy = surfaceTensorFieldCopies_.at(key);
+        *fieldCopy = *field;
+        DEBUG(adapterInfo("Checkpointed " + key));
+
     }
 
-    // Store all the fields of type pointScalarField
-    for (uint i = 0; i < pointScalarFields_.size(); i++)
+    for (const auto& kv : pointScalarFields_)
     {
-        *(pointScalarFieldCopies_.at(i)) == *(pointScalarFields_.at(i));
+        const std::string& key = kv.first;
+        pointScalarField* field = kv.second;
+        pointScalarField* fieldCopy = pointScalarFieldCopies_.at(key);
+        *fieldCopy = *field;
+        DEBUG(adapterInfo("Checkpointed " + key));
+
     }
 
-    // Store all the fields of type pointVectorField
-    for (uint i = 0; i < pointVectorFields_.size(); i++)
+    for (const auto& kv : pointVectorFields_)
     {
-        *(pointVectorFieldCopies_.at(i)) == *(pointVectorFields_.at(i));
+        const std::string& key = kv.first;
+        pointVectorField* field = kv.second;
+        pointVectorField* fieldCopy = pointVectorFieldCopies_.at(key);
+        *fieldCopy = *field;
+        DEBUG(adapterInfo("Checkpointed " + key));
+
     }
 
-    // Store all the fields of type pointTensorField
-    for (uint i = 0; i < pointTensorFields_.size(); i++)
+    for (const auto& kv : pointTensorFields_)
     {
-        *(pointTensorFieldCopies_.at(i)) == *(pointTensorFields_.at(i));
+        const std::string& key = kv.first;
+        pointTensorField* field = kv.second;
+        pointTensorField* fieldCopy = pointTensorFieldCopies_.at(key);
+        *fieldCopy = *field;
+        DEBUG(adapterInfo("Checkpointed " + key));
+
     }
     // NOTE: Add here other types to write, if needed.
 
@@ -1514,44 +1621,6 @@ void preciceAdapter::Adapter::teardown()
     {
         DEBUG(adapterInfo("Deleting the checkpoints... "));
 
-        // Fields
-        // volScalarFields
-        for (uint i = 0; i < volScalarFieldCopies_.size(); i++)
-        {
-            delete volScalarFieldCopies_.at(i);
-        }
-        volScalarFieldCopies_.clear();
-        // volVector
-        for (uint i = 0; i < volVectorFieldCopies_.size(); i++)
-        {
-            delete volVectorFieldCopies_.at(i);
-        }
-        volVectorFieldCopies_.clear();
-        // surfaceScalar
-        for (uint i = 0; i < surfaceScalarFieldCopies_.size(); i++)
-        {
-            delete surfaceScalarFieldCopies_.at(i);
-        }
-        surfaceScalarFieldCopies_.clear();
-        // surfaceVector
-        for (uint i = 0; i < surfaceVectorFieldCopies_.size(); i++)
-        {
-            delete surfaceVectorFieldCopies_.at(i);
-        }
-        surfaceVectorFieldCopies_.clear();
-        // pointScalar
-        for (uint i = 0; i < pointScalarFieldCopies_.size(); i++)
-        {
-            delete pointScalarFieldCopies_.at(i);
-        }
-        pointScalarFieldCopies_.clear();
-        // pointVector
-        for (uint i = 0; i < pointVectorFieldCopies_.size(); i++)
-        {
-            delete pointVectorFieldCopies_.at(i);
-        }
-        pointVectorFieldCopies_.clear();
-
         // Mesh fields
         // meshSurfaceScalar
         for (uint i = 0; i < meshSurfaceScalarFieldCopies_.size(); i++)
@@ -1582,33 +1651,76 @@ void preciceAdapter::Adapter::teardown()
         }
         volScalarInternalFieldCopies_.clear();
 
-        // volTensorField
-        for (uint i = 0; i < volTensorFieldCopies_.size(); i++)
+        // volScalarField copies
+        for (auto& kv : volScalarFieldCopies_)
         {
-            delete volTensorFieldCopies_.at(i);
+            delete kv.second; // Delete each dynamic field copy
+        }
+        volScalarFieldCopies_.clear();
+
+        // volVectorField copies
+        for (auto& kv : volVectorFieldCopies_)
+        {
+            delete kv.second;
+        }
+        volVectorFieldCopies_.clear();
+
+        // volTensorField copies
+        for (auto& kv : volTensorFieldCopies_)
+        {
+            delete kv.second;
         }
         volTensorFieldCopies_.clear();
 
-        // surfaceTensorField
-        for (uint i = 0; i < surfaceTensorFieldCopies_.size(); i++)
+        // volSymmTensorField copies
+        for (auto& kv : volSymmTensorFieldCopies_)
         {
-            delete surfaceTensorFieldCopies_.at(i);
+            delete kv.second;
+        }
+        volSymmTensorFieldCopies_.clear();
+
+        // surfaceScalarField copies
+        for (auto& kv : surfaceScalarFieldCopies_)
+        {
+            delete kv.second;
+        }
+        surfaceScalarFieldCopies_.clear();
+
+        // surfaceVectorField copies
+        for (auto& kv : surfaceVectorFieldCopies_)
+        {
+            delete kv.second;
+        }
+        surfaceVectorFieldCopies_.clear();
+
+        // surfaceTensorField copies
+        for (auto& kv : surfaceTensorFieldCopies_)
+        {
+            delete kv.second;
         }
         surfaceTensorFieldCopies_.clear();
 
-        // pointTensorField
-        for (uint i = 0; i < pointTensorFieldCopies_.size(); i++)
+        // pointScalarField copies
+        for (auto& kv : pointScalarFieldCopies_)
         {
-            delete pointTensorFieldCopies_.at(i);
+            delete kv.second;
+        }
+        pointScalarFieldCopies_.clear();
+
+        // pointVectorField copies
+        for (auto& kv : pointVectorFieldCopies_)
+        {
+            delete kv.second;
+        }
+        pointVectorFieldCopies_.clear();
+
+        // pointTensorField copies
+        for (auto& kv : pointTensorFieldCopies_)
+        {
+            delete kv.second;
         }
         pointTensorFieldCopies_.clear();
 
-        // volSymmTensor
-        for (uint i = 0; i < volSymmTensorFieldCopies_.size(); i++)
-        {
-            delete volSymmTensorFieldCopies_.at(i);
-        }
-        volSymmTensorFieldCopies_.clear();
 
         // NOTE: Add here delete for other types, if needed
 

--- a/Adapter.C
+++ b/Adapter.C
@@ -929,7 +929,7 @@ void preciceAdapter::Adapter::pruneCheckpointedFields()
     // Check if checkpointed fields exist in OpenFOAM registry
     // If not, remove them from the checkpointed fields vector
 
-    word obj;
+    word fieldName;
     std::vector<word> regFields;
     std::vector<word> toRemove;
 
@@ -938,17 +938,17 @@ void preciceAdapter::Adapter::pruneCheckpointedFields()
     regFields.clear();                                                                                                 \
     toRemove.clear();                                                                                                  \
     /* Iterate through fields in OpenFOAM registry */                                                                  \
-    for (const word& obj : mesh_.sortedNames<GeomField>())                                                             \
+    for (const word& fieldName : mesh_.sortedNames<GeomField>())                                                       \
     {                                                                                                                  \
-        regFields.push_back(obj);                                                                                      \
+        regFields.push_back(fieldName);                                                                                \
     }                                                                                                                  \
     /* Iterate through checkpointed fields */                                                                          \
-    for (uint i = 0; i < GeomFieldCopies_.size(); i++)                                                                 \
+    for (GeomField * fieldObj : GeomFieldCopies_)                                                                      \
     {                                                                                                                  \
-        obj = GeomFieldCopies_.at(i)->name();                                                                          \
-        if (std::find(regFields.begin(), regFields.end(), obj) == regFields.end())                                     \
+        fieldName = fieldObj->name();                                                                                  \
+        if (std::find(regFields.begin(), regFields.end(), fieldName) == regFields.end())                               \
         {                                                                                                              \
-            toRemove.push_back(obj);                                                                                   \
+            toRemove.push_back(fieldName);                                                                             \
         }                                                                                                              \
     }                                                                                                                  \
     if (!toRemove.empty())                                                                                             \

--- a/Adapter.C
+++ b/Adapter.C
@@ -925,47 +925,6 @@ void preciceAdapter::Adapter::setupCheckpointing()
     ACCUMULATE_TIMER(timeInCheckpointingSetup_);
 }
 
-void preciceAdapter::Adapter::printFieldCountsDB()
-{
-
-// Print fields in the OpenFOAM database
-// don't print the fields ending with '0' aka oldTime
-
-std::string fields;
-int count = 0;
-int strlen = 0;
-
-#undef doLocalCode
-#define doLocalCode(GeomField)                                           \
-    for (const word& obj : mesh_.sortedNames<GeomField>())               \
-    {                                                                    \
-        strlen = obj.size();                                             \
-        if (obj[strlen - 1] != '0')                                      \
-        {                                                                \
-            fields += obj + " ";                                         \
-            count++;                                                     \
-        }                                                                \
-    }                                                                    \
-    DEBUG(adapterInfo(std::to_string(count) + " : " #GeomField + " : " + fields));
-    fields = "";
-    count = 0;
-
-    doLocalCode(volScalarField);
-    doLocalCode(volVectorField);
-    doLocalCode(volTensorField);
-    doLocalCode(volSymmTensorField);
-
-    doLocalCode(surfaceScalarField);
-    doLocalCode(surfaceVectorField);
-    doLocalCode(surfaceTensorField);
-
-    doLocalCode(pointScalarField);
-    doLocalCode(pointVectorField);
-    doLocalCode(pointTensorField);
-
-#undef doLocalCode
-}
-
 void preciceAdapter::Adapter::pruneCheckpointedFields()
 {
     // Check if checkpointed fields exist in OpenFOAM database
@@ -1154,8 +1113,6 @@ void preciceAdapter::Adapter::readCheckpoint()
     //  Therefore, loading the oldTime() and oldTime().oldTime() fields for the other fields can be excluded
     //  for efficiency.
     DEBUG(adapterInfo("Reading a checkpoint..."));
-
-    printFieldCountsDB();
 
     // Reload the runTime
     reloadCheckpointTime();
@@ -1380,8 +1337,6 @@ void preciceAdapter::Adapter::writeCheckpoint()
     SETUP_TIMER();
 
     DEBUG(adapterInfo("Writing a checkpoint..."));
-
-    printFieldCountsDB();
 
     // Store the runTime
     storeCheckpointTime();

--- a/Adapter.C
+++ b/Adapter.C
@@ -958,7 +958,7 @@ void preciceAdapter::Adapter::pruneCheckpointedFields()
     if (!toRemoveIndices.empty())                                                                                                             \
     {                                                                                                                                         \
         /* Iterate in reverse to avoid index shifting */                                                                                      \
-        for (auto it = toRemoveIndices.rbegin(); it < toRemoveIndices.rend(); ++it)                                                           \
+        for (auto it = toRemoveIndices.rbegin(); it != toRemoveIndices.rend(); ++it)                                                          \
         {                                                                                                                                     \
             index = *it;                                                                                                                      \
             DEBUG(adapterInfo("Removed " #GeomFieldType " : " + GeomFieldCopies_.at(index)->name() + " from the checkpointed fields list.")); \

--- a/Adapter.H
+++ b/Adapter.H
@@ -24,8 +24,6 @@
 // preCICE Solver Interface
 #include <precice/precice.hpp>
 
-#include <algorithm>
-
 namespace preciceAdapter
 {
 

--- a/Adapter.H
+++ b/Adapter.H
@@ -24,6 +24,8 @@
 // preCICE Solver Interface
 #include <precice/precice.hpp>
 
+#include <algorithm>
+
 namespace preciceAdapter
 {
 

--- a/Adapter.H
+++ b/Adapter.H
@@ -1,8 +1,10 @@
 #ifndef PRECICEADAPTER_H
 #define PRECICEADAPTER_H
 
-#include "Interface.H"
 #include <unordered_map>
+#include <algorithm>
+
+#include "Interface.H"
 
 // Conjugate Heat Transfer module
 #include "CHT/CHT.H"
@@ -293,7 +295,14 @@ private:
 
     //- Configure the checkpointing
     void setupCheckpointing();
-    void printFieldCounts();
+    
+    // Debug
+    void printFieldCountsDB();
+
+    // Cross check the checkpointed fields with the
+    // OpenFOAM database and remove the fields that are not in the database.
+    void pruneCheckpointedFields();
+
 
     //- Make a copy of the runTime object
     void storeCheckpointTime();

--- a/Adapter.H
+++ b/Adapter.H
@@ -1,9 +1,6 @@
 #ifndef PRECICEADAPTER_H
 #define PRECICEADAPTER_H
 
-#include <unordered_map>
-#include <algorithm>
-
 #include "Interface.H"
 
 // Conjugate Heat Transfer module
@@ -180,67 +177,68 @@ private:
     //- Checkpointed volScalarField mesh fields (copies)
     std::vector<Foam::volScalarField::Internal*> volScalarInternalFieldCopies_;
 
-    // Maps of pointers to checkpointed fields and their copies
+    // Vectors of pointers to the checkpointed fields and their copies
 
     //- Checkpointed volScalarField fields
-    std::unordered_map<std::string, Foam::volScalarField*> volScalarFields_;
+    std::vector<Foam::volScalarField*> volScalarFields_;
 
     //- Checkpointed volScalarField fields (copies)
-    std::unordered_map<std::string, Foam::volScalarField*> volScalarFieldCopies_;
+    std::vector<Foam::volScalarField*> volScalarFieldCopies_;
 
     //- Checkpointed volVectorField fields
-    std::unordered_map<std::string, Foam::volVectorField*> volVectorFields_;
+    std::vector<Foam::volVectorField*> volVectorFields_;
 
     //- Checkpointed volVectorField fields (copies)
-    std::unordered_map<std::string, Foam::volVectorField*> volVectorFieldCopies_;
+    std::vector<Foam::volVectorField*> volVectorFieldCopies_;
 
     //- Checkpointed surfaceScalarField fields
-    std::unordered_map<std::string, Foam::surfaceScalarField*> surfaceScalarFields_;
+    std::vector<Foam::surfaceScalarField*> surfaceScalarFields_;
 
     //- Checkpointed surfaceScalarField fields (copies)
-    std::unordered_map<std::string, Foam::surfaceScalarField*> surfaceScalarFieldCopies_;
+    std::vector<Foam::surfaceScalarField*> surfaceScalarFieldCopies_;
 
     //- Checkpointed surfaceVectorField fields
-    std::unordered_map<std::string, Foam::surfaceVectorField*> surfaceVectorFields_;
+    std::vector<Foam::surfaceVectorField*> surfaceVectorFields_;
 
     //- Checkpointed surfaceVectorField fields (copies)
-    std::unordered_map<std::string, Foam::surfaceVectorField*> surfaceVectorFieldCopies_;
+    std::vector<Foam::surfaceVectorField*> surfaceVectorFieldCopies_;
 
     //- Checkpointed pointScalarField fields
-    std::unordered_map<std::string, Foam::pointScalarField*> pointScalarFields_;
+    std::vector<Foam::pointScalarField*> pointScalarFields_;
 
     //- Checkpointed pointScalarField fields (copies)
-    std::unordered_map<std::string, Foam::pointScalarField*> pointScalarFieldCopies_;
+    std::vector<Foam::pointScalarField*> pointScalarFieldCopies_;
 
     //- Checkpointed pointVectorField fields
-    std::unordered_map<std::string, Foam::pointVectorField*> pointVectorFields_;
+    std::vector<Foam::pointVectorField*> pointVectorFields_;
 
     //- Checkpointed pointVectorField fields (copies)
-    std::unordered_map<std::string, Foam::pointVectorField*> pointVectorFieldCopies_;
+    std::vector<Foam::pointVectorField*> pointVectorFieldCopies_;
 
     //- Checkpointed volTensorField fields
-    std::unordered_map<std::string, Foam::volTensorField*> volTensorFields_;
+    std::vector<Foam::volTensorField*> volTensorFields_;
 
     //- Checkpointed volTensorField fields (copies)
-    std::unordered_map<std::string, Foam::volTensorField*> volTensorFieldCopies_;
+    std::vector<Foam::volTensorField*> volTensorFieldCopies_;
 
     //- Checkpointed surfaceTensorField fields
-    std::unordered_map<std::string, Foam::surfaceTensorField*> surfaceTensorFields_;
+    std::vector<Foam::surfaceTensorField*> surfaceTensorFields_;
 
     //- Checkpointed surfaceTensorField fields (copies)
-    std::unordered_map<std::string, Foam::surfaceTensorField*> surfaceTensorFieldCopies_;
+    std::vector<Foam::surfaceTensorField*> surfaceTensorFieldCopies_;
 
     //- Checkpointed pointTensorField fields
-    std::unordered_map<std::string, Foam::pointTensorField*> pointTensorFields_;
+    std::vector<Foam::pointTensorField*> pointTensorFields_;
 
     //- Checkpointed pointTensorField fields (copies)
-    std::unordered_map<std::string, Foam::pointTensorField*> pointTensorFieldCopies_;
+    std::vector<Foam::pointTensorField*> pointTensorFieldCopies_;
 
     //- Checkpointed volSymmTensorField fields
-    std::unordered_map<std::string, Foam::volSymmTensorField*> volSymmTensorFields_;
+    std::vector<Foam::volSymmTensorField*> volSymmTensorFields_;
 
     //- Checkpointed volSymmTensorField fields (copies)
-    std::unordered_map<std::string, Foam::volSymmTensorField*> volSymmTensorFieldCopies_;
+    std::vector<Foam::volSymmTensorField*> volSymmTensorFieldCopies_;
+
 
     // NOTE: Declare additional vectors for any other types required.
 
@@ -296,8 +294,7 @@ private:
     //- Configure the checkpointing
     void setupCheckpointing();
 
-    // Cross check the checkpointed fields with the
-    // OpenFOAM database and remove the fields that are not in the database.
+    //- Remove checkpointed fields which are not used by OpenFOAM anymore
     void pruneCheckpointedFields();
 
 
@@ -331,37 +328,37 @@ private:
     // Add checkpoint fields, depending on the type
 
     //- Add a volScalarField to checkpoint
-    void addCheckpointField(const std::string& name, volScalarField* field);
+    void addCheckpointField(volScalarField* field);
 
     //- Add a volVectorField to checkpoint
-    void addCheckpointField(const std::string& name, volVectorField* field);
+    void addCheckpointField(volVectorField* field);
 
     //- Add a surfaceScalarField to checkpoint
-    void addCheckpointField(const std::string& name, surfaceScalarField* field);
+    void addCheckpointField(surfaceScalarField* field);
 
     //- Add a surfaceVectorField to checkpoint
-    void addCheckpointField(const std::string& name, surfaceVectorField* field);
+    void addCheckpointField(surfaceVectorField* field);
 
     //- Add a pointScalarField to checkpoint
-    void addCheckpointField(const std::string& name, pointScalarField* field);
+    void addCheckpointField(pointScalarField* field);
 
     //- Add a pointVectorField to checkpoint
-    void addCheckpointField(const std::string& name, pointVectorField* field);
+    void addCheckpointField(pointVectorField* field);
 
     // NOTE: Add here methods to add other object types to checkpoint,
     // if needed.
 
     //- Add a volTensorField to checkpoint
-    void addCheckpointField(const std::string& name, volTensorField* field);
+    void addCheckpointField(volTensorField* field);
 
     //- Add a surfaceTensorField to checkpoint
-    void addCheckpointField(const std::string& name, surfaceTensorField* field);
+    void addCheckpointField(surfaceTensorField* field);
 
     //- Add a pointTensorField to checkpoint
-    void addCheckpointField(const std::string& name, pointTensorField* field);
+    void addCheckpointField(pointTensorField* field);
 
     //- Add a volSymmTensorField to checkpoint
-    void addCheckpointField(const std::string& name, volSymmTensorField* field);
+    void addCheckpointField(volSymmTensorField* field);
 
     //- Read the checkpoint - restore the mesh fields and time
     void readMeshCheckpoint();

--- a/Adapter.H
+++ b/Adapter.H
@@ -2,6 +2,7 @@
 #define PRECICEADAPTER_H
 
 #include "Interface.H"
+#include <unordered_map>
 
 // Conjugate Heat Transfer module
 #include "CHT/CHT.H"
@@ -177,68 +178,67 @@ private:
     //- Checkpointed volScalarField mesh fields (copies)
     std::vector<Foam::volScalarField::Internal*> volScalarInternalFieldCopies_;
 
-    // Vectors of pointers to the checkpointed fields and their copies
+    // Maps of pointers to checkpointed fields and their copies
 
     //- Checkpointed volScalarField fields
-    std::vector<Foam::volScalarField*> volScalarFields_;
+    std::unordered_map<std::string, Foam::volScalarField*> volScalarFields_;
 
     //- Checkpointed volScalarField fields (copies)
-    std::vector<Foam::volScalarField*> volScalarFieldCopies_;
+    std::unordered_map<std::string, Foam::volScalarField*> volScalarFieldCopies_;
 
     //- Checkpointed volVectorField fields
-    std::vector<Foam::volVectorField*> volVectorFields_;
+    std::unordered_map<std::string, Foam::volVectorField*> volVectorFields_;
 
     //- Checkpointed volVectorField fields (copies)
-    std::vector<Foam::volVectorField*> volVectorFieldCopies_;
+    std::unordered_map<std::string, Foam::volVectorField*> volVectorFieldCopies_;
 
     //- Checkpointed surfaceScalarField fields
-    std::vector<Foam::surfaceScalarField*> surfaceScalarFields_;
+    std::unordered_map<std::string, Foam::surfaceScalarField*> surfaceScalarFields_;
 
     //- Checkpointed surfaceScalarField fields (copies)
-    std::vector<Foam::surfaceScalarField*> surfaceScalarFieldCopies_;
+    std::unordered_map<std::string, Foam::surfaceScalarField*> surfaceScalarFieldCopies_;
 
     //- Checkpointed surfaceVectorField fields
-    std::vector<Foam::surfaceVectorField*> surfaceVectorFields_;
+    std::unordered_map<std::string, Foam::surfaceVectorField*> surfaceVectorFields_;
 
     //- Checkpointed surfaceVectorField fields (copies)
-    std::vector<Foam::surfaceVectorField*> surfaceVectorFieldCopies_;
+    std::unordered_map<std::string, Foam::surfaceVectorField*> surfaceVectorFieldCopies_;
 
     //- Checkpointed pointScalarField fields
-    std::vector<Foam::pointScalarField*> pointScalarFields_;
+    std::unordered_map<std::string, Foam::pointScalarField*> pointScalarFields_;
 
     //- Checkpointed pointScalarField fields (copies)
-    std::vector<Foam::pointScalarField*> pointScalarFieldCopies_;
+    std::unordered_map<std::string, Foam::pointScalarField*> pointScalarFieldCopies_;
 
     //- Checkpointed pointVectorField fields
-    std::vector<Foam::pointVectorField*> pointVectorFields_;
+    std::unordered_map<std::string, Foam::pointVectorField*> pointVectorFields_;
 
     //- Checkpointed pointVectorField fields (copies)
-    std::vector<Foam::pointVectorField*> pointVectorFieldCopies_;
+    std::unordered_map<std::string, Foam::pointVectorField*> pointVectorFieldCopies_;
 
     //- Checkpointed volTensorField fields
-    std::vector<Foam::volTensorField*> volTensorFields_;
+    std::unordered_map<std::string, Foam::volTensorField*> volTensorFields_;
 
     //- Checkpointed volTensorField fields (copies)
-    std::vector<Foam::volTensorField*> volTensorFieldCopies_;
+    std::unordered_map<std::string, Foam::volTensorField*> volTensorFieldCopies_;
 
     //- Checkpointed surfaceTensorField fields
-    std::vector<Foam::surfaceTensorField*> surfaceTensorFields_;
+    std::unordered_map<std::string, Foam::surfaceTensorField*> surfaceTensorFields_;
 
     //- Checkpointed surfaceTensorField fields (copies)
-    std::vector<Foam::surfaceTensorField*> surfaceTensorFieldCopies_;
+    std::unordered_map<std::string, Foam::surfaceTensorField*> surfaceTensorFieldCopies_;
 
     //- Checkpointed pointTensorField fields
-    std::vector<Foam::pointTensorField*> pointTensorFields_;
+    std::unordered_map<std::string, Foam::pointTensorField*> pointTensorFields_;
 
     //- Checkpointed pointTensorField fields (copies)
-    std::vector<Foam::pointTensorField*> pointTensorFieldCopies_;
+    std::unordered_map<std::string, Foam::pointTensorField*> pointTensorFieldCopies_;
 
     //- Checkpointed volSymmTensorField fields
-    std::vector<Foam::volSymmTensorField*> volSymmTensorFields_;
+    std::unordered_map<std::string, Foam::volSymmTensorField*> volSymmTensorFields_;
 
     //- Checkpointed volSymmTensorField fields (copies)
-    std::vector<Foam::volSymmTensorField*> volSymmTensorFieldCopies_;
-
+    std::unordered_map<std::string, Foam::volSymmTensorField*> volSymmTensorFieldCopies_;
 
     // NOTE: Declare additional vectors for any other types required.
 
@@ -293,6 +293,7 @@ private:
 
     //- Configure the checkpointing
     void setupCheckpointing();
+    void printFieldCounts();
 
     //- Make a copy of the runTime object
     void storeCheckpointTime();
@@ -324,37 +325,37 @@ private:
     // Add checkpoint fields, depending on the type
 
     //- Add a volScalarField to checkpoint
-    void addCheckpointField(volScalarField* field);
+    void addCheckpointField(const std::string& name, volScalarField* field);
 
     //- Add a volVectorField to checkpoint
-    void addCheckpointField(volVectorField* field);
+    void addCheckpointField(const std::string& name, volVectorField* field);
 
     //- Add a surfaceScalarField to checkpoint
-    void addCheckpointField(surfaceScalarField* field);
+    void addCheckpointField(const std::string& name, surfaceScalarField* field);
 
     //- Add a surfaceVectorField to checkpoint
-    void addCheckpointField(surfaceVectorField* field);
+    void addCheckpointField(const std::string& name, surfaceVectorField* field);
 
     //- Add a pointScalarField to checkpoint
-    void addCheckpointField(pointScalarField* field);
+    void addCheckpointField(const std::string& name, pointScalarField* field);
 
     //- Add a pointVectorField to checkpoint
-    void addCheckpointField(pointVectorField* field);
+    void addCheckpointField(const std::string& name, pointVectorField* field);
 
     // NOTE: Add here methods to add other object types to checkpoint,
     // if needed.
 
     //- Add a volTensorField to checkpoint
-    void addCheckpointField(volTensorField* field);
+    void addCheckpointField(const std::string& name, volTensorField* field);
 
     //- Add a surfaceTensorField to checkpoint
-    void addCheckpointField(surfaceTensorField* field);
+    void addCheckpointField(const std::string& name, surfaceTensorField* field);
 
     //- Add a pointTensorField to checkpoint
-    void addCheckpointField(pointTensorField* field);
+    void addCheckpointField(const std::string& name, pointTensorField* field);
 
     //- Add a volSymmTensorField to checkpoint
-    void addCheckpointField(volSymmTensorField* field);
+    void addCheckpointField(const std::string& name, volSymmTensorField* field);
 
     //- Read the checkpoint - restore the mesh fields and time
     void readMeshCheckpoint();

--- a/Adapter.H
+++ b/Adapter.H
@@ -295,9 +295,6 @@ private:
 
     //- Configure the checkpointing
     void setupCheckpointing();
-    
-    // Debug
-    void printFieldCountsDB();
 
     // Cross check the checkpointed fields with the
     // OpenFOAM database and remove the fields that are not in the database.

--- a/changelog-entries/344.md
+++ b/changelog-entries/344.md
@@ -1,0 +1,2 @@
+- Fixed a bug where a field was checkpointed, but doesn't exist anymore in OpenFOAM registry, causing a crash when reloading last timestep into OpenFOAM [#344](https://github.com/precice/openfoam-adapter/pull/344)
+- Added new function 'pruneCheckpointedFields()' which is called before readCheckpoint().

--- a/changelog-entries/344.md
+++ b/changelog-entries/344.md
@@ -1,2 +1,1 @@
-- Fixed a bug where a field was checkpointed, but doesn't exist anymore in OpenFOAM registry, causing a crash when reloading last timestep into OpenFOAM [#344](https://github.com/precice/openfoam-adapter/pull/344)
-- Added new function 'pruneCheckpointedFields()' which is called before readCheckpoint().
+- Fixed a bug where a field was checkpointed, but doesn't exist anymore in OpenFOAM registry, causing a crash when reloading last timestep into OpenFOAM. This is done by pruning checkpointed fields that do not (anymore) appear in the registry of objects at that timestep before reading the checkpoint. [#344](https://github.com/precice/openfoam-adapter/pull/344)


### PR DESCRIPTION
In issue #158 it was discovered that using the kOmegaSST turbulence model together with implicit coupling causes a dimension mismatch error in OpenFOAM, when starting the second timestep / reading the checkpointed fields. The perpetrator was found to be the field 'grad(U)', which was created in the first timestep during the execution of the kOmegaSST turbulence model.  The field is created only temporarily and afterwards is not stored in the OpenFOAM registry / fields database, thus causing an error when trying to read it in the next timesteps. A failing case was posted by a user:

>Hi makis, I have made a case related to this problem, you may run this case to catch the error.
>[3000_40Mpa_orig.zip](https://github.com/user-attachments/files/17321380/3000_40Mpa_orig.zip)

_Originally posted by @c7888026 in https://github.com/precice/openfoam-adapter/issues/158#issuecomment-2403864736_

However the problem is more general since other functions can create temporary checkpointable fields, such as 'yPsi' used for 'wallDist' calculation as posted by user:

>... The log is attached above , I found that the variable **yPSi** that is calculated in the _fvSolution_ and required by the method of the wall distance in the _fvSchemes_  is the problem, so it behaves as the gradU as you described and not passed correctly through the check point . I changed the wallDist method to meshWave as @c7888026 did in his case , and it worked fine even with K-omega sst and in parallel setting using mpirun , so it is matter of variables that are not passing well ( may be ) through the checkpoint step.

_Originally posted by @KariimAhmed in https://github.com/precice/openfoam-adapter/issues/158#issuecomment-2468859857_ 

I could not yet replicate this issue, because for some reason OpenFOAM is still selecting 'meshWave' method for 'wallDist' instead of 'Poisson', which I specified in fvSchemes. Also there are no preCICE tutorials without 'meshWave'.

The general solution I found is to check which fields are stored in the OpenFOAM database and which ones are checkpointed, then remove those checkpointed fields which are no longer used by OpenFOAM. This new function 'pruneCheckpointedFields()' is executed before the `readCheckpoint()` function, where the copy was loaded `*field = *fieldCopy;`. I am not sure, but I assume the field pointer was set to another field by OpenFOAM, otherwise it would be a memory error and not a dimensions error.  

```C++
void preciceAdapter::Adapter::pruneCheckpointedFields()
{
    // Check if checkpointed fields exist in OpenFOAM database
    // If not, remove them from the checkpointed fields list
	// [...]
}
```
```C++
void preciceAdapter::Adapter::readCheckpoint()
{
	// [...]
	
    // Reload all the fields of type volVectorField
    for (const auto& kv : volVectorFields_)
    {
        const std::string& key = kv.first;
        volVectorField* field = kv.second;
        volVectorField* fieldCopy = volVectorFieldCopies_.at(key);

        // Load the volume field
        *field = *fieldCopy;

        int nOldTimes = field->nOldTimes();
        if (nOldTimes >= 1)
        {
            field->oldTime() = fieldCopy->oldTime();
        }
        if (nOldTimes == 2)
        {
            field->oldTime().oldTime() = fieldCopy->oldTime().oldTime();
        }
    }
	// [...]
}
```

Originally I thought it was an issue with storing the field pointers in a vector and using the wrong index to access this vector, so I tried to change the storage to an unordered_map and use the field name as the key:

```C++
    //- Checkpointed volScalarField fields
    std::unordered_map<std::string, Foam::volScalarField*> volScalarFields_;
```

However, the problem remained unchanged. Thus I can revert the storage back to vectors for simplicity and access the name of the field from the field object when accessing it from the vector.  

Also, the new function 'pruneCheckpointedFields()'  uses a macro and is not the prettiest, so I am open for a refactor. I included the '<algorithm>' header in 'Adapter.H' to search the fields database, but it can be done without it. When a field is removed from checkpointing, a new debug message is logged:

```Bash
[2] ---[preciceAdapter] [DEBUG] Removed volTensorField : grad(U) from the checkpointed fields list.
```

TODO list:

- [x] Revert the fields storage from vectors to unordered_map  ?
- Can be done without using macro (it's fine as it is - @MakisH)
- [x] Can be done without including <algorithm> header
- [x] Replicate and test issue with a different wallDist method than meshWave (e.g. Poisson)
- I updated the documentation in `docs/` -> N/A
- [x] I added a changelog entry in `changelog-entries/` (create directory if missing)
