### PR TITLE
Avoid ambiguous type conversion when accessing tmp<vectorField>

### DIFF
--- a/FF/BoundaryConditions/coupledPressure/coupledPressureFvPatchField.C
+++ b/FF/BoundaryConditions/coupledPressure/coupledPressureFvPatchField.C
@@ -99,7 +99,7 @@ void Foam::coupledPressureFvPatchField::updateCoeffs()
     const scalarField& phip = phi->boundaryField()[this->patch().index()];
     const Foam::volVectorField* U = &db().lookupObject<volVectorField>(uName_);
     const vectorField& Up = U->boundaryField()[this->patch().index()];
-    const vectorField n = this->patch().nf();
+    const vectorField n = this->patch().nf().cref();
 
     int t0 = this->patch().boundaryMesh().mesh().time().startTimeIndex();
     int t = this->patch().boundaryMesh().mesh().time().timeIndex();

--- a/FF/BoundaryConditions/coupledVelocity/coupledVelocityFvPatchField.C
+++ b/FF/BoundaryConditions/coupledVelocity/coupledVelocityFvPatchField.C
@@ -95,7 +95,7 @@ void Foam::coupledVelocityFvPatchField::updateCoeffs()
     }
     const Foam::surfaceScalarField* phi = &db().lookupObject<surfaceScalarField>(phiName_);
     const scalarField& phip = phi->boundaryField()[this->patch().index()];
-    const vectorField n = this->patch().nf();
+    const vectorField n = this->patch().nf().cref();
 
     int t0 = this->patch().boundaryMesh().mesh().time().startTimeIndex();
     int t = this->patch().boundaryMesh().mesh().time().timeIndex();

--- a/FF/Velocity.C
+++ b/FF/Velocity.C
@@ -92,7 +92,7 @@ std::size_t preciceAdapter::FF::Velocity::write(double* buffer, bool meshConnect
         if (fluxCorrection_)
         {
             scalarField phip = phi_->boundaryFieldRef()[patchID];
-            vectorField n = U_->boundaryField()[patchID].patch().nf();
+            const vectorField n = U_->boundaryField()[patchID].patch().nf().cref();
             const scalarField& magS = U_->boundaryFieldRef()[patchID].patch().magSf();
             UPatch = UPatch - n * (n & U_->boundaryField()[patchID]) + n * phip / magS;
         }

--- a/changelog-entries/358.md
+++ b/changelog-entries/358.md
@@ -1,0 +1,1 @@
+- Fixed an issue preventing compiling the adapter with the Intel compiler [#358](https://github.com/precice/openfoam-adapter/pull/358).


### PR DESCRIPTION
Reported by a user using the Intel compiler (OneAPI 2023.2, RHEL 8, OpenFOAM v2406) in the [forum](https://precice.discourse.group/t/failing-to-compile-the-openfoam-adapter-at-moduleff-o/2240/3).

Resolves errors such as:

```
In file included from FF/ModuleFF.C:3:
FF/Velocity.C:95:25: error: conversion from 'tmp<vectorField>' (aka 'tmp<Field<Vector<double>>>') to 'vectorField' (aka 'Field<Vector<double>>') is ambiguous
            vectorField n = U_->boundaryField()[patchID].patch().nf();
                        ^   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/leonardo/prod/spack/05/install/0.21/linux-rhel8-icelake/oneapi-2023.2.0/openfoam-2406-psbdrns5bo35czf4hemtwyre65rfdf32/src/OpenFOAM/lnInclude/tmp.H:320:9: note: candidate function
        operator const T&() const { return cref(); }
        ^
/leonardo/prod/spack/05/install/0.21/linux-rhel8-icelake/oneapi-2023.2.0/openfoam-2406-psbdrns5bo35czf4hemtwyre65rfdf32/src/OpenFOAM/lnInclude/Field.H:266:16: note: candidate constructor
        inline Field(const tmp<Field<Type>>& tfld);
               ^
```