### PR TITLE
Add missing overrides

### DIFF
--- a/CHT/SinkTemperature.H
+++ b/CHT/SinkTemperature.H
@@ -26,10 +26,10 @@ public:
         const std::string nameT);
 
     //- Write the sink temperature values into the buffer
-    std::size_t write(double* buffer, bool meshConnectivity, const unsigned int dim);
+    std::size_t write(double* buffer, bool meshConnectivity, const unsigned int dim) final;
 
     //- Read the sink temperature values from the buffer
-    void read(double* buffer, const unsigned int dim);
+    void read(double* buffer, const unsigned int dim) final;
 
     bool isLocationTypeSupported(const bool meshConnectivity) const final;
 

--- a/CHT/Temperature.H
+++ b/CHT/Temperature.H
@@ -27,10 +27,10 @@ public:
         const std::string nameT);
 
     //- Write the temperature values into the buffer
-    std::size_t write(double* buffer, bool meshConnectivity, const unsigned int dim);
+    std::size_t write(double* buffer, bool meshConnectivity, const unsigned int dim) final;
 
     //- Read the temperature values from the buffer
-    void read(double* buffer, const unsigned int dim);
+    void read(double* buffer, const unsigned int dim) final;
 
     bool isLocationTypeSupported(const bool meshConnectivity) const final;
 

--- a/FF/Alpha.H
+++ b/FF/Alpha.H
@@ -26,15 +26,15 @@ public:
         const std::string nameAlpha);
 
     //- Write the Alpha values into the buffer
-    std::size_t write(double* buffer, bool meshConnectivity, const unsigned int dim);
+    std::size_t write(double* buffer, bool meshConnectivity, const unsigned int dim) final;
 
     //- Read the Alpha values from the buffer
-    void read(double* buffer, const unsigned int dim);
+    void read(double* buffer, const unsigned int dim) final;
 
-    bool isLocationTypeSupported(const bool meshConnectivity) const override;
+    bool isLocationTypeSupported(const bool meshConnectivity) const final;
 
     //- Get the name of the current data field
-    std::string getDataName() const override;
+    std::string getDataName() const final;
 };
 
 }

--- a/FF/AlphaGradient.H
+++ b/FF/AlphaGradient.H
@@ -25,15 +25,15 @@ public:
         const std::string nameAlpha);
 
     //- Write the Alpha gradient values into the buffer
-    std::size_t write(double* buffer, bool meshConnectivity, const unsigned int dim);
+    std::size_t write(double* buffer, bool meshConnectivity, const unsigned int dim) final;
 
     //- Read the Alpha gradient values from the buffer
-    void read(double* buffer, const unsigned int dim);
+    void read(double* buffer, const unsigned int dim) final;
 
-    bool isLocationTypeSupported(const bool meshConnectivity) const override;
+    bool isLocationTypeSupported(const bool meshConnectivity) const final;
 
     //- Get the name of the current data field
-    std::string getDataName() const override;
+    std::string getDataName() const final;
 };
 
 }

--- a/FF/Phi.H
+++ b/FF/Phi.H
@@ -25,15 +25,15 @@ public:
         const std::string namePhi);
 
     //- Write the Phi values into the buffer
-    std::size_t write(double* buffer, bool meshConnectivity, const unsigned int dim);
+    std::size_t write(double* buffer, bool meshConnectivity, const unsigned int dim) final;
 
     //- Read the Phi values from the buffer
-    void read(double* buffer, const unsigned int dim);
+    void read(double* buffer, const unsigned int dim) final;
 
-    bool isLocationTypeSupported(const bool meshConnectivity) const override;
+    bool isLocationTypeSupported(const bool meshConnectivity) const final;
 
     //- Get the name of the current data field
-    std::string getDataName() const override;
+    std::string getDataName() const final;
 };
 
 }

--- a/FF/Pressure.H
+++ b/FF/Pressure.H
@@ -26,10 +26,10 @@ public:
         const std::string nameP);
 
     //- Write the pressure values into the buffer
-    std::size_t write(double* buffer, bool meshConnectivity, const unsigned int dim);
+    std::size_t write(double* buffer, bool meshConnectivity, const unsigned int dim) final;
 
     //- Read the pressure values from the buffer
-    void read(double* buffer, const unsigned int dim);
+    void read(double* buffer, const unsigned int dim) final;
 
     bool isLocationTypeSupported(const bool meshConnectivity) const final;
 

--- a/FF/PressureGradient.H
+++ b/FF/PressureGradient.H
@@ -25,10 +25,10 @@ public:
         const std::string nameP);
 
     //- Write the pressure gradient values into the buffer
-    std::size_t write(double* buffer, bool meshConnectivity, const unsigned int dim);
+    std::size_t write(double* buffer, bool meshConnectivity, const unsigned int dim) override;
 
     //- Read the pressure gradient values from the buffer
-    void read(double* buffer, const unsigned int dim);
+    void read(double* buffer, const unsigned int dim) override;
 
     bool isLocationTypeSupported(const bool meshConnectivity) const final;
 

--- a/FF/Temperature.H
+++ b/FF/Temperature.H
@@ -25,10 +25,10 @@ public:
         const std::string nameT);
 
     //- Write the temperature values into the buffer
-    std::size_t write(double* buffer, bool meshConnectivity, const unsigned int dim);
+    std::size_t write(double* buffer, bool meshConnectivity, const unsigned int dim) override;
 
     //- Read the temperature values from the buffer
-    void read(double* buffer, const unsigned int dim);
+    void read(double* buffer, const unsigned int dim) override;
 
     bool isLocationTypeSupported(const bool meshConnectivity) const override;
 

--- a/FF/TemperatureGradient.H
+++ b/FF/TemperatureGradient.H
@@ -25,15 +25,15 @@ public:
         const std::string nameT);
 
     //- Write the Temperature gradient values into the buffer
-    std::size_t write(double* buffer, bool meshConnectivity, const unsigned int dim);
+    std::size_t write(double* buffer, bool meshConnectivity, const unsigned int dim) final;
 
     //- Read the Temperature gradient values from the buffer
-    void read(double* buffer, const unsigned int dim);
+    void read(double* buffer, const unsigned int dim) final;
 
-    bool isLocationTypeSupported(const bool meshConnectivity) const override;
+    bool isLocationTypeSupported(const bool meshConnectivity) const final;
 
     //- Get the name of the current data field
-    std::string getDataName() const override;
+    std::string getDataName() const final;
 };
 
 }

--- a/FF/Velocity.H
+++ b/FF/Velocity.H
@@ -32,10 +32,10 @@ public:
         bool fluxCorrection = false);
 
     //- Write the velocity values into the buffer
-    std::size_t write(double* buffer, bool meshConnectivity, const unsigned int dim);
+    std::size_t write(double* buffer, bool meshConnectivity, const unsigned int dim) final;
 
     //- Read the velocity values from the buffer
-    void read(double* buffer, const unsigned int dim);
+    void read(double* buffer, const unsigned int dim) final;
 
     bool isLocationTypeSupported(const bool meshConnectivity) const final;
 

--- a/FSI/DisplacementDelta.H
+++ b/FSI/DisplacementDelta.H
@@ -44,7 +44,7 @@ public:
     bool isLocationTypeSupported(const bool meshConnectivity) const final;
 
     //- Get the name of the current data field
-    std::string getDataName() const;
+    std::string getDataName() const final;
 
     //- We need to initialize the cell-based vector and the interpolation object
     // in case we want to use the faceCenter location for the coupling


### PR DESCRIPTION
Resolves compilation warnings such as:

```
In file included from FF/ModuleFF.C:2:
In file included from FF/FF.C:1:
In file included from FF/FF.H:8:
./FF/Temperature.H:28:17: warning: 'write' overrides a member function but is not marked 'override' [-Winconsistent-missing-override]
    std::size_t write(double* buffer, bool meshConnectivity, const unsigned int dim);
                ^
./CouplingDataUser.H:78:25: note: overridden virtual function is here
    virtual std::size_t write(double* dataBuffer, bool meshConnectivity, const unsigned int dim) = 0;
                        ^
```

This was observed with the Intel compiler (OneAPI 2023.2, RHEL 8, OpenFOAM v2406) and reported by a user in https://precice.discourse.group/t/failing-to-compile-the-openfoam-adapter-at-moduleff-o/2240/3

We already had `override` in some virtual functions, but not all (especially missing in the FF module, most probably because of the order things got merged back in the day). I also replaced some inconsistent `override` that should have been `final`.

I did not enable `-Wsuggest-override` for GCC, as this picks up excessively many similar issues from OpenFOAM itself, and it seems like it has been removed in later versions of GCC.

Skipping peer review as this is trivial/clear and I need it for further work.