### PR TITLE
Add missing headers in Interface.C

### DIFF
--- a/Interface.C
+++ b/Interface.C
@@ -1,3 +1,6 @@
+#include <map>
+#include <tuple>
+
 #include "Interface.H"
 #include "Utilities.H"
 #include "faceTriangulation.H"


### PR DESCRIPTION
In `Interface.C`, we use an `std::map` and an `std::tuple`. We should normally include the respective headers in the same file, but these were already included by some other file in the default OpenFOAM version.

Trying to port to other versions, I realized that this is not the case for every version.

I looked at the codebase, and it looks like we don't have similar issues elsewhere, if we ignore the `<string>` and `<vector>`, that are used everywhere and are rather expected.

Merging without a peer review, as this is trivial and I need it to continue further work.