### PR TITLE
Update preCICE reference version to v3.2.0

### DIFF
--- a/.github/workflows/build-custom.input
+++ b/.github/workflows/build-custom.input
@@ -1,7 +1,7 @@
 virtualEnvironment="ubuntu-22.04"
 refAdapter="develop"
 versionOpenFOAM="2412"
-versionpreCICE="v3.1.2"
+versionpreCICE="v3.2.0"
 runTutorialHeatedPlate="false"
 runTutorialQuickstart="false"
 runTutorialPartitionedPipe="false"

--- a/.github/workflows/build-custom.yml
+++ b/.github/workflows/build-custom.yml
@@ -37,7 +37,7 @@ on:
           - 7
       versionpreCICE:
         description: 'Version of preCICE to build with'
-        default: 'v3.1.2'
+        default: 'v3.2.0'
         required: true
       runTutorialHeatedPlate:
         description: Run tutorial flow-over-heated-plate

--- a/.github/workflows/system-tests.yaml
+++ b/.github/workflows/system-tests.yaml
@@ -40,6 +40,6 @@ jobs:
     uses: precice/tutorials/.github/workflows/run_testsuite_workflow.yml@develop
     with:
       suites: openfoam_adapter_pr
-      build_args: TUTORIALS_REF:${{ needs.gather-refs.outputs.ref-tutorials }},PRECICE_REF:v3.1.1,OPENFOAM_EXECUTABLE:openfoam2312,OPENFOAM_ADAPTER_PR:${{ github.event.number }},OPENFOAM_ADAPTER_REF:${{ github.event.pull_request.head.sha }}
+      build_args: TUTORIALS_REF:${{ needs.gather-refs.outputs.ref-tutorials }},PRECICE_REF:v3.2.0,OPENFOAM_EXECUTABLE:openfoam2312,OPENFOAM_ADAPTER_PR:${{ github.event.number }},OPENFOAM_ADAPTER_REF:${{ github.event.pull_request.head.sha }}
       system_tests_branch: develop
       log_level: "DEBUG"

--- a/changelog-entries/365.md
+++ b/changelog-entries/365.md
@@ -1,0 +1,1 @@
+- Changed the reference version of preCICE used by the CI workflows to v3.2.0. [#365](https://github.com/precice/openfoam-adapter/pull/365)


### PR DESCRIPTION
Bumps the preCICE version to v3.2.0 in the following workflows:

- `build-custom.yml` (triggered manually) and in the `build-custom.input` meant for local runs with act.
- `system-tests.yml` -> This is important since we got some results regressions accepted in v3.2.0.
