### PR TITLE
Set `ADAPTER_TARGET_DIR` and `ADAPTER_CFLAGS` (`ADAPTER_PREP_FLAGS`) via environment variables

### DIFF
--- a/Allwmake
+++ b/Allwmake
@@ -6,7 +6,7 @@ set -e -u
 # Optional: Preprocessor flags
 # "-DADAPTER_DEBUG_MODE" enables debug messages
 # "-DADAPTER_ENABLE_TIMINGS" enables time measurements
-ADAPTER_PREP_FLAGS="${ADAPTER_PREP_FLAGS:-}"
+ADAPTER_PREP_FLAGS="${PRECICE_OPENFOAM_PREP_FLAGS:-}"
 
 # Build command and options
 # In order to compile with multiple threads, set the environment variable WM_NCOMPPROCS,
@@ -17,7 +17,7 @@ adapter_build_command(){
 }
 
 # Where should the adapter be built? Default: "${FOAM_USER_LIBBIN}"
-ADAPTER_TARGET_DIR="${ADAPTER_TARGET_DIR:-$FOAM_USER_LIBBIN}"
+ADAPTER_TARGET_DIR="${PRECICE_OPENFOAM_TARGET_DIR:-$FOAM_USER_LIBBIN}"
 
 # More information for compatibility with OpenFOAM
 DOC_COMPATIBILITY="https://precice.org/adapter-openfoam-support.html"

--- a/Allwmake
+++ b/Allwmake
@@ -6,7 +6,7 @@ set -e -u
 # Optional: Preprocessor flags
 # "-DADAPTER_DEBUG_MODE" enables debug messages
 # "-DADAPTER_ENABLE_TIMINGS" enables time measurements
-ADAPTER_PREP_FLAGS="${PRECICE_OPENFOAM_PREP_FLAGS:-}"
+ADAPTER_CFLAGS="${PRECICE_OPENFOAM_CFLAGS:-}"
 
 # Build command and options
 # In order to compile with multiple threads, set the environment variable WM_NCOMPPROCS,
@@ -38,7 +38,7 @@ warning() {
 log "Building the OpenFOAM-preCICE adapter..."
 
 # Export the environment variables
-export ADAPTER_PREP_FLAGS
+export ADAPTER_CFLAGS
 export ADAPTER_TARGET_DIR
 
 # Check if pkg-config is available and get the config for preCICE
@@ -90,7 +90,7 @@ fi
 
 log ""
 log "The adapter will be built into ${ADAPTER_TARGET_DIR}"
-log "Additional preprocessor/compiler options: ${ADAPTER_PREP_FLAGS}"
+log "Additional preprocessor/compiler options: ${ADAPTER_CFLAGS}"
 
 # Run wmake (build the adapter) and check the exit code
 log ""

--- a/Allwmake
+++ b/Allwmake
@@ -17,7 +17,7 @@ adapter_build_command(){
 }
 
 # Where should the adapter be built? Default: "${FOAM_USER_LIBBIN}"
-ADAPTER_TARGET_DIR="${FOAM_USER_LIBBIN:-}"
+ADAPTER_TARGET_DIR="${ADAPTER_TARGET_DIR:-$FOAM_USER_LIBBIN}"
 
 # More information for compatibility with OpenFOAM
 DOC_COMPATIBILITY="https://precice.org/adapter-openfoam-support.html"

--- a/Make/options
+++ b/Make/options
@@ -14,7 +14,7 @@ EXE_INC = \
     -I$(LIB_SRC)/triSurface/lnInclude \
     $(ADAPTER_PKG_CONFIG_CFLAGS) \
     -I../ \
-    $(ADAPTER_PREP_FLAGS)
+    $(ADAPTER_CFLAGS)
 
 LIB_LIBS = \
     -lfiniteVolume \

--- a/changelog-entries/352.md
+++ b/changelog-entries/352.md
@@ -1,1 +1,2 @@
-- Fixes procedure for installation of adapter at custom path. [#352](https://github.com/precice/openfoam-adapter/pull/352)
+- Renamed `ADAPTER_PREP_FLAGS` to `ADAPTER_CFLAGS` and set it from `PRECICE_OPENFOAM_CFLAGS`. [#352](https://github.com/precice/openfoam-adapter/pull/352)
+- Set `ADAPTER_TARGET_DIT` from `PRECICE_OPENFOAM_TARGET_DIR`. [#352](https://github.com/precice/openfoam-adapter/pull/352)

--- a/changelog-entries/352.md
+++ b/changelog-entries/352.md
@@ -1,0 +1,1 @@
+- Fixes procedure for installation of adapter at custom path. [#352](https://github.com/precice/openfoam-adapter/pull/352)

--- a/docs/get.md
+++ b/docs/get.md
@@ -17,6 +17,8 @@ To build the adapter, you need to install a few dependencies and then execute th
 
 The adapter also requires [pkg-config](https://linux.die.net/man/1/pkg-config) to [link to preCICE](https://precice.org/installation-linking.html). This is a very common dependency on Linux and is usually already installed.
 
+By default, the adapter will be installed under `FOAM_USER_LIBBIN`. If you want to use a different location please set `ADAPTER_TARGET_DIR` before running `./Allwmake`. You can, for example, use `export ADAPTER_TARGET_DIR=$FOAM_LIBBIN` to install the adapter system-wide (requires `sudo`).
+
 You can set compile flags by either changing the `ADAPTER_PREP_FLAGS` variable in the `Allwmake` script, or directly setting the value of `ADAPTER_PREP_FLAGS`  as an environment variable.
 To do so, `export ADAPTER_PREP_FLAGS="-D<desired> -D<options>"` before compiling the adapter.
 

--- a/docs/get.md
+++ b/docs/get.md
@@ -20,7 +20,7 @@ The adapter also requires [pkg-config](https://linux.die.net/man/1/pkg-config) t
 The `Allwmake` script uses two environment variables:
 
 * `PRECICE_OPENFOAM_TARGET_DIR`: Where the `libpreciceAdapterFunctionObject.so` will be installed. Defaults to `FOAM_USER_LIBBIN`.
-* `PRECICE_OPENFOAM_PREP_FLAGS`: Additional flags passed to wmake and used by the preprocessor/compiler. Defaults to an empty string.
+* `PRECICE_OPENFOAM_CFLAGS`: Additional flags passed to wmake and used by the preprocessor/compiler. Defaults to an empty string.
   * Adding `-DADAPTER_DEBUG_MODE` flag activates additional debug messages.
   * Adding the `-DADAPTER_ENABLE_TIMINGS` flag  activates time measurements for several regions of the adapter, printed at the end of the simulation output.
 

--- a/docs/get.md
+++ b/docs/get.md
@@ -17,14 +17,12 @@ To build the adapter, you need to install a few dependencies and then execute th
 
 The adapter also requires [pkg-config](https://linux.die.net/man/1/pkg-config) to [link to preCICE](https://precice.org/installation-linking.html). This is a very common dependency on Linux and is usually already installed.
 
-By default, the adapter will be installed under `FOAM_USER_LIBBIN`. If you want to use a different location please set `ADAPTER_TARGET_DIR` before running `./Allwmake`. You can, for example, use `export ADAPTER_TARGET_DIR=$FOAM_LIBBIN` to install the adapter system-wide (requires `sudo`).
+The `Allwmake` script uses two environment variables:
 
-You can set compile flags by either changing the `ADAPTER_PREP_FLAGS` variable in the `Allwmake` script, or directly setting the value of `ADAPTER_PREP_FLAGS`  as an environment variable.
-To do so, `export ADAPTER_PREP_FLAGS="-D<desired> -D<options>"` before compiling the adapter.
-
-Adding the `-DADAPTER_DEBUG_MODE` flag to the `ADAPTER_PREP_FLAGS` activates additional debug messages. You may also change the target directory or specify the number of threads to use for the compilation. See the comments in `Allwmake` for more.
-
-Adding the `-DADAPTER_ENABLE_TIMINGS` flag to the `ADAPTER_PREP_FLAGS` activates time measurements for several regions of the adapter, printed at the end of the simulation output (available since v1.2.0).
+* `PRECICE_OPENFOAM_TARGET_DIR`: Where the `libpreciceAdapterFunctionObject.so` will be installed. Defaults to `FOAM_USER_LIBBIN`.
+* `PRECICE_OPENFOAM_PREP_FLAGS`: Additional flags passed to wmake and used by the preprocessor/compiler. Defaults to an empty string.
+  * Adding `-DADAPTER_DEBUG_MODE` flag activates additional debug messages.
+  * Adding the `-DADAPTER_ENABLE_TIMINGS` flag  activates time measurements for several regions of the adapter, printed at the end of the simulation output.
 
 If you are building the adapter often, you may want to build it in parallel. You can set the environment variable `WM_NCOMPPROCS` to the number of parallel threads you want WMake to use.
 


### PR DESCRIPTION
## Changes

* Will use value of `ADAPTER_TARGET_DIR` if set
* Will use `FOAM_USER_LIBBIN` as `ADAPTER_TARGET_DIR` if `ADAPTER_TARGET_DIR` is unset

## Motivation

I tried to install the adapter as root user under `FOAM_LIBBIN` and this did not work (some docker environment). As a workaround I'm currently temporarily overwriting `FOAM_USER_LIBBIN` with `FOAM_LIBBIN`.

<!-- Thank you for your contribution! Have a look at the file `CONTRIBUTING.md` for a few hints and guidelines. -->

TODO list:

- [x] I updated the documentation in `docs/`
- [x] I added a changelog entry in `changelog-entries/` (create directory if missing)
