### PR TITLE
Make readData and writeData optional

### DIFF
--- a/Adapter.C
+++ b/Adapter.C
@@ -139,7 +139,7 @@ bool preciceAdapter::Adapter::configFileRead()
                     }
 
                     DEBUG(adapterInfo("    writeData    : "));
-                    auto writeData = interfaceDict.get<wordList>("writeData");
+                    auto writeData = interfaceDict.lookupOrDefault<wordList>("writeData", wordList());
                     for (auto writeDatum : writeData)
                     {
                         interfaceConfig.writeData.push_back(writeDatum);
@@ -147,7 +147,7 @@ bool preciceAdapter::Adapter::configFileRead()
                     }
 
                     DEBUG(adapterInfo("    readData     : "));
-                    auto readData = interfaceDict.get<wordList>("readData");
+                    auto readData = interfaceDict.lookupOrDefault<wordList>("readData", wordList());
                     for (auto readDatum : readData)
                     {
                         interfaceConfig.readData.push_back(readDatum);

--- a/changelog-entries/348.md
+++ b/changelog-entries/348.md
@@ -1,0 +1,1 @@
+- Added support for preciceDict configuration files that don't specify an `readData` or `writeData` entry at an interface. [#348](https://github.com/precice/openfoam-adapter/pull/348)


### PR DESCRIPTION
Triggered by https://github.com/precice/preeco-orga/issues/30.

In uni-directional coupling interfaces (e.g., when using separate meshes for each field), we previously had to keep an empty list of read/write data. See, for example, the `elastic-tube-3d` tutorial:

```c++
    readData
    (
    );
    
    writeData
    (
      Force
    );
```

With this change, omitting the empty `readData` is also allowed, and the `elastic-tube-3d` tutorial runs with both setups.

This requirement was apparently not documented, unless I am overlooking something.

I don't remember my original motivation for this, but I can guess that it was either:

- some restriction of older/other versions. However, in v1.2.3 for OpenFOAM 5, the same methods are available.
- just an assumption that was not important.

TODO list:

- I updated the documentation in `docs/` -> N/A
- [x] I added a changelog entry in `changelog-entries/` (create directory if missing)
