### PR TITLE
Simplify error handling (remove error-deferred workaround)

### DIFF
--- a/Adapter.C
+++ b/Adapter.C
@@ -230,20 +230,7 @@ bool preciceAdapter::Adapter::configFileRead()
 void preciceAdapter::Adapter::configure()
 {
     // Read the adapter's configuration file
-    if (!configFileRead())
-    {
-        // This method is called from the functionObject's read() method,
-        // which is called by the Foam::functionObjectList::read() method.
-        // All the exceptions triggered in this method are caught as
-        // warnings and the simulation continues simply without the
-        // functionObject. However, we want the simulation to exit with an
-        // error in case something is wrong. We store the information that
-        // there was an error and it will be handled by the first call to
-        // the functionObject's execute(), which can throw errors normally.
-        errorsInConfigure = true;
-
-        return;
-    }
+    configFileRead();
 
     // Check the timestep type (fixed vs adjustable)
     DEBUG(adapterInfo("Checking the timestep type (fixed vs adjustable)..."));

--- a/Adapter.C
+++ b/Adapter.C
@@ -16,215 +16,210 @@ preciceAdapter::Adapter::Adapter(const Time& runTime, const fvMesh& mesh)
     return;
 }
 
-bool preciceAdapter::Adapter::configFileRead()
+void preciceAdapter::Adapter::configFileRead()
 {
 
-    // We need a try-catch here, as if reading preciceDict fails,
-    // the respective exception will be reduced to a warning.
-    // See also comment in preciceAdapter::Adapter::configure().
-    try
+    SETUP_TIMER();
+    adapterInfo("Reading preciceDict...", "info");
+
+    // TODO: static is just a quick workaround to be able
+    // to find the dictionary also out of scope (e.g. in KappaEffective).
+    // We need a better solution.
+    static IOdictionary preciceDict(
+        IOobject(
+            "preciceDict",
+            runTime_.system(),
+            mesh_,
+            IOobject::MUST_READ_IF_MODIFIED,
+            IOobject::NO_WRITE));
+
+    // Read and display the preCICE configuration file name
+    preciceConfigFilename_ = preciceDict.get<fileName>("preciceConfig");
+    DEBUG(adapterInfo("  precice-config-file : " + preciceConfigFilename_));
+
+    // Read and display the participant name
+    participantName_ = preciceDict.get<word>("participant");
+    DEBUG(adapterInfo("  participant name    : " + participantName_));
+
+    // Read and display the list of modules
+    DEBUG(adapterInfo("  modules requested   : "));
+    auto modules_ = preciceDict.get<wordList>("modules");
+    for (const auto& module : modules_)
     {
-        SETUP_TIMER();
-        adapterInfo("Reading preciceDict...", "info");
+        DEBUG(adapterInfo("  - " + module + "\n"));
 
-        // TODO: static is just a quick workaround to be able
-        // to find the dictionary also out of scope (e.g. in KappaEffective).
-        // We need a better solution.
-        static IOdictionary preciceDict(
-            IOobject(
-                "preciceDict",
-                runTime_.system(),
-                mesh_,
-                IOobject::MUST_READ_IF_MODIFIED,
-                IOobject::NO_WRITE));
-
-        // Read and display the preCICE configuration file name
-        preciceConfigFilename_ = preciceDict.get<fileName>("preciceConfig");
-        DEBUG(adapterInfo("  precice-config-file : " + preciceConfigFilename_));
-
-        // Read and display the participant name
-        participantName_ = preciceDict.get<word>("participant");
-        DEBUG(adapterInfo("  participant name    : " + participantName_));
-
-        // Read and display the list of modules
-        DEBUG(adapterInfo("  modules requested   : "));
-        auto modules_ = preciceDict.get<wordList>("modules");
-        for (const auto& module : modules_)
+        // Set the modules switches
+        if (module == "CHT")
         {
-            DEBUG(adapterInfo("  - " + module + "\n"));
-
-            // Set the modules switches
-            if (module == "CHT")
-            {
-                CHTenabled_ = true;
-            }
-
-            if (module == "FSI")
-            {
-                FSIenabled_ = true;
-            }
-
-            if (module == "FF")
-            {
-                FFenabled_ = true;
-            }
+            CHTenabled_ = true;
         }
 
-        // Every interface is a subdictionary of "interfaces",
-        // each with an arbitrary name. Read all of them and create
-        // a list (here: pointer) of dictionaries.
-        const auto* interfaceDictPtr = preciceDict.findDict("interfaces");
-        DEBUG(adapterInfo("  interfaces : "));
-
-        // Check if we found any interfaces
-        // and get the details of each interface
-        if (!interfaceDictPtr)
+        if (module == "FSI")
         {
-            adapterInfo("  Empty list of interfaces", "warning");
-            return false;
-        }
-        else
-        {
-            for (const entry& interfaceDictEntry : *interfaceDictPtr)
-            {
-                if (interfaceDictEntry.isDict())
-                {
-                    const dictionary& interfaceDict = interfaceDictEntry.dict();
-                    struct InterfaceConfig interfaceConfig;
-
-                    interfaceConfig.meshName = interfaceDict.get<word>("mesh");
-                    DEBUG(adapterInfo("  - mesh         : " + interfaceConfig.meshName));
-
-                    // By default, assume "faceCenters" as locationsType
-                    interfaceConfig.locationsType = interfaceDict.lookupOrDefault<word>("locations", "faceCenters");
-                    DEBUG(adapterInfo("    locations    : " + interfaceConfig.locationsType));
-
-                    // By default, assume that no mesh connectivity is required (i.e. no nearest-projection mapping)
-                    interfaceConfig.meshConnectivity = interfaceDict.lookupOrDefault<bool>("connectivity", false);
-                    // Mesh connectivity only makes sense in case of faceNodes, check and raise a warning otherwise
-                    if (interfaceConfig.meshConnectivity && (interfaceConfig.locationsType == "faceCenters" || interfaceConfig.locationsType == "volumeCenters" || interfaceConfig.locationsType == "volumeCentres"))
-                    {
-                        DEBUG(adapterInfo("Mesh connectivity is not supported for faceCenters or volumeCenters. \n"
-                                          "Please configure the desired interface with the locationsType faceNodes. \n"
-                                          "Have a look in the adapter documentation for detailed information.",
-                                          "warning"));
-                        return false;
-                    }
-                    DEBUG(adapterInfo("    connectivity : " + std::to_string(interfaceConfig.meshConnectivity)));
-
-                    DEBUG(adapterInfo("    patches      : "));
-                    auto patches = interfaceDict.get<wordList>("patches");
-                    for (auto patch : patches)
-                    {
-                        interfaceConfig.patchNames.push_back(patch);
-                        DEBUG(adapterInfo("      - " + patch));
-                    }
-
-                    DEBUG(adapterInfo("    cellSets      : "));
-                    auto cellSets = interfaceDict.lookupOrDefault<wordList>("cellSets", wordList());
-
-                    for (auto cellSet : cellSets)
-                    {
-                        interfaceConfig.cellSetNames.push_back(cellSet);
-                        DEBUG(adapterInfo("      - " + cellSet));
-                    }
-
-                    if (!interfaceConfig.cellSetNames.empty() && !(interfaceConfig.locationsType == "volumeCenters" || interfaceConfig.locationsType == "volumeCentres"))
-                    {
-                        adapterInfo("Cell sets are not supported for locationType != volumeCenters. \n"
-                                    "Please configure the desired interface with the locationsType volumeCenters. \n"
-                                    "Have a look in the adapter documentation for detailed information.",
-                                    "warning");
-                        return false;
-                    }
-
-                    DEBUG(adapterInfo("    writeData    : "));
-                    auto writeData = interfaceDict.lookupOrDefault<wordList>("writeData", wordList());
-                    for (auto writeDatum : writeData)
-                    {
-                        interfaceConfig.writeData.push_back(writeDatum);
-                        DEBUG(adapterInfo("      - " + writeDatum));
-                    }
-
-                    DEBUG(adapterInfo("    readData     : "));
-                    auto readData = interfaceDict.lookupOrDefault<wordList>("readData", wordList());
-                    for (auto readDatum : readData)
-                    {
-                        interfaceConfig.readData.push_back(readDatum);
-                        DEBUG(adapterInfo("      - " + readDatum));
-                    }
-                    interfacesConfig_.push_back(interfaceConfig);
-                }
-            }
+            FSIenabled_ = true;
         }
 
-        // NOTE: set the switch for your new module here
-
-        // If the CHT module is enabled, create it, read the
-        // CHT-specific options and configure it.
-        if (CHTenabled_)
+        if (module == "FF")
         {
-            CHT_ = new CHT::ConjugateHeatTransfer(mesh_);
-            if (!CHT_->configure(preciceDict))
-            {
-                return false;
-            }
+            FFenabled_ = true;
         }
-
-        // If the FSI module is enabled, create it, read the
-        // FSI-specific options and configure it.
-        if (FSIenabled_)
-        {
-            // Check for unsupported FSI with meshConnectivity
-            for (uint i = 0; i < interfacesConfig_.size(); i++)
-            {
-                if (interfacesConfig_.at(i).meshConnectivity == true)
-                {
-                    adapterInfo(
-                        "You have requested mesh connectivity (most probably for nearest-projection mapping) "
-                        "and you have enabled the FSI module. "
-                        "Mapping with connectivity information is not implemented for FSI, only for CHT-related fields. "
-                        "warning");
-                    return false;
-                }
-            }
-
-            FSI_ = new FSI::FluidStructureInteraction(mesh_, runTime_);
-            if (!FSI_->configure(preciceDict))
-            {
-                return false;
-            }
-        }
-
-        if (FFenabled_)
-        {
-            FF_ = new FF::FluidFluid(mesh_);
-            if (!FF_->configure(preciceDict))
-            {
-                return false;
-            }
-        }
-
-        // NOTE: Create your module and read any options specific to it here
-
-        if (!CHTenabled_ && !FSIenabled_ && !FFenabled_) // NOTE: Add your new switch here
-        {
-            adapterInfo("No module is enabled.", "error");
-            return false;
-        }
-
-        // TODO: Loading modules should be implemented in more general way,
-        // in order to avoid code duplication. See issue #16 on GitHub.
-
-        ACCUMULATE_TIMER(timeInConfigRead_);
-    }
-    catch (const Foam::error& e)
-    {
-        adapterInfo(e.message(), "error");
-        return false;
     }
 
-    return true;
+    // Every interface is a subdictionary of "interfaces",
+    // each with an arbitrary name. Read all of them and create
+    // a list (here: pointer) of dictionaries.
+    const auto* interfaceDictPtr = preciceDict.findDict("interfaces");
+    DEBUG(adapterInfo("  interfaces : "));
+
+    // Check if we found any interfaces
+    // and get the details of each interface
+    if (!interfaceDictPtr)
+    {
+        adapterInfo("  Empty list of interfaces", "error");
+        return;
+    }
+    else
+    {
+        for (const entry& interfaceDictEntry : *interfaceDictPtr)
+        {
+            if (interfaceDictEntry.isDict())
+            {
+                const dictionary& interfaceDict = interfaceDictEntry.dict();
+                struct InterfaceConfig interfaceConfig;
+
+                interfaceConfig.meshName = interfaceDict.get<word>("mesh");
+                DEBUG(adapterInfo("  - mesh         : " + interfaceConfig.meshName));
+
+                // By default, assume "faceCenters" as locationsType
+                interfaceConfig.locationsType = interfaceDict.lookupOrDefault<word>("locations", "faceCenters");
+                DEBUG(adapterInfo("    locations    : " + interfaceConfig.locationsType));
+
+                // By default, assume that no mesh connectivity is required (i.e. no nearest-projection mapping)
+                interfaceConfig.meshConnectivity = interfaceDict.lookupOrDefault<bool>("connectivity", false);
+                // Mesh connectivity only makes sense in case of faceNodes, check and raise a warning otherwise
+                if (interfaceConfig.meshConnectivity && (interfaceConfig.locationsType == "faceCenters" || interfaceConfig.locationsType == "volumeCenters" || interfaceConfig.locationsType == "volumeCentres"))
+                {
+                    DEBUG(adapterInfo("Mesh connectivity is not supported for faceCenters or volumeCenters. \n"
+                                      "Please configure the desired interface with the locationsType faceNodes. \n"
+                                      "Have a look in the adapter documentation for detailed information.",
+                                      "error"));
+                    return;
+                }
+                DEBUG(adapterInfo("    connectivity : " + std::to_string(interfaceConfig.meshConnectivity)));
+
+                DEBUG(adapterInfo("    patches      : "));
+                auto patches = interfaceDict.get<wordList>("patches");
+                for (auto patch : patches)
+                {
+                    interfaceConfig.patchNames.push_back(patch);
+                    DEBUG(adapterInfo("      - " + patch));
+                }
+
+                DEBUG(adapterInfo("    cellSets      : "));
+                auto cellSets = interfaceDict.lookupOrDefault<wordList>("cellSets", wordList());
+
+                for (auto cellSet : cellSets)
+                {
+                    interfaceConfig.cellSetNames.push_back(cellSet);
+                    DEBUG(adapterInfo("      - " + cellSet));
+                }
+
+                if (!interfaceConfig.cellSetNames.empty() && !(interfaceConfig.locationsType == "volumeCenters" || interfaceConfig.locationsType == "volumeCentres"))
+                {
+                    adapterInfo("Cell sets are not supported for locationType != volumeCenters. \n"
+                                "Please configure the desired interface with the locationsType volumeCenters. \n"
+                                "Have a look in the adapter documentation for detailed information.",
+                                "error");
+                    return;
+                }
+
+                DEBUG(adapterInfo("    writeData    : "));
+                auto writeData = interfaceDict.lookupOrDefault<wordList>("writeData", wordList());
+                for (auto writeDatum : writeData)
+                {
+                    interfaceConfig.writeData.push_back(writeDatum);
+                    DEBUG(adapterInfo("      - " + writeDatum));
+                }
+
+                DEBUG(adapterInfo("    readData     : "));
+                auto readData = interfaceDict.lookupOrDefault<wordList>("readData", wordList());
+                for (auto readDatum : readData)
+                {
+                    interfaceConfig.readData.push_back(readDatum);
+                    DEBUG(adapterInfo("      - " + readDatum));
+                }
+                interfacesConfig_.push_back(interfaceConfig);
+            }
+        }
+    }
+
+    // NOTE: set the switch for your new module here
+
+    // If the CHT module is enabled, create it, read the
+    // CHT-specific options and configure it.
+    if (CHTenabled_)
+    {
+        CHT_ = new CHT::ConjugateHeatTransfer(mesh_);
+        if (!CHT_->configure(preciceDict))
+        {
+            adapterInfo("There was an error while configuring the CHT module",
+                        "error");
+            return;
+        }
+    }
+
+    // If the FSI module is enabled, create it, read the
+    // FSI-specific options and configure it.
+    if (FSIenabled_)
+    {
+        // Check for unsupported FSI with meshConnectivity
+        for (uint i = 0; i < interfacesConfig_.size(); i++)
+        {
+            if (interfacesConfig_.at(i).meshConnectivity == true)
+            {
+                adapterInfo(
+                    "You have requested mesh connectivity (most probably for nearest-projection mapping) "
+                    "and you have enabled the FSI module. "
+                    "Mapping with connectivity information is not implemented for FSI, only for CHT-related fields. "
+                    "error");
+                return;
+            }
+        }
+
+        FSI_ = new FSI::FluidStructureInteraction(mesh_, runTime_);
+        if (!FSI_->configure(preciceDict))
+        {
+            adapterInfo("There was an error while configuring the FSI module",
+                        "error");
+            return;
+        }
+    }
+
+    if (FFenabled_)
+    {
+        FF_ = new FF::FluidFluid(mesh_);
+        if (!FF_->configure(preciceDict))
+        {
+            adapterInfo("There was an error while configuring the FF module",
+                        "error");
+            return;
+        }
+    }
+
+    // NOTE: Create your module and read any options specific to it here
+
+    if (!CHTenabled_ && !FSIenabled_ && !FFenabled_) // NOTE: Add your new switch here
+    {
+        adapterInfo("No module is enabled.", "error");
+        return;
+    }
+
+    // TODO: Loading modules should be implemented in more general way,
+    // in order to avoid code duplication. See issue #16 on GitHub.
+
+    ACCUMULATE_TIMER(timeInConfigRead_);
+
+    return;
 }
 
 void preciceAdapter::Adapter::configure()

--- a/Adapter.C
+++ b/Adapter.C
@@ -209,7 +209,7 @@ bool preciceAdapter::Adapter::configFileRead()
 
         if (!CHTenabled_ && !FSIenabled_ && !FFenabled_) // NOTE: Add your new switch here
         {
-            adapterInfo("No module is enabled.", "error-deferred");
+            adapterInfo("No module is enabled.", "error");
             return false;
         }
 
@@ -220,7 +220,7 @@ bool preciceAdapter::Adapter::configFileRead()
     }
     catch (const Foam::error& e)
     {
-        adapterInfo(e.message(), "error-deferred");
+        adapterInfo(e.message(), "error");
         return false;
     }
 
@@ -245,183 +245,166 @@ void preciceAdapter::Adapter::configure()
         return;
     }
 
-    try
+    // Check the timestep type (fixed vs adjustable)
+    DEBUG(adapterInfo("Checking the timestep type (fixed vs adjustable)..."));
+    adjustableTimestep_ = runTime_.controlDict().lookupOrDefault("adjustTimeStep", false);
+
+    if (adjustableTimestep_)
     {
-        // Check the timestep type (fixed vs adjustable)
-        DEBUG(adapterInfo("Checking the timestep type (fixed vs adjustable)..."));
-        adjustableTimestep_ = runTime_.controlDict().lookupOrDefault("adjustTimeStep", false);
-
-        if (adjustableTimestep_)
-        {
-            DEBUG(adapterInfo("  Timestep type: adjustable."));
-        }
-        else
-        {
-            DEBUG(adapterInfo("  Timestep type: fixed."));
-        }
-
-        // Construct preCICE
-        SETUP_TIMER();
-        DEBUG(adapterInfo("Creating the preCICE solver interface..."));
-        DEBUG(adapterInfo("  Number of processes: " + std::to_string(Pstream::nProcs())));
-        DEBUG(adapterInfo("  MPI rank: " + std::to_string(Pstream::myProcNo())));
-        precice_ = new precice::Participant(participantName_, preciceConfigFilename_, Pstream::myProcNo(), Pstream::nProcs());
-        DEBUG(adapterInfo("  preCICE solver interface was created."));
-
-        ACCUMULATE_TIMER(timeInPreciceConstruct_);
-
-        // Create interfaces
-        REUSE_TIMER();
-        DEBUG(adapterInfo("Creating interfaces..."));
-        for (uint i = 0; i < interfacesConfig_.size(); i++)
-        {
-            std::string namePointDisplacement = FSIenabled_ ? FSI_->getPointDisplacementFieldName() : "default";
-            std::string nameCellDisplacement = FSIenabled_ ? FSI_->getCellDisplacementFieldName() : "default";
-            bool restartFromDeformed = FSIenabled_ ? FSI_->isRestartingFromDeformed() : false;
-
-            Interface* interface = new Interface(*precice_, mesh_, interfacesConfig_.at(i).meshName, interfacesConfig_.at(i).locationsType, interfacesConfig_.at(i).patchNames, interfacesConfig_.at(i).cellSetNames, interfacesConfig_.at(i).meshConnectivity, restartFromDeformed, namePointDisplacement, nameCellDisplacement);
-            interfaces_.push_back(interface);
-            DEBUG(adapterInfo("Interface created on mesh " + interfacesConfig_.at(i).meshName));
-
-            DEBUG(adapterInfo("Adding coupling data writers..."));
-            for (uint j = 0; j < interfacesConfig_.at(i).writeData.size(); j++)
-            {
-                std::string dataName = interfacesConfig_.at(i).writeData.at(j);
-
-                unsigned int inModules = 0;
-
-                // Add CHT-related coupling data writers
-                if (CHTenabled_ && CHT_->addWriters(dataName, interface))
-                {
-                    inModules++;
-                }
-
-                // Add FSI-related coupling data writers
-                if (FSIenabled_ && FSI_->addWriters(dataName, interface))
-                {
-                    inModules++;
-                }
-
-                // Add FF-related coupling data writers
-                if (FFenabled_ && FF_->addWriters(dataName, interface))
-                {
-                    inModules++;
-                }
-
-                if (inModules == 0)
-                {
-                    adapterInfo("I don't know how to write \"" + dataName
-                                    + "\". Maybe this is a typo or maybe you need to enable some adapter module?",
-                                "error-deferred");
-                }
-                else if (inModules > 1)
-                {
-                    adapterInfo("It looks like more than one modules can write \"" + dataName
-                                    + "\" and I don't know how to choose. Try disabling one of the modules.",
-                                "error-deferred");
-                }
-
-                // NOTE: Add any coupling data writers for your module here.
-            } // end add coupling data writers
-
-            DEBUG(adapterInfo("Adding coupling data readers..."));
-            for (uint j = 0; j < interfacesConfig_.at(i).readData.size(); j++)
-            {
-                std::string dataName = interfacesConfig_.at(i).readData.at(j);
-
-                unsigned int inModules = 0;
-
-                // Add CHT-related coupling data readers
-                if (CHTenabled_ && CHT_->addReaders(dataName, interface)) inModules++;
-
-                // Add FSI-related coupling data readers
-                if (FSIenabled_ && FSI_->addReaders(dataName, interface)) inModules++;
-
-                // Add FF-related coupling data readers
-                if (FFenabled_ && FF_->addReaders(dataName, interface)) inModules++;
-
-                if (inModules == 0)
-                {
-                    adapterInfo("I don't know how to read \"" + dataName
-                                    + "\". Maybe this is a typo or maybe you need to enable some adapter module?",
-                                "error-deferred");
-                }
-                else if (inModules > 1)
-                {
-                    adapterInfo("It looks like more than one modules can read \"" + dataName
-                                    + "\" and I don't know how to choose. Try disabling one of the modules.",
-                                "error-deferred");
-                }
-
-                // NOTE: Add any coupling data readers for your module here.
-            } // end add coupling data readers
-
-            // Create the interface's data buffer
-            interface->createBuffer();
-        }
-        ACCUMULATE_TIMER(timeInMeshSetup_);
-
-        // Initialize preCICE and exchange the first coupling data
-        initialize();
-
-        // If checkpointing is required, specify the checkpointed fields
-        // and write the first checkpoint
-        if (requiresWritingCheckpoint())
-        {
-            checkpointing_ = true;
-
-            // Setup the checkpointing (find and add fields to checkpoint)
-            setupCheckpointing();
-
-            // Write checkpoint (for the first iteration)
-            writeCheckpoint();
-        }
-
-        // Adjust the timestep for the first iteration, if it is fixed
-        if (!adjustableTimestep_)
-        {
-            adjustSolverTimeStepAndReadData();
-        }
-
-        // If the solver tries to end before the coupling is complete,
-        // e.g. because the solver's endTime was smaller or (in implicit
-        // coupling) equal with the max-time specified in preCICE,
-        // problems may occur near the end of the simulation,
-        // as the function object may be called only once near the end.
-        // See the implementation of Foam::Time::run() for more details.
-        // To prevent this, we set the solver's endTime to "infinity"
-        // and let only preCICE control the end of the simulation.
-        // This has the side-effect of not triggering the end() method
-        // in any function object normally. Therefore, we trigger it
-        // when preCICE dictates to stop the coupling.
-        adapterInfo(
-            "Setting the solver's endTime to infinity to prevent early exits. "
-            "Only preCICE will control the simulation's endTime. "
-            "Any functionObject's end() method will be triggered by the adapter. "
-            "You may disable this behavior in the adapter's configuration.",
-            "info");
-        const_cast<Time&>(runTime_).setEndTime(GREAT);
+        DEBUG(adapterInfo("  Timestep type: adjustable."));
     }
-    catch (const Foam::error& e)
+    else
     {
-        adapterInfo(e.message(), "error-deferred");
-        errorsInConfigure = true;
+        DEBUG(adapterInfo("  Timestep type: fixed."));
     }
+
+    // Construct preCICE
+    SETUP_TIMER();
+    DEBUG(adapterInfo("Creating the preCICE solver interface..."));
+    DEBUG(adapterInfo("  Number of processes: " + std::to_string(Pstream::nProcs())));
+    DEBUG(adapterInfo("  MPI rank: " + std::to_string(Pstream::myProcNo())));
+    precice_ = new precice::Participant(participantName_, preciceConfigFilename_, Pstream::myProcNo(), Pstream::nProcs());
+    DEBUG(adapterInfo("  preCICE solver interface was created."));
+
+    ACCUMULATE_TIMER(timeInPreciceConstruct_);
+
+    // Create interfaces
+    REUSE_TIMER();
+    DEBUG(adapterInfo("Creating interfaces..."));
+    for (uint i = 0; i < interfacesConfig_.size(); i++)
+    {
+        std::string namePointDisplacement = FSIenabled_ ? FSI_->getPointDisplacementFieldName() : "default";
+        std::string nameCellDisplacement = FSIenabled_ ? FSI_->getCellDisplacementFieldName() : "default";
+        bool restartFromDeformed = FSIenabled_ ? FSI_->isRestartingFromDeformed() : false;
+
+        Interface* interface = new Interface(*precice_, mesh_, interfacesConfig_.at(i).meshName, interfacesConfig_.at(i).locationsType, interfacesConfig_.at(i).patchNames, interfacesConfig_.at(i).cellSetNames, interfacesConfig_.at(i).meshConnectivity, restartFromDeformed, namePointDisplacement, nameCellDisplacement);
+        interfaces_.push_back(interface);
+        DEBUG(adapterInfo("Interface created on mesh " + interfacesConfig_.at(i).meshName));
+
+        DEBUG(adapterInfo("Adding coupling data writers..."));
+        for (uint j = 0; j < interfacesConfig_.at(i).writeData.size(); j++)
+        {
+            std::string dataName = interfacesConfig_.at(i).writeData.at(j);
+
+            unsigned int inModules = 0;
+
+            // Add CHT-related coupling data writers
+            if (CHTenabled_ && CHT_->addWriters(dataName, interface))
+            {
+                inModules++;
+            }
+
+            // Add FSI-related coupling data writers
+            if (FSIenabled_ && FSI_->addWriters(dataName, interface))
+            {
+                inModules++;
+            }
+
+            // Add FF-related coupling data writers
+            if (FFenabled_ && FF_->addWriters(dataName, interface))
+            {
+                inModules++;
+            }
+
+            if (inModules == 0)
+            {
+                adapterInfo("I don't know how to write \"" + dataName
+                                + "\". Maybe this is a typo or maybe you need to enable some adapter module?",
+                            "error");
+            }
+            else if (inModules > 1)
+            {
+                adapterInfo("It looks like more than one modules can write \"" + dataName
+                                + "\" and I don't know how to choose. Try disabling one of the modules.",
+                            "error");
+            }
+
+            // NOTE: Add any coupling data writers for your module here.
+        } // end add coupling data writers
+
+        DEBUG(adapterInfo("Adding coupling data readers..."));
+        for (uint j = 0; j < interfacesConfig_.at(i).readData.size(); j++)
+        {
+            std::string dataName = interfacesConfig_.at(i).readData.at(j);
+
+            unsigned int inModules = 0;
+
+            // Add CHT-related coupling data readers
+            if (CHTenabled_ && CHT_->addReaders(dataName, interface)) inModules++;
+
+            // Add FSI-related coupling data readers
+            if (FSIenabled_ && FSI_->addReaders(dataName, interface)) inModules++;
+
+            // Add FF-related coupling data readers
+            if (FFenabled_ && FF_->addReaders(dataName, interface)) inModules++;
+
+            if (inModules == 0)
+            {
+                adapterInfo("I don't know how to read \"" + dataName
+                                + "\". Maybe this is a typo or maybe you need to enable some adapter module?",
+                            "error");
+            }
+            else if (inModules > 1)
+            {
+                adapterInfo("It looks like more than one modules can read \"" + dataName
+                                + "\" and I don't know how to choose. Try disabling one of the modules.",
+                            "error");
+            }
+
+            // NOTE: Add any coupling data readers for your module here.
+        } // end add coupling data readers
+
+        // Create the interface's data buffer
+        interface->createBuffer();
+    }
+    ACCUMULATE_TIMER(timeInMeshSetup_);
+
+    // Initialize preCICE and exchange the first coupling data
+    initialize();
+
+    // If checkpointing is required, specify the checkpointed fields
+    // and write the first checkpoint
+    if (requiresWritingCheckpoint())
+    {
+        checkpointing_ = true;
+
+        // Setup the checkpointing (find and add fields to checkpoint)
+        setupCheckpointing();
+
+        // Write checkpoint (for the first iteration)
+        writeCheckpoint();
+    }
+
+    // Adjust the timestep for the first iteration, if it is fixed
+    if (!adjustableTimestep_)
+    {
+        adjustSolverTimeStepAndReadData();
+    }
+
+    // If the solver tries to end before the coupling is complete,
+    // e.g. because the solver's endTime was smaller or (in implicit
+    // coupling) equal with the max-time specified in preCICE,
+    // problems may occur near the end of the simulation,
+    // as the function object may be called only once near the end.
+    // See the implementation of Foam::Time::run() for more details.
+    // To prevent this, we set the solver's endTime to "infinity"
+    // and let only preCICE control the end of the simulation.
+    // This has the side-effect of not triggering the end() method
+    // in any function object normally. Therefore, we trigger it
+    // when preCICE dictates to stop the coupling.
+    adapterInfo(
+        "Setting the solver's endTime to infinity to prevent early exits. "
+        "Only preCICE will control the simulation's endTime. "
+        "Any functionObject's end() method will be triggered by the adapter. "
+        "You may disable this behavior in the adapter's configuration.",
+        "info");
+    const_cast<Time&>(runTime_).setEndTime(GREAT);
 
     return;
 }
 
 void preciceAdapter::Adapter::execute()
 {
-    if (errorsInConfigure)
-    {
-        // Handle any errors during configure().
-        // See the comments in configure() for details.
-        adapterInfo(
-            "There was a problem while configuring the adapter. "
-            "See the log for details.",
-            "error");
-    }
 
     // The solver has already solved the equations for this timestep.
     // Now call the adapter's methods to perform the coupling.

--- a/Adapter.H
+++ b/Adapter.H
@@ -242,7 +242,7 @@ private:
     // Configuration
 
     //- Read the adapter's configuration file
-    bool configFileRead();
+    void configFileRead();
 
     //- Check the adapter's configuration file
     bool configFileCheck(const std::string adapterConfigFileName);

--- a/Adapter.H
+++ b/Adapter.H
@@ -73,9 +73,6 @@ private:
 
     // Configuration parameters used in the Adapter
 
-    //- Remember if there were errors in the read() method
-    bool errorsInConfigure = false;
-
     //- preCICE configuration file name
     Foam::word preciceConfigFilename_;
 

--- a/CHT/KappaEffective.C
+++ b/CHT/KappaEffective.C
@@ -126,12 +126,7 @@ void preciceAdapter::CHT::KappaEff_Incompressible::extract(uint patchID, bool me
     }
     else
     {
-        WarningInFunction
-            << "The object alphat does not exist. "
-            << "An incompressible solver should create it explicitly "
-            << "(e.g. in the createFields.H)."
-            << "Assuming only the laminar part of the thermal diffusivity."
-            << nl;
+        adapterInfo("The object alphat does not exist. An incompressible solver should create it explicitly (e.g. in the createFields.H). Assuming only the laminar part of the thermal diffusivity.", "warning");
 
         alphaEff = nu / Pr_.value();
     }

--- a/FF/BoundaryConditions/coupledPressure/coupledPressureFvPatchField.C
+++ b/FF/BoundaryConditions/coupledPressure/coupledPressureFvPatchField.C
@@ -50,7 +50,7 @@ Foam::coupledPressureFvPatchField::coupledPressureFvPatchField(
 {
     if (notNull(iF) && mapper.hasUnmapped())
     {
-        adapterInfo("On field " + iF.name() + " patch " + p.name() + " patchField " + this->type() + " : mapper does not map all values. To avoid this warning fully specify the mapping in derived patch fields.", "warning");
+        adapterInfo("On field " + iF.name() + " patch " + p.name() + " patchField " + this->type() + " : mapper does not map all values. To avoid this warning, fully specify the mapping in derived patch fields.", "warning");
     }
 }
 

--- a/FF/BoundaryConditions/coupledPressure/coupledPressureFvPatchField.C
+++ b/FF/BoundaryConditions/coupledPressure/coupledPressureFvPatchField.C
@@ -50,12 +50,7 @@ Foam::coupledPressureFvPatchField::coupledPressureFvPatchField(
 {
     if (notNull(iF) && mapper.hasUnmapped())
     {
-        WarningInFunction
-            << "On field " << iF.name() << " patch " << p.name()
-            << " patchField " << this->type()
-            << " : mapper does not map all values." << nl
-            << "    To avoid this warning fully specify the mapping in derived"
-            << " patch fields." << endl;
+        adapterInfo("On field " + iF.name() + " patch " + p.name() + " patchField " + this->type() + " : mapper does not map all values. To avoid this warning fully specify the mapping in derived patch fields.", "warning");
     }
 }
 

--- a/FSI/DisplacementDelta.C
+++ b/FSI/DisplacementDelta.C
@@ -41,9 +41,7 @@ std::size_t preciceAdapter::FSI::DisplacementDelta::write(double* buffer, bool m
      * the outer for the locations and the inner for the dimensions.
      * See the preCICE writeBlockVectorData() implementation.
      */
-    FatalErrorInFunction
-        << "Writing displacementDeltas is not supported."
-        << exit(FatalError);
+    adapterInfo("Writing displacementDelta is not supported.", "error");
     return 0;
 }
 

--- a/FSI/ForceBase.C
+++ b/FSI/ForceBase.C
@@ -14,10 +14,7 @@ preciceAdapter::FSI::ForceBase::ForceBase(
         && solverType_.compare("compressible") != 0
         && solverType_.compare("solid") != 0)
     {
-        FatalErrorInFunction
-            << "Force based calculations only support "
-            << "compressible, incompressible, or solid solver types."
-            << exit(FatalError);
+        adapterInfo("Force based calculations only support compressible, incompressible, or solid solver types.", "error");
     }
 
     dataType_ = vector;
@@ -82,9 +79,7 @@ Foam::tmp<Foam::volScalarField> preciceAdapter::FSI::ForceBase::rho() const
     }
     else
     {
-        FatalErrorInFunction
-            << "Did not find the correct rho."
-            << exit(FatalError);
+        adapterInfo("Something went wrong while looking for a rho object for the force calculation.", "error");
 
         return volScalarField::null();
     }
@@ -122,9 +117,7 @@ Foam::tmp<Foam::volScalarField> preciceAdapter::FSI::ForceBase::mu() const
     }
     else
     {
-        FatalErrorInFunction
-            << "Did not find the correct mu."
-            << exit(FatalError);
+        adapterInfo("Something went wrong while looking for a mu object for the force calculation.", "error");
 
         return volScalarField::null();
     }
@@ -169,10 +162,7 @@ std::size_t preciceAdapter::FSI::ForceBase::writeToBuffer(double* buffer,
         }
         else
         {
-            FatalErrorInFunction
-                << "Forces calculation does only support "
-                << "compressible or incompressible solver type."
-                << exit(FatalError);
+            adapterInfo("Calculating forces is only supported for solverType compressible or incompressible.", "error");
         }
 
         // Viscous forces
@@ -198,7 +188,5 @@ void preciceAdapter::FSI::ForceBase::readFromBuffer(double* buffer) const
      * the outer for the locations and the inner for the dimensions.
      * See the preCICE readBlockVectorData() implementation.
      */
-    FatalErrorInFunction
-        << "Reading forces is not supported."
-        << exit(FatalError);
+    adapterInfo("Reading forces is not supported.", "error");
 }

--- a/Interface.C
+++ b/Interface.C
@@ -67,11 +67,10 @@ preciceAdapter::Interface::Interface(
         // Throw an error if the patch was not found
         if (patchID == -1)
         {
-            FatalErrorInFunction
-                << "ERROR: Patch '"
-                << patchNames.at(j)
-                << "' does not exist."
-                << exit(FatalError);
+            adapterInfo("Patch \""
+                            + patchNames.at(j) + "\" does not exist and therefore cannot be used as a coupling interface for mesh \""
+                            + meshName + "\". Check the system/preciceDict.",
+                        "error");
         }
 
         // Add the patch in the list

--- a/Utilities.C
+++ b/Utilities.C
@@ -29,7 +29,7 @@ void adapterInfo(const std::string message, const std::string level)
         // and exit the functionObject.
         // It will also exit the simulation, unless it
         // is called inside the functionObject's read().
-        FatalErrorInFunction
+        FatalError
             << "\033[31m" // red color
             << "Error in the preCICE adapter: "
             << "\033[0m" // restore color
@@ -37,24 +37,6 @@ void adapterInfo(const std::string message, const std::string level)
             << message.c_str()
             << nl
             << exit(FatalError);
-    }
-    else if (level.compare("error-deferred") == 0)
-    {
-        // Produce an warning message with red header.
-        // OpenFOAM degrades errors inside read()
-        // to warnings, stops the function object, but does
-        // not exit. We throw a warning which is described
-        // as an error, so that OpenFOAM does not exit,
-        // but the user still sees that this is the actual
-        // problem. We catch these errors and exit later.
-        WarningInFunction
-            << "\033[31m" // red color
-            << "Error (deferred - will exit later) in the preCICE adapter: "
-            << "\033[0m" // restore color
-            << nl
-            << message.c_str()
-            << nl
-            << nl;
     }
     else if (level.compare("debug") == 0)
     {

--- a/changelog-entries/364.md
+++ b/changelog-entries/364.md
@@ -1,0 +1,1 @@
+- Removed the error-deferred workaround, simplifying the error handling process in configuration. Configure simulations with the `errors strict` option for the adapter function object. [#364](https://github.com/precice/openfoam-adapter/pull/364)

--- a/docs/config.md
+++ b/docs/config.md
@@ -357,6 +357,7 @@ functions
     preCICE_Adapter
     {
         type preciceAdapterFunctionObject;
+        errors strict; // optional
     }
 }
 ```
@@ -364,6 +365,8 @@ functions
 This directs the solver to use the `preciceAdapterFunctionObject` function object,
 which is part of the `libpreciceAdapterFunctionObject.so` shared library.
 The name `preCICE_Adapter` can be arbitrary. It is important that the library is loaded outside the `functions` dictionary when you want to use the custom boundary conditions that we provide with the FF module.
+
+The `errors strict` option is optional and [available since OpenFOAM v2012](https://www.openfoam.com/news/main-news/openfoam-v20-12/post-processing#post-processing-function-object-error-handling). Since the adapter is necessary to do a coupled simulation, this option instructs OpenFOAM to stop in case it faces issues with loading the adapter. For OpenFOAM versions that don't support this, remove the option.
 
 If you are using other function objects in your simulation, add the preCICE adapter to the end of the list. The adapter will then be executed last, which is important, as the adapter also controls the end of the simulation. When the end of the simulation is detected, the adapter also triggers the `end()` method of all function objects.
 


### PR DESCRIPTION
Currently, we have a workaround to force OpenFOAM to stop when encountering an error in the configuration phase. This is not needed anymore since [OpenFOAM v2012](https://www.openfoam.com/news/main-news/openfoam-v20-12/post-processing#post-processing-function-object-error-handling), which introduces an additional option `errors` for the function object, which if set to `strict`, acts as we would expect in this scenario. See [related OpenFOAM issue](https://develop.openfoam.com/Development/openfoam/-/issues/1779#note_57407).

The `errors` option is now in OpenFOAM long enough that we can assume we will not trouble too many users.

This PR:

- Documents the option
- Removes the `error-deferred` option from `Utilities.C`
- Replaces all instances of `error-deferred` with `error`
- Replaces the `FataErrorInFunction` in `Utilities.C` with a `FatalError` (the `FatalErrorInFunction` did not seem to work in some cases, and it does not seem appropriate for a central logging function)
- Replaces a few explicit calls to `FatalErrorInFunction` with calls to the `adapterInfo` function, clarifying the respective error messages, if needed.

Ideally, I would go as far as to rename `adapterInfo` to `adapterLog`, but this would touch too many files and potentially frustrate some users that maintain their own forks.

I have tested the following:

- [x] Adapter function object does not exist
- [x] Adapter exists, preCICE does not
- [x] Typo in `patchName`
- [x] Typo in `readData`
- [x] Missing `rho` -> a default OpenFOAM error is raised during the lookup
- [x] Wrong solver type -> see #363 

Reviewers: Filter out the whitespace changes. I indented-out a large part of `Adapter.C` because I removed a try-catch construct. 

TODO list:

- [x] I updated the documentation in `docs/`
- [x] I added a changelog entry in `changelog-entries/` (create directory if missing)
