### PR TITLE
Document differences between OpenFOAM versions

### DIFF
--- a/changelog-entries/351.md
+++ b/changelog-entries/351.md
@@ -1,0 +1,1 @@
+- Documented relevant differences between OpenFOAM versions, to make porting between versions easier. [#351](https://github.com/precice/openfoam-adapter/pull/351)

--- a/docs/openfoam-support.md
+++ b/docs/openfoam-support.md
@@ -101,9 +101,45 @@ OpenFOAM 7 was [released](https://openfoam.org/release/7/) in July 2019 ([GitHub
 
 ### OpenFOAM 8
 
-OpenFOAM 8 was rele[released](https://openfoam.org/release/8/)ased in July 2020 ([GitHub mirror](https://github.com/OpenFOAM/OpenFOAM-8), [Doxygen](https://cpp.openfoam.org/v8)). Compared to OpenFOAM 7:
+OpenFOAM 8 was [released](https://openfoam.org/release/8/) in July 2020 ([GitHub mirror](https://github.com/OpenFOAM/OpenFOAM-8), [Doxygen](https://cpp.openfoam.org/v8)). Compared to OpenFOAM 7:
 
-TBD
+- **Function objects:** Function objects changed behavior, and the `execute()` method is now also executed at start. See the [adapter issue #179](https://github.com/precice/openfoam-adapter/issues/179) and [PR #180](https://github.com/precice/openfoam-adapter/pull/180).
+  - In the beginning of `preciceAdapterFunctionObject::read()`, add `this->executeAtStart_ = false;`.
+- **Thermophysical models:** Some properties were moved from the previous `TurbulenceModels` and `transportModels` to the new `ThermophysicalTransportModels` and `MomentumTransportModels`.
+  - In `Make/options`, replace the following include paths:
+    - Remove the include paths to `transportModels/incompressible`, `transportModels/compressible`, `transportModels/twoPhaseMixture`, `transportModels/interfaceProperties`, `transportModels/immiscibleIncompressibleTwoPhaseMixture`, `TurbulenceModels/turbulenceModels`, `TurbulenceModels/compressible`, `TurbulenceModels/incompressible`.
+    - Add include paths to `ThermophysicalTransportModels`, `MomentumTransportModels/momentumTransportModels`, `MomentumTransportModels/compressible`, `MomentumTransportModels/incompressible`, `transportModels`.
+    - Remove the linking paths to `compressibleTurbulenceModels`, `incompressibleTurbulenceModels`.
+    - Add linking paths to `thermophysicalTransportModels`, `fluidThermoMomentumTransportModels`, `incompressibleMomentumTransportModels`.
+  - In `CHT/KappaEffective.H`:
+    - Remove the header inclusions `turbulentFluidThermoModel.H`, `turbulentTransportModel.H`.
+    - Include the headers `fluidThermoMomentumTransportModel.H`, `kinematicMomentumTransportModel.H`, `thermophysicalTransportModel.H`.
+    - Remove the variable declarations for `turbulence_` (2x), `nameRho_`, `nameCp_`, `namePr_`, `nameAlphat_`, `rho_`, `Cp_`, `Pr_` from the compressible and incompressible variants.
+    - In the incompressible variant's constructor signature, remove the `nameRho`, `nameCp`, `namePr`, `nameAlphat`.
+    - Add a new declaration: `const Foam::thermophysicalTransportModel& thermophysicalTransportModel_;` for each one of the `turbulence_` removed.
+  - In `CHT/KappaEffective.C`:
+    - Replace all instances of `turbulence_` with `thermophysicalTransportModel_` and update the respective comments.
+    - Replace `compressible::turbulenceModel` and `incompressible::turbulenceModel` with `thermophysicalTransportModel`.
+    - Replace `turbulenceModel::propertiesName` with `thermophysicalTransportModel::typeName`.
+    - In the incompressible variant, remove all lines of code working with `nameRho_`, `nameCp_`, `namePr_`, `nameAlphat_` from the constructor (which ends up with an empty body) and the `extract()` method. Replace the usage of `kappaEff_temp` with `thermophysicalTransportModel_.kappaEff()().boundaryField()[patchID]`.
+    - Replace the `const dictionary& CHTDict` with `const dictionary CHTDict`.
+  - In `CHT/HeatFlux.C` and in `CHT/HeatTransferCoefficient.C`:
+    - Replace `KappaEff_Incompressible(mesh, nameRho, nameCp, namePr, nameAlphat)` with `KappaEff_Incompressible(mesh)`.
+  - In `FSI/ForceBase.H`:
+    - Remove the header inclusions `immiscibleIncompressibleTwoPhaseMixture.H`, `turbulentFluidThermoModel.H`, `turbulentTransportModel.H`.
+    - Include the headers `fluidThermoMomentumTransportModel.H`, `kinematicMomentumTransportModel.H`.
+  - In `FSI/ForceBase.C`, in the `ForceBase::devRhoReff()`:
+    - Replace `compressible::turbulenceModel` with `compressible::momentumTransportModel`.
+    - Replace `incompressible::turbulenceModel` with `incompressible::momentumTransportModel`.
+    - Replace `cmpTurbModel::propertiesName` with `cmpTurbModel::typeName`.
+    - Replace `turb(mesh_.lookupObject<>())` with `turb = mesh_.lookupObject<>()` (where `const cmpTurbModel& turb`).
+    - Replace `turb.devRhoReff()` with `turb.devTau()`.
+    - Replace `turb.devReff()` with `turb.devSigma()`.
+    - Replace `U(mesh_.lookupObject<>())` with `U = mesh_.lookupObject<>()` (where `const volVectorField& U`).
+  - In `FSI/ForceBase.C`, in the `ForceBase::mu()`:
+    - Remove the line `typedef immiscibleIncompressibleTwoPhaseMixture iitpMixture;`.
+    - Replace the type `iitpMixture` with `fluidThermo` and rename the respective object from `mixture` to `thermo`.
+    - Replace `"mixture"` in the lookups with `basicThermo::dictName`.
 
 ### OpenFOAM 9
 

--- a/docs/openfoam-support.md
+++ b/docs/openfoam-support.md
@@ -75,11 +75,25 @@ We take into account the following relevant differences between OpenFOAM version
   - Replace calls to pointer `.reset()`, such as `ForceOwning_.reset(new volVectorField(`, with `ForceOwning_ = new volVectorField(`. Adjust the number of closing parentheses.
   - Replace calls to pointer `.get();`, such as `ForceOwning_.get()`, with `ForceOwning_.ptr()`.
 
-### OpenFOAM 4
+### OpenFOAM 4 and 5
 
-### OpenFOAM 5
+Same as in OpenFOAM v1612-v1806.
+
+### OpenFOAM 6
+
+Compared to OpenFOAM 5:
+
+- **adjustTimeStep:** In the function objects interface, `adjustTimeStep()` was renamed to `setTimeStep()`.
+  - Replace `adjustTimeStep()` with `setTimeStep()`, both for the function object and the adapter members.
+- **setDeltaT:** The `Time` method `setDeltaT(..., false)` was replaced by `setDeltaTNoAdjust(...)`.
+  - Replace `setDeltaT(timestepSolver_, false)` with `setDeltaTNoAdjust(timestepSolver_)`.
 
 ### OpenFOAM 7
+
+Compared to OpenFOAM 6:
+
+- **fileName:** `fileName::DIRECTORY` was renamed to `fileType::directory`.
+  - Replace this in the `Adapter.C`.
 
 ### OpenFOAM 8
 

--- a/docs/openfoam-support.md
+++ b/docs/openfoam-support.md
@@ -92,12 +92,16 @@ OpenFOAM 6 was [released](https://openfoam.org/release/6/) in July 2018 ([GitHub
 - **setDeltaT:** The `Time` method `setDeltaT(..., false)` was replaced by `setDeltaTNoAdjust(...)`.
   - Replace `setDeltaT(timestepSolver_, false)` with `setDeltaTNoAdjust(timestepSolver_)`.
 
+Related work in the adapter: [PR #33](https://github.com/precice/openfoam-adapter/pull/33).
+
 ### OpenFOAM 7
 
 OpenFOAM 7 was [released](https://openfoam.org/release/7/) in July 2019 ([GitHub mirror](https://github.com/OpenFOAM/OpenFOAM-7), [Doxygen](https://cpp.openfoam.org/v7)). Compared to OpenFOAM 6:
 
 - **fileName:** `fileName::DIRECTORY` was renamed to `fileType::directory`.
   - Replace this in the `Adapter.C`.
+
+Related work in the adapter: [PR #91](https://github.com/precice/openfoam-adapter/pull/91).
 
 ### OpenFOAM 8
 
@@ -141,6 +145,8 @@ OpenFOAM 8 was [released](https://openfoam.org/release/8/) in July 2020 ([GitHub
     - Replace the type `iitpMixture` with `fluidThermo` and rename the respective object from `mixture` to `thermo`.
     - Replace `"mixture"` in the lookups with `basicThermo::dictName`.
 
+Related work in the adapter: [PR #130](https://github.com/precice/openfoam-adapter/pull/130).
+
 ### OpenFOAM 9
 
 OpenFOAM 9 was [released](https://openfoam.org/release/9/) in July 2021 ([GitHub mirror](https://github.com/OpenFOAM/OpenFOAM-9), [Doxygen](https://cpp.openfoam.org/v9)). Compared to OpenFOAM 8:
@@ -159,6 +165,8 @@ OpenFOAM 9 was [released](https://openfoam.org/release/9/) in July 2021 ([GitHub
     - `incompressible::momentumTransportModel` with `incompressibleMomentumTransportModel`. Further down, replace the usage `const incompressible::momentumTransportModel&` with `const icoTurbModel&`.
 - **Triangulation:** In `Adapter.C`:
   - Replace the header `faceTriangulation.H` with `polygonTriangulate.H`.
+
+Related work in the adapter: [PR #221](https://github.com/precice/openfoam-adapter/pull/221).
 
 ### OpenFOAM 10
 
@@ -187,6 +195,8 @@ OpenFOAM 10 was [released](https://openfoam.org/release/10/) in July 2022 ([GitH
 OpenFOAM 11 was [released](https://openfoam.org/release/11/) in July 2023 ([GitHub mirror](https://github.com/OpenFOAM/OpenFOAM-11), [Doxygen](https://cpp.openfoam.org/v11)). Compared to OpenFOAM 10:
 
 TBD
+
+Related work in the adapter: [PR #310](https://github.com/precice/openfoam-adapter/pull/310).
 
 ### OpenFOAM 12
 

--- a/docs/openfoam-support.md
+++ b/docs/openfoam-support.md
@@ -19,6 +19,10 @@ sudo apt-get install openfoam2412-dev
 
 As these steps change your `.profile`, you need to log out and in again to make OpenFOAM fully discoverable.
 
+## Supported OpenFOAM solvers
+
+We support mainstream OpenFOAM solvers such as pimpleFoam and solids4Foam for FSI, buoyantPimpleFoam, buoyantSimpleFoam, and laplacianFoam for CHT, or pimpleFoam and sonicLiquidFoam for FF. Our community has, additionally, tried the adapter with multiple different solvers that support function objects.
+
 ## Supported OpenFOAM versions
 
 OpenFOAM is a project with long history and many forks, of which we try to support as many as possible. Since several HPC systems only provide older versions, we try to also support a wide range of versions.
@@ -50,9 +54,40 @@ We provide version-specific [release archives](https://github.com/precice/openfo
 
 Known not supported versions: OpenFOAM v1606+ or older, OpenFOAM 3 or older, foam-extend (any version).
 
-## Supported OpenFOAM solvers
+## Differences between OpenFOAM versions
 
-We support mainstream OpenFOAM solvers such as pimpleFoam and solids4Foam for FSI, buoyantPimpleFoam, buoyantSimpleFoam, and laplacianFoam for CHT, or pimpleFoam and sonicLiquidFoam for FF. Our community has, additionally, tried the adapter with multiple different solvers that support function objects.
+We take into account the following relevant differences between OpenFOAM versions, compared to the latest OpenCFD version. This list is important for maintainers of version-specific ports of the adapter.
+
+### OpenFOAM v1612-v1806
+
+- **clockValue:** The `clockValue.H` header is not available (used in `preciceAdapterFunctionObject.H`).
+  - Disable the timers feature, controlled by the `ADAPTER_ENABLE_TIMINGS` preprocessor variable (set in `Allwmake`).
+- **dictionary access:** In dictionaries (essentially: in the `preciceDict`), some methods are not available. These are mainly used in the configuration step in `Adapter.C`, but also in `ForceBase.C`.
+  - Replace `preciceDict.get<fileName>("...")` with `static_cast<fileName>(preciceDict.lookup("...")`.
+  - Replace `preciceDict.get<word>("...")` with `static_cast<word>(preciceDict.lookup("..."))`.
+  - Replace `preciceDict.get<wordList>("...")` with `static_cast<wordList>(preciceDict.lookup("..."))`.
+  - Replace `preciceDict.findDict("...")` with `preciceDict.subDictPtr("...")`.
+- **Db access:** In the macro that deals with adding checkpointed fields, some methods are not available.
+  - Replace `mesh_.sortedNames<GeomField>()` with `mesh_.lookupClass<GeomField>().sortedToc()`.
+  - Replace `mesh_.thisDb().getObjectPtr<GeomField>(obj)` with `&(const_cast<GeomField&>(mesh_.thisDb().lookupObject<GeomField>(obj)))`.
+- **Pointers:** `std::unique_ptr` is not available.
+  - Replace `std::unique_ptr<T>` with `Foam::autoPtr<T>`.
+  - Replace calls to pointer `.reset()`, such as `ForceOwning_.reset(new volVectorField(`, with `ForceOwning_ = new volVectorField(`. Adjust the number of closing parentheses.
+  - Replace calls to pointer `.get();`, such as `ForceOwning_.get()`, with `ForceOwning_.ptr()`.
+
+### OpenFOAM 4
+
+### OpenFOAM 5
+
+### OpenFOAM 7
+
+### OpenFOAM 8
+
+### OpenFOAM 9
+
+### OpenFOAM 10
+
+### foam-extend
 
 ## Notes on OpenFOAM features
 

--- a/docs/openfoam-support.md
+++ b/docs/openfoam-support.md
@@ -77,13 +77,15 @@ We take into account the following relevant differences between OpenFOAM version
 
 ### OpenFOAM 4 and 5
 
-OpenFOAM 4 was released in June 2016 and OpenFOAM 5 in July 2017.
+OpenFOAM 4 was [released](https://openfoam.org/release/4/) in June 2016 ([GitHub mirror](https://github.com/OpenFOAM/OpenFOAM-4.x), [Doxygen](https://cpp.openfoam.org/v4)).
+
+OpenFOAM 5 was [released](https://openfoam.org/release/5/) in July 2017 ([GitHub mirror](https://github.com/OpenFOAM/OpenFOAM-5.x), [Doxygen](https://cpp.openfoam.org/v5)).
 
 Same as in OpenFOAM v1612-v1806.
 
 ### OpenFOAM 6
 
-OpenFOAM 6 was released in July 2018. Compared to OpenFOAM 5:
+OpenFOAM 6 was [released](https://openfoam.org/release/6/) in July 2018 ([GitHub mirror](https://github.com/OpenFOAM/OpenFOAM-6), [Doxygen](https://cpp.openfoam.org/v6)). Compared to OpenFOAM 5:
 
 - **adjustTimeStep:** In the function objects interface, `adjustTimeStep()` was renamed to `setTimeStep()`.
   - Replace `adjustTimeStep()` with `setTimeStep()`, both for the function object and the adapter members.
@@ -92,38 +94,38 @@ OpenFOAM 6 was released in July 2018. Compared to OpenFOAM 5:
 
 ### OpenFOAM 7
 
-OpenFOAM 7 was released in July 2019. Compared to OpenFOAM 6:
+OpenFOAM 7 was [released](https://openfoam.org/release/7/) in July 2019 ([GitHub mirror](https://github.com/OpenFOAM/OpenFOAM-7), [Doxygen](https://cpp.openfoam.org/v7)). Compared to OpenFOAM 6:
 
 - **fileName:** `fileName::DIRECTORY` was renamed to `fileType::directory`.
   - Replace this in the `Adapter.C`.
 
 ### OpenFOAM 8
 
-OpenFOAM 8 was released in July 2020. Compared to OpenFOAM 7:
+OpenFOAM 8 was rele[released](https://openfoam.org/release/8/)ased in July 2020 ([GitHub mirror](https://github.com/OpenFOAM/OpenFOAM-8), [Doxygen](https://cpp.openfoam.org/v8)). Compared to OpenFOAM 7:
 
 TBD
 
 ### OpenFOAM 9
 
-OpenFOAM 9 was released in July 2021. Compared to OpenFOAM 8:
+OpenFOAM 9 was [released](https://openfoam.org/release/9/) in July 2021 ([GitHub mirror](https://github.com/OpenFOAM/OpenFOAM-9), [Doxygen](https://cpp.openfoam.org/v9)). Compared to OpenFOAM 8:
 
 TBD
 
 ### OpenFOAM 10
 
-OpenFOAM 10 was released in July 2022. Compared to OpenFOAM 9:
+OpenFOAM 10 was [released](https://openfoam.org/release/10/) in July 2022 ([GitHub mirror](https://github.com/OpenFOAM/OpenFOAM-10), [Doxygen](https://cpp.openfoam.org/v10)). Compared to OpenFOAM 9:
 
 TBD
 
 ### OpenFOAM 11
 
-OpenFOAM 11 was released in July 2023. Compared to OpenFOAM 10:
+OpenFOAM 11 was [released](https://openfoam.org/release/11/) in July 2023 ([GitHub mirror](https://github.com/OpenFOAM/OpenFOAM-11), [Doxygen](https://cpp.openfoam.org/v11)). Compared to OpenFOAM 10:
 
 TBD
 
 ### OpenFOAM 12
 
-OpenFOAM 12 was released in July 2024. Compared to OpenFOAM 11:
+OpenFOAM 12 was [released](https://openfoam.org/release/12/) in July 2024 ([GitHub mirror](https://github.com/OpenFOAM/OpenFOAM-12), [Doxygen](https://cpp.openfoam.org/v12)). Compared to OpenFOAM 11:
 
 TBD
 

--- a/docs/openfoam-support.md
+++ b/docs/openfoam-support.md
@@ -164,7 +164,23 @@ OpenFOAM 9 was [released](https://openfoam.org/release/9/) in July 2021 ([GitHub
 
 OpenFOAM 10 was [released](https://openfoam.org/release/10/) in July 2022 ([GitHub mirror](https://github.com/OpenFOAM/OpenFOAM-10), [Doxygen](https://cpp.openfoam.org/v10)). Compared to OpenFOAM 9:
 
-TBD
+- **Function objects:** The method `fields()` has been made pure virtual, meaning it needs to be implemented.
+  - In `preciceAdapterFunctionObject.H`, implement it as (more of a workaround to avoid implementation):
+
+    ```c++
+    virtual wordList fields() const
+    {
+        return wordList::null();
+    }
+    ```
+
+- **Physical properties and models:** The `physicalProperties` was replaced by `transportModels`.
+  - In `Make/options`, replace `physicalProperties` with `transportModels` in the included paths and in the linked libraries.
+  - In `FSI/ForceBase.H`, replace `kinematicMomentumTransportModel.H` with `incompressibleMomentumTransportModel.H`.
+  - In `FSI/ForceBase.C`, replace `basicThermo::dictName` with `physicalProperties::typeName`.
+- **Fields `V0` and `V00`:** The fields `V0` and `V00` have been removed or renamed (not sure to what).
+  - In `Adapter.C`, method `preciceAdapter::Adapter::setupMeshVolCheckpointing()`, guard each of these two fields with a `if (mesh_.foundObject<volScalarField::Internal>("V0"))` (and `if (... ("V00"))`, respectively). Alternatively, remove the implementation of this method altogether.
+  - **Impact:** This might lead to stability issues in FSI simulations with implicit coupling. Check your results.
 
 ### OpenFOAM 11
 

--- a/docs/openfoam-support.md
+++ b/docs/openfoam-support.md
@@ -192,17 +192,13 @@ OpenFOAM 10 was [released](https://openfoam.org/release/10/) in July 2022 ([GitH
 
 ### OpenFOAM 11
 
-OpenFOAM 11 was [released](https://openfoam.org/release/11/) in July 2023 ([GitHub mirror](https://github.com/OpenFOAM/OpenFOAM-11), [Doxygen](https://cpp.openfoam.org/v11)). Compared to OpenFOAM 10:
-
-TBD
+OpenFOAM 11 was [released](https://openfoam.org/release/11/) in July 2023 ([GitHub mirror](https://github.com/OpenFOAM/OpenFOAM-11), [Doxygen](https://cpp.openfoam.org/v11)). We do not yet know which are relevant changes. Please help us port the adapter to OpenFOAM 11.
 
 Related work in the adapter: [PR #310](https://github.com/precice/openfoam-adapter/pull/310).
 
 ### OpenFOAM 12
 
-OpenFOAM 12 was [released](https://openfoam.org/release/12/) in July 2024 ([GitHub mirror](https://github.com/OpenFOAM/OpenFOAM-12), [Doxygen](https://cpp.openfoam.org/v12)). Compared to OpenFOAM 11:
-
-TBD
+OpenFOAM 12 was [released](https://openfoam.org/release/12/) in July 2024 ([GitHub mirror](https://github.com/OpenFOAM/OpenFOAM-12), [Doxygen](https://cpp.openfoam.org/v12)). We do not yet know which are relevant changes. Please help us port the adapter to OpenFOAM 12.
 
 ### foam-extend
 

--- a/docs/openfoam-support.md
+++ b/docs/openfoam-support.md
@@ -202,6 +202,10 @@ OpenFOAM 12 was [released](https://openfoam.org/release/12/) in July 2024 ([GitH
 
 ### foam-extend
 
+We have not yet documented all related changes that would make the adapter work for foam-extend. See the repository [`precice/foam-extend-adapter`](https://github.com/precice/foam-extend-adapter) for the latest state and please contribute to this page.
+
+Related work in the adapter: [PR #302](https://github.com/precice/openfoam-adapter/pull/302).
+
 ## Notes on OpenFOAM features
 
 ### End of the simulation

--- a/docs/openfoam-support.md
+++ b/docs/openfoam-support.md
@@ -35,20 +35,13 @@ We provide version-specific [release archives](https://github.com/precice/openfo
 
 - OpenCFD / ESI (openfoam.com) - main focus:
   - [OpenFOAM v1812-v2412](https://github.com/precice/openfoam-adapter) or newer
-    - OpenFOAM v2212 and newer is only supported since v1.2.2 of the adapter.
   - [OpenFOAM v1612-v1806](https://github.com/precice/openfoam-adapter/tree/OpenFOAMv1806) (not tested)
 - OpenFOAM Foundation (openfoam.org) - secondary, consider experimental:
   - [OpenFOAM 10](https://github.com/precice/openfoam-adapter/tree/OpenFOAM10)
-    - Several [changes to the tutorials](https://github.com/precice/tutorials/tree/OpenFOAM10) are also needed, read the [discussion](https://github.com/precice/tutorials/pull/283).
-    - Same limitations as for OpenFOAM 9.
   - [OpenFOAM 9](https://github.com/precice/openfoam-adapter/tree/OpenFOAM9)
-    - Rename `solver` to `motionSolver` in `constant/dynamicMeshDict`.
-    - Modify also `residualControl` to `outerCorrectorResidualControl` in `system/fvSolution`.
-    - Limitations in adjustable time step size ([#261](https://github.com/precice/openfoam-adapter/issues/261)).
   - [OpenFOAM 8](https://github.com/precice/openfoam-adapter/tree/OpenFOAM8)
   - [OpenFOAM 7](https://github.com/precice/openfoam-adapter/tree/OpenFOAM7)
   - [OpenFOAM 6](https://github.com/precice/openfoam-adapter/tree/OpenFOAM6)
-    - Modify also `residualControl` to `outerResidualControl` in `system/fvSolution`.
   - [OpenFOAM 5.x](https://github.com/precice/openfoam-adapter/tree/OpenFOAM5)
   - [OpenFOAM 4.0/4.1](https://github.com/precice/openfoam-adapter/tree/OpenFOAM4) (not tested)
 
@@ -91,6 +84,8 @@ OpenFOAM 6 was [released](https://openfoam.org/release/6/) in July 2018 ([GitHub
   - Replace `adjustTimeStep()` with `setTimeStep()`, both for the function object and the adapter members.
 - **setDeltaT:** The `Time` method `setDeltaT(..., false)` was replaced by `setDeltaTNoAdjust(...)`.
   - Replace `setDeltaT(timestepSolver_, false)` with `setDeltaTNoAdjust(timestepSolver_)`.
+- **Case files:**
+  - In `system/fvSolution`, replace `residualControl` with `outerResidualControl`.
 
 Related work in the adapter: [PR #33](https://github.com/precice/openfoam-adapter/pull/33).
 
@@ -153,7 +148,7 @@ OpenFOAM 9 was [released](https://openfoam.org/release/9/) in July 2021 ([GitHub
 
 - **Function objects:** The `setTimeStep()` method was removed.
   - Remove the method from the `preciceAdapterFunctionObject.H` and `preciceAdapterFunctionObject.C`. Adjust the comments for the equivalent method in `Adapter.H`.
-  - **Impact:** None expected. preCICE can still adjust the time step size of OpenFOAM and the adapter should still read the updated time step size of OpenFOAM inside `execute()`.
+  - **Impact:** See limitations in adjustable time step size ([#261](https://github.com/precice/openfoam-adapter/issues/261)).
 - **Thermophysical models:** Different libraries need to be linked and different headers need to be included:
   - In `Make/options`, remove the linking of `fluidThermoMomentumTransportModels` and `incompressibleMomentumTransportModels`.
   - In `Make/options`, link to `transportModels`, `momentumTransportModels`, `incompressibleMomentumTransportModels`, `compressibleMomentumTransportModels`.
@@ -165,6 +160,9 @@ OpenFOAM 9 was [released](https://openfoam.org/release/9/) in July 2021 ([GitHub
     - `incompressible::momentumTransportModel` with `incompressibleMomentumTransportModel`. Further down, replace the usage `const incompressible::momentumTransportModel&` with `const icoTurbModel&`.
 - **Triangulation:** In `Adapter.C`:
   - Replace the header `faceTriangulation.H` with `polygonTriangulate.H`.
+- **Case files:**
+  - In `constant/dynamicMeshDict`, replace `solver` with `motionSolver`.
+  - In `system/fvSolution`, replace `residualControl` with `outerCorrectorResidualControl`. This was already renamed to `outerResidualControl` in OpenFOAM 6.
 
 Related work in the adapter: [PR #221](https://github.com/precice/openfoam-adapter/pull/221).
 
@@ -189,6 +187,7 @@ OpenFOAM 10 was [released](https://openfoam.org/release/10/) in July 2022 ([GitH
 - **Fields `V0` and `V00`:** The fields `V0` and `V00` have been removed or renamed (not sure to what).
   - In `Adapter.C`, method `preciceAdapter::Adapter::setupMeshVolCheckpointing()`, guard each of these two fields with a `if (mesh_.foundObject<volScalarField::Internal>("V0"))` (and `if (... ("V00"))`, respectively). Alternatively, remove the implementation of this method altogether.
   - **Impact:** This might lead to stability issues in FSI simulations with implicit coupling. Check your results.
+- **Case files:** Several [changes to the tutorials](https://github.com/precice/tutorials/tree/OpenFOAM10) are needed, read the [discussion](https://github.com/precice/tutorials/pull/283).
 
 ### OpenFOAM 11
 

--- a/docs/openfoam-support.md
+++ b/docs/openfoam-support.md
@@ -77,11 +77,13 @@ We take into account the following relevant differences between OpenFOAM version
 
 ### OpenFOAM 4 and 5
 
+OpenFOAM 4 was released in June 2016 and OpenFOAM 5 in July 2017.
+
 Same as in OpenFOAM v1612-v1806.
 
 ### OpenFOAM 6
 
-Compared to OpenFOAM 5:
+OpenFOAM 6 was released in July 2018. Compared to OpenFOAM 5:
 
 - **adjustTimeStep:** In the function objects interface, `adjustTimeStep()` was renamed to `setTimeStep()`.
   - Replace `adjustTimeStep()` with `setTimeStep()`, both for the function object and the adapter members.
@@ -90,16 +92,40 @@ Compared to OpenFOAM 5:
 
 ### OpenFOAM 7
 
-Compared to OpenFOAM 6:
+OpenFOAM 7 was released in July 2019. Compared to OpenFOAM 6:
 
 - **fileName:** `fileName::DIRECTORY` was renamed to `fileType::directory`.
   - Replace this in the `Adapter.C`.
 
 ### OpenFOAM 8
 
+OpenFOAM 8 was released in July 2020. Compared to OpenFOAM 7:
+
+TBD
+
 ### OpenFOAM 9
 
+OpenFOAM 9 was released in July 2021. Compared to OpenFOAM 8:
+
+TBD
+
 ### OpenFOAM 10
+
+OpenFOAM 10 was released in July 2022. Compared to OpenFOAM 9:
+
+TBD
+
+### OpenFOAM 11
+
+OpenFOAM 11 was released in July 2023. Compared to OpenFOAM 10:
+
+TBD
+
+### OpenFOAM 12
+
+OpenFOAM 12 was released in July 2024. Compared to OpenFOAM 11:
+
+TBD
 
 ### foam-extend
 

--- a/docs/openfoam-support.md
+++ b/docs/openfoam-support.md
@@ -145,7 +145,20 @@ OpenFOAM 8 was [released](https://openfoam.org/release/8/) in July 2020 ([GitHub
 
 OpenFOAM 9 was [released](https://openfoam.org/release/9/) in July 2021 ([GitHub mirror](https://github.com/OpenFOAM/OpenFOAM-9), [Doxygen](https://cpp.openfoam.org/v9)). Compared to OpenFOAM 8:
 
-TBD
+- **Function objects:** The `setTimeStep()` method was removed.
+  - Remove the method from the `preciceAdapterFunctionObject.H` and `preciceAdapterFunctionObject.C`. Adjust the comments for the equivalent method in `Adapter.H`.
+  - **Impact:** None expected. preCICE can still adjust the time step size of OpenFOAM and the adapter should still read the updated time step size of OpenFOAM inside `execute()`.
+- **Thermophysical models:** Different libraries need to be linked and different headers need to be included:
+  - In `Make/options`, remove the linking of `fluidThermoMomentumTransportModels` and `incompressibleMomentumTransportModels`.
+  - In `Make/options`, link to `transportModels`, `momentumTransportModels`, `incompressibleMomentumTransportModels`, `compressibleMomentumTransportModels`.
+  - In `CHT/KappaEffective.H`, replace the headers `fluidThermoMomentumTransportModel.H` and `kinematicMomentumTransportModel.H` with `momentumTransportModel.H`.
+  - In `FSI/ForceBase.H`, replace the header `fluidThermoMomentumTransportModel.H` with `compressibleMomentumTransportModel.H`.
+  - In `FSI/ForceBase.C`, add the header `fluidThermo.H`.
+  - In `FSI/ForceBase.C`, replace:
+    - `compressible::momentumTransportModel` with `compressibleMomentumTransportModel`
+    - `incompressible::momentumTransportModel` with `incompressibleMomentumTransportModel`. Further down, replace the usage `const incompressible::momentumTransportModel&` with `const icoTurbModel&`.
+- **Triangulation:** In `Adapter.C`:
+  - Replace the header `faceTriangulation.H` with `polygonTriangulate.H`.
 
 ### OpenFOAM 10
 


### PR DESCRIPTION
During the preCICE Workshop 2024, and in the context of https://github.com/precice/openfoam-adapter/issues/328, we decided (among other things) to document the relevant differences between OpenFOAM versions. This should help maintainers port new versions of the adapters to other OpenFOAM versions, even if the development state diverges so much that Git rebasing becomes difficult.

This PR adds documentation for each version (under [OpenFOAM support](https://precice.org/adapter-openfoam-support.html)):

- Link to the release notes (including date)
- Link to GitHub repository mirror
- Link to Doxygen pages
- List of changes, grouped, with add/remove/replace steps
- Links to related PRs in this repository

The list of differences is based on a text comparison between the release artifacts of v1.2.3.

This is now ready for review, but it might be worth it waiting for me to do the actual porting before merging, as more changes might be relevant now.

TODO list:

- [x] I updated the documentation in `docs/`
- [x] I added a changelog entry in `changelog-entries/` (create directory if missing)
