### PR TITLE
System tests workflow: Pass PR number and add job summary

### DIFF
--- a/.github/workflows/system-tests.yaml
+++ b/.github/workflows/system-tests.yaml
@@ -24,6 +24,6 @@ jobs:
     uses: precice/tutorials/.github/workflows/run_testsuite_workflow.yml@develop
     with:
       suites: openfoam_adapter_pr
-      build_args: TUTORIALS_REF:${{ needs.gather-refs.outputs.reftutorials }},PRECICE_REF:v3.1.1,OPENFOAM_EXECUTABLE:openfoam2312,OPENFOAM_ADAPTER_REF:${{ github.event.pull_request.head.sha }}
-      system_tests_branch: develop
+      build_args: TUTORIALS_REF:${{ needs.gather-refs.outputs.reftutorials }},PRECICE_REF:v3.1.1,OPENFOAM_EXECUTABLE:openfoam2312,OPENFOAM_ADAPTER_PR:${{ github.event.number }},OPENFOAM_ADAPTER_REF:${{ github.event.pull_request.head.sha }}
+      system_tests_branch: test-forks
       log_level: "DEBUG"

--- a/.github/workflows/system-tests.yaml
+++ b/.github/workflows/system-tests.yaml
@@ -41,5 +41,5 @@ jobs:
     with:
       suites: openfoam_adapter_pr
       build_args: TUTORIALS_REF:${{ needs.gather-refs.outputs.ref-tutorials }},PRECICE_REF:v3.1.1,OPENFOAM_EXECUTABLE:openfoam2312,OPENFOAM_ADAPTER_PR:${{ github.event.number }},OPENFOAM_ADAPTER_REF:${{ github.event.pull_request.head.sha }}
-      system_tests_branch: test-forks
+      system_tests_branch: develop
       log_level: "DEBUG"

--- a/.github/workflows/system-tests.yaml
+++ b/.github/workflows/system-tests.yaml
@@ -9,14 +9,30 @@ jobs:
     if: ${{ github.event.label.name == 'trigger-system-tests' }}
     runs-on: ubuntu-latest
     outputs:
-      reftutorials: ${{ steps.reftutorials.outputs.shorthash }}
+      ref-tutorials: ${{ steps.ref-tutorials.outputs.shorthash }}
     steps:
-      - id: reftutorials
+      - id: ref-tutorials
         uses: nmbgeek/github-action-get-latest-commit@main
         with:
           owner: precice
           repo: tutorials
           branch: develop
+      - id: report-refs
+        name: Report Git refs
+        run: |
+          printf 'Tutorials: ${{ steps.ref-tutorials.outputs.shorthash }}\n ${{ steps.ref-tutorials.outputs.description }}\n----------\n'
+      - id: summary
+        name: Prepare Markdown summary
+        run: |
+          echo "### OpenFOAM adapter" >> $GITHUB_STEP_SUMMARY
+          echo "Reference (pull request): \`${{ github.event.pull_request.head.sha }}\`" >> $GITHUB_STEP_SUMMARY
+          echo "Pull request number: [${{ github.event.number }}](https://github.com/precice/openfoam-adapter/pull/${{ github.event.number }})" >> $GITHUB_STEP_SUMMARY
+          echo "### Tutorials" >> $GITHUB_STEP_SUMMARY
+          echo "Reference (develop): [\`${{ steps.ref-tutorials.outputs.shorthash }}\`](https://github.com/precice/tutorials/commit/${{ steps.ref-tutorials.outputs.shorthash }})" >> $GITHUB_STEP_SUMMARY
+          echo "Description:" >> $GITHUB_STEP_SUMMARY
+          echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
+          echo "${{ steps.ref-openfoam-adapter.outputs.description }}" >> $GITHUB_STEP_SUMMARY
+          echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
 
   run-system-tests:
     if: ${{ github.event.label.name == 'trigger-system-tests' }}
@@ -24,6 +40,6 @@ jobs:
     uses: precice/tutorials/.github/workflows/run_testsuite_workflow.yml@develop
     with:
       suites: openfoam_adapter_pr
-      build_args: TUTORIALS_REF:${{ needs.gather-refs.outputs.reftutorials }},PRECICE_REF:v3.1.1,OPENFOAM_EXECUTABLE:openfoam2312,OPENFOAM_ADAPTER_PR:${{ github.event.number }},OPENFOAM_ADAPTER_REF:${{ github.event.pull_request.head.sha }}
+      build_args: TUTORIALS_REF:${{ needs.gather-refs.outputs.ref-tutorials }},PRECICE_REF:v3.1.1,OPENFOAM_EXECUTABLE:openfoam2312,OPENFOAM_ADAPTER_PR:${{ github.event.number }},OPENFOAM_ADAPTER_REF:${{ github.event.pull_request.head.sha }}
       system_tests_branch: test-forks
       log_level: "DEBUG"

--- a/.github/workflows/system-tests.yaml
+++ b/.github/workflows/system-tests.yaml
@@ -31,7 +31,7 @@ jobs:
           echo "Reference (develop): [\`${{ steps.ref-tutorials.outputs.shorthash }}\`](https://github.com/precice/tutorials/commit/${{ steps.ref-tutorials.outputs.shorthash }})" >> $GITHUB_STEP_SUMMARY
           echo "Description:" >> $GITHUB_STEP_SUMMARY
           echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
-          echo "${{ steps.ref-openfoam-adapter.outputs.description }}" >> $GITHUB_STEP_SUMMARY
+          echo "${{ steps.ref-tutorials.outputs.description }}" >> $GITHUB_STEP_SUMMARY
           echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
 
   run-system-tests:


### PR DESCRIPTION
Extends the system tests workflow to pass the PR number, enabling the tests to run on forks as well.

Depends on https://github.com/precice/tutorials/pull/638 to be merged to the tutorials/develop.