### PR TITLE
Not checkpointing non-geometric fields

### DIFF
--- a/Adapter.C
+++ b/Adapter.C
@@ -815,14 +815,6 @@ void preciceAdapter::Adapter::reloadMeshPoints()
 void preciceAdapter::Adapter::setupMeshCheckpointing()
 {
     DEBUG(adapterInfo("Creating a list of the mesh checkpointed fields..."));
-
-    // // TODO: Seperate function for topology
-    // // Add faces, owner, neighbour (Topology)
-    // addMeshCheckpointField(const_cast<Foam::faceList&>(mesh_.faces()));
-    // addMeshCheckpointField(const_cast<Foam::labelUList&>(mesh_.owner()));
-    // addMeshCheckpointField(const_cast<Foam::labelUList&>(mesh_.neighbour()));
-    // DEBUG(adapterInfo("Checkpoint mesh faces, owner, neighbour"));
-
     // Add meshPhi (Face motion flux)
     addMeshCheckpointField(const_cast<surfaceScalarField&>(mesh_.phi()));
 

--- a/Adapter.C
+++ b/Adapter.C
@@ -768,7 +768,8 @@ void preciceAdapter::Adapter::storeMeshPoints()
         // TODO: In foam-extend, we would need "allPoints()". Check if this gives the same data.
         // Add points and oldPoints
         meshPoints_ = new Foam::pointField(mesh_.points());
-        meshOldPoints_ = new Foam::pointField(mesh_.oldPoints());
+        // At the beginning, oldPoints doesn't exist
+        meshOldPoints_ = new Foam::pointField(mesh_.points());
 
         DEBUG(adapterInfo("Added mesh points and oldPoints to the list of checkpointed fields."));
         meshCheckPointed = true;
@@ -1358,12 +1359,10 @@ void preciceAdapter::Adapter::readMeshCheckpoint()
     (void)mesh_.Cf();
 
     // Reload mesh points
-    Foam::pointField* Points = &const_cast<Foam::pointField&>(mesh_.points());
+    const_cast<Foam::fvMesh&>(mesh_).movePoints(*meshPoints_);
+
+    // fvMesh.movePoints overwrites the pointer to the oldPoints
     Foam::pointField* OldPoints = &const_cast<Foam::pointField&>(mesh_.oldPoints());
-
-    const_cast<Foam::fvMesh&>(mesh_).movePoints(*Points);
-
-    // fvMesh::movePoints will incorrectly set oldPoints
     *OldPoints = *meshOldPoints_;
 
     // TODO only the meshPhi field is here, which is a surfaceScalarField. The other fields can be removed. (Done)
@@ -1408,8 +1407,8 @@ void preciceAdapter::Adapter::writeMeshCheckpoint()
     DEBUG(adapterInfo("Storing mesh points..."));
 
     // Store mesh points
+    *(meshOldPoints_) = *(meshPoints_);
     *(meshPoints_) = mesh_.points();
-    *(meshOldPoints_) = mesh_.oldPoints();
 
     // // Store faces
     // for (uint i = 0; i < meshFaceLists_.size(); i++)

--- a/Adapter.C
+++ b/Adapter.C
@@ -754,11 +754,6 @@ void preciceAdapter::Adapter::reloadCheckpointTime()
 
 void preciceAdapter::Adapter::storeMeshPoints()
 {
-    DEBUG(adapterInfo("Storing mesh points..."));
-    // TODO: In foam-extend, we would need "allPoints()". Check if this gives the same data.
-    meshPoints_ = mesh_.points();
-    oldMeshPoints_ = mesh_.oldPoints();
-
     /*
     // TODO  This is only required for subcycling. It should not be called when not subcycling!!
     // Add a bool 'subcycling' which can be evaluated every timestep.
@@ -770,17 +765,17 @@ void preciceAdapter::Adapter::storeMeshPoints()
     // Update any volume fields from the buffer to the checkpointed values (if already exists.)
     */
 
-    DEBUG(adapterInfo("Stored mesh points."));
     if (mesh_.moving())
     {
         if (!meshCheckPointed)
         {
             // Set up the checkpoint for the mesh flux: meshPhi
             setupMeshCheckpointing();
+            setupMeshVolCheckpointing();
             meshCheckPointed = true;
         }
         writeMeshCheckpoint();
-        writeVolCheckpoint(); // Does not write anything unless subcycling.
+        writeMeshVolCheckpoint();
     }
 }
 
@@ -792,23 +787,9 @@ void preciceAdapter::Adapter::reloadMeshPoints()
         return;
     }
 
-    // In Foam::polyMesh::movePoints.
-    // TODO: The function movePoints overwrites the pointer to the old mesh.
-    // Therefore, if you revert the mesh, the oldpointer will be set to the points, which are the new values.
-    DEBUG(adapterInfo("Moving mesh points to their previous locations..."));
-
-    // TODO
-    // Switch oldpoints on for pure physics. (is this required?). Switch off for better mesh deformation capabilities?
-    // const_cast<pointField&>(mesh_.points()) = oldMeshPoints_;
-    const_cast<fvMesh&>(mesh_).movePoints(meshPoints_);
+    readMeshCheckpoint();
 
     DEBUG(adapterInfo("Moved mesh points to their previous locations."));
-
-    // TODO The if statement can be removed in this case, but it is still included for clarity
-    if (meshCheckPointed)
-    {
-        readMeshCheckpoint();
-    }
 
     /*  // TODO This part should only be used when sybcycling. See the description in 'storeMeshPoints()'
         // The if statement can be removed in this case, but it is still included for clarity
@@ -817,6 +798,8 @@ void preciceAdapter::Adapter::reloadMeshPoints()
         readVolCheckpoint();
     }
     */
+
+    readMeshVolCheckpoint();
 }
 
 void preciceAdapter::Adapter::setupMeshCheckpointing()
@@ -830,62 +813,42 @@ void preciceAdapter::Adapter::setupMeshCheckpointing()
     // are updated by the function fvMesh::movePoints. Only the meshPhi needs checkpointing.
     DEBUG(adapterInfo("Creating a list of the mesh checkpointed fields..."));
 
-    // Add meshPhi to the checkpointed fields
-    addMeshCheckpointField(
-        const_cast<surfaceScalarField&>(
-            mesh_.phi()));
-#ifdef ADAPTER_DEBUG_MODE
-    adapterInfo(
-        "Added " + mesh_.phi().name() + " in the list of checkpointed fields.");
-#endif
+    // TODO: In foam-extend, we would need "allPoints()". Check if this gives the same data.
+    // Add points and oldPoints
+    meshPoints_ = new Foam::pointField(mesh_.points());
+    meshOldPoints_ = new Foam::pointField(mesh_.oldPoints());
+
+    DEBUG(adapterInfo("Added mesh points and oldPoints to the list of checkpointed fields."));
+
+    // // TODO: Seperate function for topology
+    // // Add faces, owner, neighbour (Topology)
+    // addMeshCheckpointField(const_cast<Foam::faceList&>(mesh_.faces()));
+    // addMeshCheckpointField(const_cast<Foam::labelUList&>(mesh_.owner()));
+    // addMeshCheckpointField(const_cast<Foam::labelUList&>(mesh_.neighbour()));
+    // DEBUG(adapterInfo("Checkpoint mesh faces, owner, neighbour"));
+
+    // Add meshPhi (Face motion flux)
+    addMeshCheckpointField(const_cast<surfaceScalarField&>(mesh_.phi()));
+
+    DEBUG(adapterInfo("Added " + mesh_.phi().name() + " to the list of checkpointed fields."));
 }
 
 void preciceAdapter::Adapter::setupMeshVolCheckpointing()
 {
-    DEBUG(adapterInfo("Creating a list of the mesh volume checkpointed fields..."));
-    // Add the V0 and the V00 to the list of checkpointed fields.
-    // For V0
-    addVolCheckpointField(
-        const_cast<volScalarField::Internal&>(
-            mesh_.V0()));
-#ifdef ADAPTER_DEBUG_MODE
-    adapterInfo(
-        "Added " + mesh_.V0().name() + " in the list of checkpointed fields.");
-#endif
-    // For V00
-    addVolCheckpointField(
-        const_cast<volScalarField::Internal&>(
-            mesh_.V00()));
-#ifdef ADAPTER_DEBUG_MODE
-    adapterInfo(
-        "Added " + mesh_.V00().name() + " in the list of checkpointed fields.");
-#endif
+    // Add V, V0, V00
+    const volScalarField::Internal& constRefV = mesh_.V();
+    volScalarField::Internal& nonConstRefV = const_cast<volScalarField::Internal&>(constRefV);
+    addMeshVolCheckpointField(nonConstRefV);
 
-    // Also add the buffer fields.
-    // TODO For V0
-    /* addVolCheckpointFieldBuffer
-    (
-        const_cast<volScalarField::Internal&>
-        (
-            mesh_.V0()
-        )
-    ); */
-#ifdef ADAPTER_DEBUG_MODE
-    adapterInfo(
-        "Added " + mesh_.V0().name() + " in the list of buffer checkpointed fields.");
-#endif
-    // TODO For V00
-    /* addVolCheckpointFieldBuffer
-    (
-        const_cast<volScalarField::Internal&>
-        (
-            mesh_.V00()
-        )
-    );*/
-#ifdef ADAPTER_DEBUG_MODE
-    adapterInfo(
-        "Added " + mesh_.V00().name() + " in the list of buffer checkpointed fields.");
-#endif
+    const volScalarField::Internal& constRefV0 = mesh_.V0();
+    volScalarField::Internal& nonConstRefV0 = const_cast<volScalarField::Internal&>(constRefV0);
+    addMeshVolCheckpointField(nonConstRefV0);
+
+    const volScalarField::Internal& constRefV00 = mesh_.V00();
+    volScalarField::Internal& nonConstRefV00 = const_cast<volScalarField::Internal&>(constRefV00);
+    addMeshVolCheckpointField(nonConstRefV00);
+
+    DEBUG(adapterInfo("Checkpoint mesh V, V0, V00"));
 }
 
 
@@ -988,35 +951,26 @@ void preciceAdapter::Adapter::pruneCheckpointedFields()
 
 void preciceAdapter::Adapter::addMeshCheckpointField(surfaceScalarField& field)
 {
-    {
-        meshSurfaceScalarFields_.push_back(&field);
-        meshSurfaceScalarFieldCopies_.push_back(new surfaceScalarField(field));
-    }
+    meshSurfaceScalarFields_.push_back(&field);
+    meshSurfaceScalarFieldCopies_.push_back(new surfaceScalarField(field));
 }
 
-void preciceAdapter::Adapter::addMeshCheckpointField(surfaceVectorField& field)
-{
-    {
-        meshSurfaceVectorFields_.push_back(&field);
-        meshSurfaceVectorFieldCopies_.push_back(new surfaceVectorField(field));
-    }
-}
+// void preciceAdapter::Adapter::addMeshCheckpointField(Foam::faceList& field)
+// {
+//     meshFaceLists_.push_back(&field);
+//     meshFaceListCopies_.push_back(new Foam::faceList(field));
+// }
 
-void preciceAdapter::Adapter::addMeshCheckpointField(volVectorField& field)
-{
-    {
-        meshVolVectorFields_.push_back(&field);
-        meshVolVectorFieldCopies_.push_back(new volVectorField(field));
-    }
-}
+// void preciceAdapter::Adapter::addMeshCheckpointField(Foam::labelUList& field)
+// {
+//     meshLabelLists_.push_back(&field);
+//     meshLabelListCopies_.push_back(new Foam::labelUList(field));
+// }
 
-// TODO Internal field for the V0 (volume old) and V00 (volume old-old) fields
-void preciceAdapter::Adapter::addVolCheckpointField(volScalarField::Internal& field)
+void preciceAdapter::Adapter::addMeshVolCheckpointField(volScalarField::Internal& field)
 {
-    {
-        volScalarInternalFields_.push_back(&field);
-        volScalarInternalFieldCopies_.push_back(new volScalarField::Internal(field));
-    }
+    meshVolFields_.push_back(&field);
+    meshVolFieldCopies_.push_back(new volScalarField::Internal(field));
 }
 
 
@@ -1305,10 +1259,7 @@ void preciceAdapter::Adapter::readCheckpoint()
 
     // NOTE: Add here other field types to read, if needed.
 
-#ifdef ADAPTER_DEBUG_MODE
-    adapterInfo(
-        "Checkpoint was read. Time = " + std::to_string(runTime_.value()));
-#endif
+    DEBUG(adapterInfo("Checkpoint was read. Time = " + std::to_string(runTime_.value())));
 
     ACCUMULATE_TIMER(timeInCheckpointingRead_);
 
@@ -1392,10 +1343,7 @@ void preciceAdapter::Adapter::writeCheckpoint()
     }
     // NOTE: Add here other types to write, if needed.
 
-#ifdef ADAPTER_DEBUG_MODE
-    adapterInfo(
-        "Checkpoint for time t = " + std::to_string(runTime_.value()) + " was stored.");
-#endif
+    DEBUG(adapterInfo("Checkpoint for time t = " + std::to_string(runTime_.value()) + " was stored."));
 
     ACCUMULATE_TIMER(timeInCheckpointingWrite_);
 
@@ -1404,13 +1352,12 @@ void preciceAdapter::Adapter::writeCheckpoint()
 
 void preciceAdapter::Adapter::readMeshCheckpoint()
 {
+
     DEBUG(adapterInfo("Reading a mesh checkpoint..."));
 
-    // TODO only the meshPhi field is here, which is a surfaceScalarField. The other fields can be removed.
-    //  Reload all the fields of type mesh surfaceScalarField
+    // TODO only the meshPhi field is here, which is a surfaceScalarField. The other fields can be removed. (Done)
     for (uint i = 0; i < meshSurfaceScalarFields_.size(); i++)
     {
-        // Load the volume field
         *(meshSurfaceScalarFields_.at(i)) == *(meshSurfaceScalarFieldCopies_.at(i));
 
         int nOldTimes(meshSurfaceScalarFields_.at(i)->nOldTimes());
@@ -1424,117 +1371,79 @@ void preciceAdapter::Adapter::readMeshCheckpoint()
         }
     }
 
-    // Reload all the fields of type mesh surfaceVectorField
-    for (uint i = 0; i < meshSurfaceVectorFields_.size(); i++)
-    {
-        // Load the volume field
-        *(meshSurfaceVectorFields_.at(i)) == *(meshSurfaceVectorFieldCopies_.at(i));
+    // Reload mesh points
+    Foam::pointField* Points = &const_cast<Foam::pointField&>(mesh_.points());
+    Foam::pointField* OldPoints = &const_cast<Foam::pointField&>(mesh_.oldPoints());
+    *Points = *meshPoints_;
+    *OldPoints = *meshOldPoints_;
 
-        int nOldTimes(meshSurfaceVectorFields_.at(i)->nOldTimes());
-        if (nOldTimes >= 1)
-        {
-            meshSurfaceVectorFields_.at(i)->oldTime() == meshSurfaceVectorFieldCopies_.at(i)->oldTime();
-        }
-        if (nOldTimes == 2)
-        {
-            meshSurfaceVectorFields_.at(i)->oldTime().oldTime() == meshSurfaceVectorFieldCopies_.at(i)->oldTime().oldTime();
-        }
-    }
+    // Reload faces, owner, neighbour
+    // for (uint i = 0; i < meshFaceLists_.size(); i++) // faces
+    // {
+    //     *(meshFaceLists_.at(i)) = *(meshFaceListCopies_.at(i));
+    // }
+    // for (uint i = 0; i < meshLabelLists_.size(); i++) // owner and neighbour
+    // {
+    //     *(meshLabelLists_.at(i)) = *(meshLabelListCopies_.at(i));
+    // }
 
-    // Reload all the fields of type mesh volVectorField
-    for (uint i = 0; i < meshVolVectorFields_.size(); i++)
-    {
-        // Load the volume field
-        *(meshVolVectorFields_.at(i)) == *(meshVolVectorFieldCopies_.at(i));
-
-        int nOldTimes(meshVolVectorFields_.at(i)->nOldTimes());
-        if (nOldTimes >= 1)
-        {
-            meshVolVectorFields_.at(i)->oldTime() == meshVolVectorFieldCopies_.at(i)->oldTime();
-        }
-        if (nOldTimes == 2)
-        {
-            meshVolVectorFields_.at(i)->oldTime().oldTime() == meshVolVectorFieldCopies_.at(i)->oldTime().oldTime();
-        }
-    }
-
-#ifdef ADAPTER_DEBUG_MODE
-    adapterInfo(
-        "Mesh checkpoint was read. Time = " + std::to_string(runTime_.value()));
-#endif
-
-    return;
+    DEBUG(adapterInfo("Mesh checkpoint was read. Time = " + std::to_string(runTime_.value())));
 }
 
 void preciceAdapter::Adapter::writeMeshCheckpoint()
 {
     DEBUG(adapterInfo("Writing a mesh checkpoint..."));
 
-    // Store all the fields of type mesh surfaceScalar
+    // Store all the fields of type mesh surfaceScalar (phi)
     for (uint i = 0; i < meshSurfaceScalarFields_.size(); i++)
     {
         *(meshSurfaceScalarFieldCopies_.at(i)) == *(meshSurfaceScalarFields_.at(i));
     }
 
-    // Store all the fields of type mesh surfaceVector
-    for (uint i = 0; i < meshSurfaceVectorFields_.size(); i++)
-    {
-        *(meshSurfaceVectorFieldCopies_.at(i)) == *(meshSurfaceVectorFields_.at(i));
-    }
+    DEBUG(adapterInfo("Storing mesh points..."));
 
-    // Store all the fields of type mesh volVector
-    for (uint i = 0; i < meshVolVectorFields_.size(); i++)
-    {
-        *(meshVolVectorFieldCopies_.at(i)) == *(meshVolVectorFields_.at(i));
-    }
+    // Store mesh points
+    *(meshPoints_) = mesh_.points();
+    *(meshOldPoints_) = mesh_.oldPoints();
 
-#ifdef ADAPTER_DEBUG_MODE
-    adapterInfo(
-        "Mesh checkpoint for time t = " + std::to_string(runTime_.value()) + " was stored.");
-#endif
+    // // Store faces
+    // for (uint i = 0; i < meshFaceLists_.size(); i++)
+    // {
+    //     *(meshFaceListCopies_.at(i)) = *(meshFaceLists_.at(i));
+    // }
+    // Store owner and neighbour
+
+    DEBUG(adapterInfo("Mesh checkpoint for time t = " + std::to_string(runTime_.value()) + " was stored."));
 
     return;
 }
 
-// TODO for the volumes of the mesh, check this part for subcycling.
-void preciceAdapter::Adapter::readVolCheckpoint()
+void preciceAdapter::Adapter::readMeshVolCheckpoint()
 {
-    DEBUG(adapterInfo("Reading the mesh volumes checkpoint..."));
-
-    // Reload all the fields of type mesh volVectorField::Internal
-    for (uint i = 0; i < volScalarInternalFields_.size(); i++)
+    // Reload V, V0, V00
+    for (uint i = 0; i < meshVolFields_.size(); i++)
     {
-        // Load the volume field
-        *(volScalarInternalFields_.at(i)) = *(volScalarInternalFieldCopies_.at(i));
-        // There are no old times for the internal fields.
+        *(meshVolFields_.at(i)) = *(meshVolFieldCopies_.at(i));
     }
 
-#ifdef ADAPTER_DEBUG_MODE
-    adapterInfo(
-        "Mesh volumes were read. Time = " + std::to_string(runTime_.value()));
-#endif
+    DEBUG(adapterInfo("Mesh volumes checkpoint for time t = " + std::to_string(runTime_.value()) + " were read."));
 
     return;
 }
 
-void preciceAdapter::Adapter::writeVolCheckpoint()
+void preciceAdapter::Adapter::writeMeshVolCheckpoint()
 {
-    DEBUG(adapterInfo("Writing a mesh volumes checkpoint..."));
 
-    // Store all the fields of type mesh volScalarField::Internal
-    for (uint i = 0; i < volScalarInternalFields_.size(); i++)
+    // Store V, V0, V00
+    for (uint i = 0; i < meshVolFields_.size(); i++)
     {
-        *(volScalarInternalFieldCopies_.at(i)) = *(volScalarInternalFields_.at(i));
+        *(meshVolFieldCopies_.at(i)) = *(meshVolFields_.at(i));
     }
 
-#ifdef ADAPTER_DEBUG_MODE
-    adapterInfo(
-        "Mesh volumes checkpoint for time t = " + std::to_string(runTime_.value()) + " was stored.");
-#endif
+    DEBUG(adapterInfo("Mesh volumes checkpoint for time t = " + std::to_string(runTime_.value()) + " were stored."));
 
     return;
 }
-
 
 void preciceAdapter::Adapter::end()
 {
@@ -1620,27 +1529,27 @@ void preciceAdapter::Adapter::teardown()
         }
         meshSurfaceScalarFieldCopies_.clear();
 
-        // meshSurfaceVector
-        for (uint i = 0; i < meshSurfaceVectorFieldCopies_.size(); i++)
+        for (uint i = 0; i < meshVolFieldCopies_.size(); i++)
         {
-            delete meshSurfaceVectorFieldCopies_.at(i);
+            delete meshVolFieldCopies_.at(i);
         }
-        meshSurfaceVectorFieldCopies_.clear();
+        meshVolFieldCopies_.clear();
 
-        // meshVolVector
-        for (uint i = 0; i < meshVolVectorFieldCopies_.size(); i++)
-        {
-            delete meshVolVectorFieldCopies_.at(i);
-        }
-        meshVolVectorFieldCopies_.clear();
+        delete meshPoints_;
+        delete meshOldPoints_;
 
-        // TODO for the internal volume
-        //  volScalarInternal
-        for (uint i = 0; i < volScalarInternalFieldCopies_.size(); i++)
-        {
-            delete volScalarInternalFieldCopies_.at(i);
-        }
-        volScalarInternalFieldCopies_.clear();
+        // // meshFaceLists
+        // for (uint i = 0; i < meshFaceListCopies_.size(); i++)
+        // {
+        //     delete meshFaceListCopies_.at(i);
+        // }
+        // meshFaceListCopies_.clear();
+        // // meshLabelLists (owner, neighbour)
+        // for (uint i = 0; i < meshLabelListCopies_.size(); i++)
+        // {
+        //     delete meshLabelListCopies_.at(i);
+        // }
+        // meshLabelListCopies_.clear();
 
         // volTensorField
         for (uint i = 0; i < volTensorFieldCopies_.size(); i++)

--- a/Adapter.C
+++ b/Adapter.C
@@ -754,16 +754,15 @@ void preciceAdapter::Adapter::reloadCheckpointTime()
 
 void preciceAdapter::Adapter::storeMeshPoints()
 {
-    /*
     // TODO  This is only required for subcycling. It should not be called when not subcycling!!
     // Add a bool 'subcycling' which can be evaluated every timestep.
-    if ( !oldVolsStored && mesh_.foundObject<volScalarField::Internal>("V00") ) // For Ddt schemes which use one previous timestep
+    if (!oldVolsStored && mesh_.foundObject<volScalarField::Internal>("V00")) // For Ddt schemes which use one previous timestep
     {
         setupMeshVolCheckpointing();
         oldVolsStored = true;
     }
     // Update any volume fields from the buffer to the checkpointed values (if already exists.)
-    */
+
     if (!meshCheckPointed)
     {
         // TODO: In foam-extend, we would need "allPoints()". Check if this gives the same data.
@@ -780,11 +779,14 @@ void preciceAdapter::Adapter::storeMeshPoints()
         {
             // Set up the checkpoint for the mesh flux: meshPhi
             setupMeshCheckpointing();
-            setupMeshVolCheckpointing();
             meshStartedMoving = true;
         }
         writeMeshCheckpoint();
-        // writeMeshVolCheckpoint();
+
+        if (oldVolsStored)
+        {
+            writeMeshVolCheckpoint();
+        }
     }
 }
 
@@ -800,15 +802,12 @@ void preciceAdapter::Adapter::reloadMeshPoints()
 
     DEBUG(adapterInfo("Moved mesh points to their previous locations."));
 
-    /*  // TODO This part should only be used when sybcycling. See the description in 'storeMeshPoints()'
-        // The if statement can be removed in this case, but it is still included for clarity
-    if ( oldVolsStored )
+    // TODO This part should only be used when sybcycling. See the description in 'storeMeshPoints()'
+    // The if statement can be removed in this case, but it is still included for clarity
+    if (oldVolsStored)
     {
-        readVolCheckpoint();
+        readMeshVolCheckpoint();
     }
-    */
-
-    // readMeshVolCheckpoint();
 }
 
 void preciceAdapter::Adapter::setupMeshCheckpointing()
@@ -1350,6 +1349,23 @@ void preciceAdapter::Adapter::readMeshCheckpoint()
 
     DEBUG(adapterInfo("Reading a mesh checkpoint..."));
 
+    // Invalidate on-demand fields
+    // fvMesh::updateGeomNotOldVol()
+    // (void)mesh_.V();
+    (void)mesh_.Sf();
+    (void)mesh_.magSf();
+    (void)mesh_.C();
+    (void)mesh_.Cf();
+
+    // Reload mesh points
+    Foam::pointField* Points = &const_cast<Foam::pointField&>(mesh_.points());
+    Foam::pointField* OldPoints = &const_cast<Foam::pointField&>(mesh_.oldPoints());
+
+    const_cast<Foam::fvMesh&>(mesh_).movePoints(*Points);
+
+    // fvMesh::movePoints will incorrectly set oldPoints
+    *OldPoints = *meshOldPoints_;
+
     // TODO only the meshPhi field is here, which is a surfaceScalarField. The other fields can be removed. (Done)
     for (uint i = 0; i < meshSurfaceScalarFields_.size(); i++)
     {
@@ -1365,21 +1381,6 @@ void preciceAdapter::Adapter::readMeshCheckpoint()
             meshSurfaceScalarFields_.at(i)->oldTime().oldTime() == meshSurfaceScalarFieldCopies_.at(i)->oldTime().oldTime();
         }
     }
-
-    // Reload mesh points
-    Foam::pointField* Points = &const_cast<Foam::pointField&>(mesh_.points());
-    Foam::pointField* OldPoints = &const_cast<Foam::pointField&>(mesh_.oldPoints());
-    *Points = *meshPoints_;
-    *OldPoints = *meshOldPoints_;
-
-
-    // Invalidate on-demand fields
-    // fvMesh::updateGeomNotOldVol()
-    (void)mesh_.V();
-    (void)mesh_.Sf();
-    (void)mesh_.magSf();
-    (void)mesh_.C();
-    (void)mesh_.Cf();
 
     // Reload faces, owner, neighbour
     // for (uint i = 0; i < meshFaceLists_.size(); i++) // faces

--- a/Adapter.C
+++ b/Adapter.C
@@ -1377,6 +1377,15 @@ void preciceAdapter::Adapter::readMeshCheckpoint()
     *Points = *meshPoints_;
     *OldPoints = *meshOldPoints_;
 
+
+    // Invalidate on-demand fields
+    // fvMesh::updateGeomNotOldVol()
+    (void)mesh_.V();
+    (void)mesh_.Sf();
+    (void)mesh_.magSf();
+    (void)mesh_.C();
+    (void)mesh_.Cf();
+
     // Reload faces, owner, neighbour
     // for (uint i = 0; i < meshFaceLists_.size(); i++) // faces
     // {

--- a/Adapter.C
+++ b/Adapter.C
@@ -1386,14 +1386,14 @@ void preciceAdapter::Adapter::readMeshVolCheckpoint()
 
         const_cast<volScalarField::Internal&>(mesh_.V0()) = *(meshVolFieldCopies_.at(1));
         DEBUG(adapterInfo("Read mesh volume " + meshVolFieldCopies_.at(1)->name()));
+
+        DEBUG(adapterInfo("Mesh volumes checkpoint for time t = " + std::to_string(runTime_.value()) + " were read."));
     }
     if (volumeCheckpointCounter == 3)
     {
         const_cast<volScalarField::Internal&>(mesh_.V00()) = *(meshVolFieldCopies_.at(2));
         DEBUG(adapterInfo("Read mesh volume " + meshVolFieldCopies_.at(2)->name()));
     }
-
-    DEBUG(adapterInfo("Mesh volumes checkpoint for time t = " + std::to_string(runTime_.value()) + " were read."));
 
     return;
 }
@@ -1408,14 +1408,14 @@ void preciceAdapter::Adapter::writeMeshVolCheckpoint()
 
         *(meshVolFieldCopies_.at(1)) = const_cast<volScalarField::Internal&>(mesh_.V0());
         DEBUG(adapterInfo("Write mesh volume " + meshVolFieldCopies_.at(1)->name()));
+
+        DEBUG(adapterInfo("Mesh volumes checkpoint for time t = " + std::to_string(runTime_.value()) + " were stored."));
     }
     if (volumeCheckpointCounter == 3)
     {
         *(meshVolFieldCopies_.at(2)) = const_cast<volScalarField::Internal&>(mesh_.V00());
         DEBUG(adapterInfo("Write mesh volume " + meshVolFieldCopies_.at(2)->name()));
     }
-
-    DEBUG(adapterInfo("Mesh volumes checkpoint for time t = " + std::to_string(runTime_.value()) + " were stored."));
 
     return;
 }

--- a/Adapter.C
+++ b/Adapter.C
@@ -654,13 +654,11 @@ void preciceAdapter::Adapter::adjustSolverTimeStepAndReadData()
     double tolerance = 1e-14;
     if (precice_->getMaxTimeStepSize() - timestepSolverDetermined > tolerance)
     {
-        // Add a bool 'subCycling = true' which is checked in the storeMeshPoints() function.
         adapterInfo(
             "The solver's timestep is smaller than the "
             "coupling timestep. Subcycling...",
             "info");
         timestepSolver_ = timestepSolverDetermined;
-        // TODO subcycling is enabled. For FSI the oldVolumes must be written, which is normally not done.
         if (FSIenabled_)
         {
             adapterInfo(
@@ -773,19 +771,13 @@ void preciceAdapter::Adapter::storeMeshPoints()
         }
         writeMeshCheckpoint();
 
-        // TODO  This is only required for subcycling. It should not be called when not subcycling!!
-        // Add a bool 'subcycling' which can be evaluated every timestep.
-
-        if (subcycling)
+        // For Ddt schemes which use up to two previous timesteps V0, V00
+        if (volumeCheckpointCounter < 3)
         {
-            // For Ddt schemes which use up to two previous timesteps V0, V00
-            if (volumeCheckpointCounter < 3)
-            {
-                setupMeshVolCheckpointing();
-            }
-
-            writeMeshVolCheckpoint();
+            setupMeshVolCheckpointing();
         }
+
+        writeMeshVolCheckpoint();
     }
 }
 
@@ -801,11 +793,7 @@ void preciceAdapter::Adapter::reloadMeshPoints()
 
     DEBUG(adapterInfo("Moved mesh points to their previous locations."));
 
-    // TODO This part should only be used when sybcycling. See the description in 'storeMeshPoints()'
-    if (subcycling)
-    {
-        readMeshVolCheckpoint();
-    }
+    readMeshVolCheckpoint();
 }
 
 void preciceAdapter::Adapter::setupMeshCheckpointing()
@@ -1391,18 +1379,18 @@ void preciceAdapter::Adapter::writeMeshCheckpoint()
 void preciceAdapter::Adapter::readMeshVolCheckpoint()
 {
     // Reload V, V0, V00
-    if (volumeCheckpointCounter == 2)
+    if (volumeCheckpointCounter == 2 || volumeCheckpointCounter == 3)
     {
-        DEBUG(adapterInfo("Read mesh volume " + meshVolFieldCopies_.at(0)->name()));
         const_cast<volScalarField::Internal&>(mesh_.V()) = *(meshVolFieldCopies_.at(0));
+        DEBUG(adapterInfo("Read mesh volume " + meshVolFieldCopies_.at(0)->name()));
 
-        DEBUG(adapterInfo("Read mesh volume " + meshVolFieldCopies_.at(1)->name()));
         const_cast<volScalarField::Internal&>(mesh_.V0()) = *(meshVolFieldCopies_.at(1));
+        DEBUG(adapterInfo("Read mesh volume " + meshVolFieldCopies_.at(1)->name()));
     }
     if (volumeCheckpointCounter == 3)
     {
-        DEBUG(adapterInfo("Read mesh volume " + meshVolFieldCopies_.at(2)->name()));
         const_cast<volScalarField::Internal&>(mesh_.V00()) = *(meshVolFieldCopies_.at(2));
+        DEBUG(adapterInfo("Read mesh volume " + meshVolFieldCopies_.at(2)->name()));
     }
 
     DEBUG(adapterInfo("Mesh volumes checkpoint for time t = " + std::to_string(runTime_.value()) + " were read."));
@@ -1413,18 +1401,18 @@ void preciceAdapter::Adapter::readMeshVolCheckpoint()
 void preciceAdapter::Adapter::writeMeshVolCheckpoint()
 {
     // Store V, V0, V00
-    if (volumeCheckpointCounter == 2)
+    if (volumeCheckpointCounter == 2 || volumeCheckpointCounter == 3)
     {
-        DEBUG(adapterInfo("Write mesh volume " + meshVolFieldCopies_.at(0)->name()));
         *(meshVolFieldCopies_.at(0)) = const_cast<volScalarField::Internal&>(mesh_.V());
+        DEBUG(adapterInfo("Write mesh volume " + meshVolFieldCopies_.at(0)->name()));
 
-        DEBUG(adapterInfo("Write mesh volume " + meshVolFieldCopies_.at(1)->name()));
         *(meshVolFieldCopies_.at(1)) = const_cast<volScalarField::Internal&>(mesh_.V0());
+        DEBUG(adapterInfo("Write mesh volume " + meshVolFieldCopies_.at(1)->name()));
     }
     if (volumeCheckpointCounter == 3)
     {
-        DEBUG(adapterInfo("Write mesh volume " + meshVolFieldCopies_.at(2)->name()));
         *(meshVolFieldCopies_.at(2)) = const_cast<volScalarField::Internal&>(mesh_.V00());
+        DEBUG(adapterInfo("Write mesh volume " + meshVolFieldCopies_.at(2)->name()));
     }
 
     DEBUG(adapterInfo("Mesh volumes checkpoint for time t = " + std::to_string(runTime_.value()) + " were stored."));

--- a/Adapter.C
+++ b/Adapter.C
@@ -947,18 +947,6 @@ void preciceAdapter::Adapter::addMeshCheckpointField(surfaceScalarField& field)
     meshSurfaceScalarFieldCopies_.push_back(new surfaceScalarField(field));
 }
 
-// void preciceAdapter::Adapter::addMeshCheckpointField(Foam::faceList& field)
-// {
-//     meshFaceLists_.push_back(&field);
-//     meshFaceListCopies_.push_back(new Foam::faceList(field));
-// }
-
-// void preciceAdapter::Adapter::addMeshCheckpointField(Foam::labelUList& field)
-// {
-//     meshLabelLists_.push_back(&field);
-//     meshLabelListCopies_.push_back(new Foam::labelUList(field));
-// }
-
 void preciceAdapter::Adapter::addMeshVolCheckpointField(volScalarField::Internal& field)
 {
     meshVolFields_.push_back(&field);
@@ -1377,16 +1365,6 @@ void preciceAdapter::Adapter::readMeshCheckpoint()
         }
     }
 
-    // Reload faces, owner, neighbour
-    // for (uint i = 0; i < meshFaceLists_.size(); i++) // faces
-    // {
-    //     *(meshFaceLists_.at(i)) = *(meshFaceListCopies_.at(i));
-    // }
-    // for (uint i = 0; i < meshLabelLists_.size(); i++) // owner and neighbour
-    // {
-    //     *(meshLabelLists_.at(i)) = *(meshLabelListCopies_.at(i));
-    // }
-
     DEBUG(adapterInfo("Mesh checkpoint was read. Time = " + std::to_string(runTime_.value())));
 }
 
@@ -1405,13 +1383,6 @@ void preciceAdapter::Adapter::writeMeshCheckpoint()
     // Store mesh points
     *(meshOldPoints_) = *(meshPoints_);
     *(meshPoints_) = mesh_.points();
-
-    // // Store faces
-    // for (uint i = 0; i < meshFaceLists_.size(); i++)
-    // {
-    //     *(meshFaceListCopies_.at(i)) = *(meshFaceLists_.at(i));
-    // }
-    // Store owner and neighbour
 
     DEBUG(adapterInfo("Mesh checkpoint for time t = " + std::to_string(runTime_.value()) + " was stored."));
 
@@ -1537,19 +1508,6 @@ void preciceAdapter::Adapter::teardown()
 
         delete meshPoints_;
         delete meshOldPoints_;
-
-        // // meshFaceLists
-        // for (uint i = 0; i < meshFaceListCopies_.size(); i++)
-        // {
-        //     delete meshFaceListCopies_.at(i);
-        // }
-        // meshFaceListCopies_.clear();
-        // // meshLabelLists (owner, neighbour)
-        // for (uint i = 0; i < meshLabelListCopies_.size(); i++)
-        // {
-        //     delete meshLabelListCopies_.at(i);
-        // }
-        // meshLabelListCopies_.clear();
 
         // volTensorField
         for (uint i = 0; i < volTensorFieldCopies_.size(); i++)

--- a/Adapter.C
+++ b/Adapter.C
@@ -763,18 +763,6 @@ void preciceAdapter::Adapter::storeMeshPoints()
         meshOldPoints_ = new Foam::pointField(mesh_.oldPoints());
     }
 
-    // TODO  This is only required for subcycling. It should not be called when not subcycling!!
-    // Add a bool 'subcycling' which can be evaluated every timestep.
-
-    // V00 is not a registered field and thus will never be found !
-    // Implement ddt counter
-    bool ddt_counter = mesh_.foundObject<volScalarField::Internal>("V00");
-    if (!oldVolsStored && ddt_counter) // For Ddt schemes which use one previous timestep
-    {
-        setupMeshVolCheckpointing();
-        oldVolsStored = true;
-    }
-
     if (mesh_.moving())
     {
         if (!meshCheckPointed)
@@ -785,8 +773,17 @@ void preciceAdapter::Adapter::storeMeshPoints()
         }
         writeMeshCheckpoint();
 
-        if (oldVolsStored)
+        // TODO  This is only required for subcycling. It should not be called when not subcycling!!
+        // Add a bool 'subcycling' which can be evaluated every timestep.
+
+        if (subcycling)
         {
+            // For Ddt schemes which use up to two previous timesteps V0, V00
+            if (volumeCheckpointCounter < 3)
+            {
+                setupMeshVolCheckpointing();
+            }
+
             writeMeshVolCheckpoint();
         }
     }
@@ -805,8 +802,7 @@ void preciceAdapter::Adapter::reloadMeshPoints()
     DEBUG(adapterInfo("Moved mesh points to their previous locations."));
 
     // TODO This part should only be used when sybcycling. See the description in 'storeMeshPoints()'
-    // The if statement can be removed in this case, but it is still included for clarity
-    if (oldVolsStored)
+    if (subcycling)
     {
         readMeshVolCheckpoint();
     }
@@ -824,16 +820,27 @@ void preciceAdapter::Adapter::setupMeshCheckpointing()
 void preciceAdapter::Adapter::setupMeshVolCheckpointing()
 {
     // Add V, V0, V00
-    volScalarField::Internal& nonConstRefV = const_cast<volScalarField::Internal&>(mesh_.V());
-    addMeshVolCheckpointField(nonConstRefV);
+    if (volumeCheckpointCounter == 0)
+    {
+        // When V is available, also V0 is available (see fvMesh::movePoints, storeOldVol(V()))
+        // volumeCheckpointCounter will be 2 after this call
 
-    volScalarField::Internal& nonConstRefV0 = const_cast<volScalarField::Internal&>(mesh_.V0());
-    addMeshVolCheckpointField(nonConstRefV0);
+        addMeshVolCheckpointField(const_cast<volScalarField::Internal&>(mesh_.V()));
+        DEBUG(adapterInfo("Checkpoint mesh V"));
 
-    volScalarField::Internal& nonConstRefV00 = const_cast<volScalarField::Internal&>(mesh_.V00());
-    addMeshVolCheckpointField(nonConstRefV00);
+        volumeCheckpointCounter += 1;
 
-    DEBUG(adapterInfo("Checkpoint mesh V, V0, V00"));
+        addMeshVolCheckpointField(const_cast<volScalarField::Internal&>(mesh_.V0()));
+        DEBUG(adapterInfo("Checkpoint mesh V0"));
+    }
+
+    if (volumeCheckpointCounter == 2)
+    {
+        addMeshVolCheckpointField(const_cast<volScalarField::Internal&>(mesh_.V00()));
+        DEBUG(adapterInfo("Checkpoint mesh V00"));
+    }
+
+    volumeCheckpointCounter += 1;
 }
 
 
@@ -942,7 +949,6 @@ void preciceAdapter::Adapter::addMeshCheckpointField(surfaceScalarField& field)
 
 void preciceAdapter::Adapter::addMeshVolCheckpointField(volScalarField::Internal& field)
 {
-    meshVolFields_.push_back(&field);
     meshVolFieldCopies_.push_back(new volScalarField::Internal(field));
 }
 
@@ -1385,9 +1391,18 @@ void preciceAdapter::Adapter::writeMeshCheckpoint()
 void preciceAdapter::Adapter::readMeshVolCheckpoint()
 {
     // Reload V, V0, V00
-    for (uint i = 0; i < meshVolFields_.size(); i++)
+    if (volumeCheckpointCounter == 2)
     {
-        *(meshVolFields_.at(i)) = *(meshVolFieldCopies_.at(i));
+        DEBUG(adapterInfo("Read mesh volume " + meshVolFieldCopies_.at(0)->name()));
+        const_cast<volScalarField::Internal&>(mesh_.V()) = *(meshVolFieldCopies_.at(0));
+
+        DEBUG(adapterInfo("Read mesh volume " + meshVolFieldCopies_.at(1)->name()));
+        const_cast<volScalarField::Internal&>(mesh_.V0()) = *(meshVolFieldCopies_.at(1));
+    }
+    if (volumeCheckpointCounter == 3)
+    {
+        DEBUG(adapterInfo("Read mesh volume " + meshVolFieldCopies_.at(2)->name()));
+        const_cast<volScalarField::Internal&>(mesh_.V00()) = *(meshVolFieldCopies_.at(2));
     }
 
     DEBUG(adapterInfo("Mesh volumes checkpoint for time t = " + std::to_string(runTime_.value()) + " were read."));
@@ -1397,11 +1412,19 @@ void preciceAdapter::Adapter::readMeshVolCheckpoint()
 
 void preciceAdapter::Adapter::writeMeshVolCheckpoint()
 {
-
     // Store V, V0, V00
-    for (uint i = 0; i < meshVolFields_.size(); i++)
+    if (volumeCheckpointCounter == 2)
     {
-        *(meshVolFieldCopies_.at(i)) = *(meshVolFields_.at(i));
+        DEBUG(adapterInfo("Write mesh volume " + meshVolFieldCopies_.at(0)->name()));
+        *(meshVolFieldCopies_.at(0)) = const_cast<volScalarField::Internal&>(mesh_.V());
+
+        DEBUG(adapterInfo("Write mesh volume " + meshVolFieldCopies_.at(1)->name()));
+        *(meshVolFieldCopies_.at(1)) = const_cast<volScalarField::Internal&>(mesh_.V0());
+    }
+    if (volumeCheckpointCounter == 3)
+    {
+        DEBUG(adapterInfo("Write mesh volume " + meshVolFieldCopies_.at(2)->name()));
+        *(meshVolFieldCopies_.at(2)) = const_cast<volScalarField::Internal&>(mesh_.V00());
     }
 
     DEBUG(adapterInfo("Mesh volumes checkpoint for time t = " + std::to_string(runTime_.value()) + " were stored."));

--- a/Adapter.C
+++ b/Adapter.C
@@ -764,18 +764,27 @@ void preciceAdapter::Adapter::storeMeshPoints()
     }
     // Update any volume fields from the buffer to the checkpointed values (if already exists.)
     */
+    if (!meshCheckPointed)
+    {
+        // TODO: In foam-extend, we would need "allPoints()". Check if this gives the same data.
+        // Add points and oldPoints
+        meshPoints_ = new Foam::pointField(mesh_.points());
+        meshOldPoints_ = new Foam::pointField(mesh_.oldPoints());
 
+        DEBUG(adapterInfo("Added mesh points and oldPoints to the list of checkpointed fields."));
+        meshCheckPointed = true;
+    }
     if (mesh_.moving())
     {
-        if (!meshCheckPointed)
+        if (!meshStartedMoving)
         {
             // Set up the checkpoint for the mesh flux: meshPhi
             setupMeshCheckpointing();
             setupMeshVolCheckpointing();
-            meshCheckPointed = true;
+            meshStartedMoving = true;
         }
         writeMeshCheckpoint();
-        writeMeshVolCheckpoint();
+        // writeMeshVolCheckpoint();
     }
 }
 
@@ -799,26 +808,12 @@ void preciceAdapter::Adapter::reloadMeshPoints()
     }
     */
 
-    readMeshVolCheckpoint();
+    // readMeshVolCheckpoint();
 }
 
 void preciceAdapter::Adapter::setupMeshCheckpointing()
 {
-    // The other mesh <type>Fields:
-    //      C
-    //      Cf
-    //      Sf
-    //      magSf
-    //      delta
-    // are updated by the function fvMesh::movePoints. Only the meshPhi needs checkpointing.
     DEBUG(adapterInfo("Creating a list of the mesh checkpointed fields..."));
-
-    // TODO: In foam-extend, we would need "allPoints()". Check if this gives the same data.
-    // Add points and oldPoints
-    meshPoints_ = new Foam::pointField(mesh_.points());
-    meshOldPoints_ = new Foam::pointField(mesh_.oldPoints());
-
-    DEBUG(adapterInfo("Added mesh points and oldPoints to the list of checkpointed fields."));
 
     // // TODO: Seperate function for topology
     // // Add faces, owner, neighbour (Topology)

--- a/Adapter.C
+++ b/Adapter.C
@@ -432,20 +432,29 @@ void preciceAdapter::Adapter::execute()
     // Write the coupling data in the buffer
     writeCouplingData();
 
-    // Advance preCICE
-    advance();
+    timeWithinIteration_ += timestepSolver_;
 
-    // Read checkpoint if required
-    if (requiresReadingCheckpoint())
+    if (timeWithinIteration_ >= precice_->getMaxTimeStepSize())
     {
-        pruneCheckpointedFields();
-        readCheckpoint();
-    }
+        timeWithinIteration_ = precice_->getMaxTimeStepSize();
 
-    // Write checkpoint if required
-    if (requiresWritingCheckpoint())
-    {
-        writeCheckpoint();
+        // Advance preCICE
+        advance();
+
+        // Read checkpoint if required
+        if (requiresReadingCheckpoint())
+        {
+            pruneCheckpointedFields();
+            readCheckpoint();
+            timeWithinIteration_ = timestepSolver_; // Reset the time within iteration
+        }
+
+        // Write checkpoint at end of subcycles
+        // Write checkpoint if required
+        if (requiresWritingCheckpoint())
+        {
+            writeCheckpoint();
+        }
     }
 
     // As soon as OpenFOAM writes the results, it will not try to write again
@@ -585,9 +594,9 @@ void preciceAdapter::Adapter::finalize()
 void preciceAdapter::Adapter::advance()
 {
     DEBUG(adapterInfo("Advancing preCICE..."));
-
     SETUP_TIMER();
-    precice_->advance(timestepSolver_);
+    precice_->advance(precice_->getMaxTimeStepSize());
+    // precice_->advance(timestepSolver_);
     ACCUMULATE_TIMER(timeInAdvance_);
 
     return;
@@ -695,7 +704,15 @@ void preciceAdapter::Adapter::adjustSolverTimeStepAndReadData()
 
     // Read the received coupling data from the buffer
     // Fits to an implicit Euler
-    readCouplingData(runTime_.deltaT().value());
+
+    double readTime = timestepSolver_ + timeWithinIteration_;
+    if (readTime > precice_->getMaxTimeStepSize())
+    {
+        readTime = precice_->getMaxTimeStepSize();
+    }
+    readCouplingData(readTime);
+    DEBUG(adapterInfo("timeWithinIteration_ = " + std::to_string(timeWithinIteration_)));
+    DEBUG(adapterInfo("readTime = " + std::to_string(readTime)));
 
     return;
 }

--- a/Adapter.C
+++ b/Adapter.C
@@ -831,16 +831,13 @@ void preciceAdapter::Adapter::setupMeshCheckpointing()
 void preciceAdapter::Adapter::setupMeshVolCheckpointing()
 {
     // Add V, V0, V00
-    const volScalarField::Internal& constRefV = mesh_.V();
-    volScalarField::Internal& nonConstRefV = const_cast<volScalarField::Internal&>(constRefV);
+    volScalarField::Internal& nonConstRefV = const_cast<volScalarField::Internal&>(mesh_.V());
     addMeshVolCheckpointField(nonConstRefV);
 
-    const volScalarField::Internal& constRefV0 = mesh_.V0();
-    volScalarField::Internal& nonConstRefV0 = const_cast<volScalarField::Internal&>(constRefV0);
+    volScalarField::Internal& nonConstRefV0 = const_cast<volScalarField::Internal&>(mesh_.V0());
     addMeshVolCheckpointField(nonConstRefV0);
 
-    const volScalarField::Internal& constRefV00 = mesh_.V00();
-    volScalarField::Internal& nonConstRefV00 = const_cast<volScalarField::Internal&>(constRefV00);
+    volScalarField::Internal& nonConstRefV00 = const_cast<volScalarField::Internal&>(mesh_.V00());
     addMeshVolCheckpointField(nonConstRefV00);
 
     DEBUG(adapterInfo("Checkpoint mesh V, V0, V00"));
@@ -1079,6 +1076,11 @@ void preciceAdapter::Adapter::readCheckpoint()
     // Reload the runTime
     reloadCheckpointTime();
 
+    if (meshStatePtr_)
+    {
+        const_cast<Foam::dictionary&>(meshStatePtr_->solverPerformanceDict()) = solverPerformanceDict_;
+    }
+
     // Reload the meshPoints (if FSI is enabled)
     if (FSIenabled_)
     {
@@ -1270,6 +1272,12 @@ void preciceAdapter::Adapter::writeCheckpoint()
 
     // Store the runTime
     storeCheckpointTime();
+
+    if (!meshStatePtr_)
+    {
+        meshStatePtr_ = mesh_.thisDb().getObjectPtr<Foam::meshState>("data");
+    }
+    solverPerformanceDict_ = meshStatePtr_->solverPerformanceDict();
 
     // Store the meshPoints (if FSI is enabled)
     if (FSIenabled_)

--- a/Adapter.C
+++ b/Adapter.C
@@ -756,7 +756,11 @@ void preciceAdapter::Adapter::storeMeshPoints()
 {
     // TODO  This is only required for subcycling. It should not be called when not subcycling!!
     // Add a bool 'subcycling' which can be evaluated every timestep.
-    if (!oldVolsStored && mesh_.foundObject<volScalarField::Internal>("V00")) // For Ddt schemes which use one previous timestep
+
+    // V00 is not a registered field and thus will never be found !
+    // Implement ddt counter
+    bool ddt_counter = mesh_.foundObject<volScalarField::Internal>("V00");
+    if (!oldVolsStored && ddt_counter) // For Ddt schemes which use one previous timestep
     {
         setupMeshVolCheckpointing();
         oldVolsStored = true;

--- a/Adapter.C
+++ b/Adapter.C
@@ -754,6 +754,15 @@ void preciceAdapter::Adapter::reloadCheckpointTime()
 
 void preciceAdapter::Adapter::storeMeshPoints()
 {
+    if (!meshPoints_)
+    {
+        DEBUG(adapterInfo("Storing mesh points..."));
+        // Add points and oldPoints
+        meshPoints_ = new Foam::pointField(mesh_.points());
+        // First timestep oldPoints doesn't exist yet
+        meshOldPoints_ = new Foam::pointField(mesh_.oldPoints());
+    }
+
     // TODO  This is only required for subcycling. It should not be called when not subcycling!!
     // Add a bool 'subcycling' which can be evaluated every timestep.
 
@@ -765,26 +774,14 @@ void preciceAdapter::Adapter::storeMeshPoints()
         setupMeshVolCheckpointing();
         oldVolsStored = true;
     }
-    // Update any volume fields from the buffer to the checkpointed values (if already exists.)
 
-    if (!meshCheckPointed)
-    {
-        // TODO: In foam-extend, we would need "allPoints()". Check if this gives the same data.
-        // Add points and oldPoints
-        meshPoints_ = new Foam::pointField(mesh_.points());
-        // At the beginning, oldPoints doesn't exist
-        meshOldPoints_ = new Foam::pointField(mesh_.points());
-
-        DEBUG(adapterInfo("Added mesh points and oldPoints to the list of checkpointed fields."));
-        meshCheckPointed = true;
-    }
     if (mesh_.moving())
     {
-        if (!meshStartedMoving)
+        if (!meshCheckPointed)
         {
             // Set up the checkpoint for the mesh flux: meshPhi
             setupMeshCheckpointing();
-            meshStartedMoving = true;
+            meshCheckPointed = true;
         }
         writeMeshCheckpoint();
 

--- a/Adapter.C
+++ b/Adapter.C
@@ -1355,12 +1355,11 @@ void preciceAdapter::Adapter::readMeshCheckpoint()
     (void)mesh_.C();
     (void)mesh_.Cf();
 
+    // fvMesh.movePoints overwrites the pointer to the oldPoints
+    const_cast<pointField&>(mesh_.points()) = *meshOldPoints_;
+
     // Reload mesh points
     const_cast<Foam::fvMesh&>(mesh_).movePoints(*meshPoints_);
-
-    // fvMesh.movePoints overwrites the pointer to the oldPoints
-    Foam::pointField* OldPoints = &const_cast<Foam::pointField&>(mesh_.oldPoints());
-    *OldPoints = *meshOldPoints_;
 
     // TODO only the meshPhi field is here, which is a surfaceScalarField. The other fields can be removed. (Done)
     for (uint i = 0; i < meshSurfaceScalarFields_.size(); i++)

--- a/Adapter.C
+++ b/Adapter.C
@@ -1076,11 +1076,6 @@ void preciceAdapter::Adapter::readCheckpoint()
     // Reload the runTime
     reloadCheckpointTime();
 
-    if (meshStatePtr_)
-    {
-        const_cast<Foam::dictionary&>(meshStatePtr_->solverPerformanceDict()) = solverPerformanceDict_;
-    }
-
     // Reload the meshPoints (if FSI is enabled)
     if (FSIenabled_)
     {
@@ -1272,12 +1267,6 @@ void preciceAdapter::Adapter::writeCheckpoint()
 
     // Store the runTime
     storeCheckpointTime();
-
-    if (!meshStatePtr_)
-    {
-        meshStatePtr_ = mesh_.thisDb().getObjectPtr<Foam::meshState>("data");
-    }
-    solverPerformanceDict_ = meshStatePtr_->solverPerformanceDict();
 
     // Store the meshPoints (if FSI is enabled)
     if (FSIenabled_)

--- a/Adapter.H
+++ b/Adapter.H
@@ -138,44 +138,32 @@ private:
     //- Checkpointed time (index)
     Foam::label couplingIterationTimeIndex_;
 
-    //- Checkpointed mesh points
-    Foam::pointField meshPoints_;
-    Foam::pointField oldMeshPoints_;
     bool meshCheckPointed = false;
-
-    // TODO: Currently unused, see storeMeshPoints().
-    //- Checkpointed mesh volume
-    // bool oldVolsStored = false;
-    // Foam::volScalarField::Internal * oldVols_;
-    // Foam::volScalarField::Internal * oldOldVols_;
-    // int curTimeIndex_ = 0;
 
     // Vectors of pointers to the checkpointed mesh fields and their copies
 
-    //- Checkpointed surfaceScalarField mesh fields
+    //- Checkpointed mesh points, oldPoints
+    // TODO: is oldPoints even needed?
+    Foam::pointField* meshPoints_;
+    Foam::pointField* meshOldPoints_;
+
+    //- Checkpointed volScalarField mesh fields (V, V0, V00)
+    std::vector<volScalarField::Internal*> meshVolFields_;
+    std::vector<volScalarField::Internal*> meshVolFieldCopies_;
+
+    // //- Checkpointed faceCompactIOList mesh fields (faces)
+    // std::vector<Foam::faceList*> meshFaceLists_;
+    // std::vector<Foam::faceList*> meshFaceListCopies_;
+
+    // //- Checkpointed labelIOList mesh fields (owner, neighbour)
+    // std::vector<Foam::labelUList*> meshLabelLists_;
+    // std::vector<Foam::labelUList*> meshLabelListCopies_;
+
+    //- Checkpointed surfaceScalarField mesh fields (phi)
     std::vector<Foam::surfaceScalarField*> meshSurfaceScalarFields_;
 
     //- Checkpointed surfaceScalarField mesh fields (copies)
     std::vector<Foam::surfaceScalarField*> meshSurfaceScalarFieldCopies_;
-
-    //- Checkpointed surfaceVectorField mesh fields
-    std::vector<Foam::surfaceVectorField*> meshSurfaceVectorFields_;
-
-    //- Checkpointed surfaceVectorField mesh fields (copies)
-    std::vector<Foam::surfaceVectorField*> meshSurfaceVectorFieldCopies_;
-
-    //- Checkpointed volVectorField mesh fields
-    std::vector<Foam::volVectorField*> meshVolVectorFields_;
-
-    //- Checkpointed volVectorField mesh fields (copies)
-    std::vector<Foam::volVectorField*> meshVolVectorFieldCopies_;
-
-    // TODO checkpoint for the V0 (Old volume) and V00 (Old-Old volume) fields.
-    //- Checkpointed volScalarField mesh fields
-    std::vector<Foam::volScalarField::Internal*> volScalarInternalFields_;
-
-    //- Checkpointed volScalarField mesh fields (copies)
-    std::vector<Foam::volScalarField::Internal*> volScalarInternalFieldCopies_;
 
     // Vectors of pointers to the checkpointed fields and their copies
 
@@ -311,21 +299,18 @@ private:
     void reloadMeshPoints();
 
     // Add mesh checkpoint fields, depending on the type
-    //- Add a surfaceScalarField mesh field
-    void addMeshCheckpointField(surfaceScalarField& field);
 
-    //- Add a surfaceVectorField mesh field
-    void addMeshCheckpointField(surfaceVectorField& field);
+    //- Add a volScalarField::Internal mesh field (V, V0, V00)
+    void addMeshVolCheckpointField(volScalarField::Internal& field);
 
-    //- Add a volVectorField mesh field
-    void addMeshCheckpointField(volVectorField& field);
+    //- Add a faceList mesh field (faces)
+    void addMeshCheckpointField(Foam::faceList& field);
 
-    // TODO V0 and V00 checkpointed field.
-    //- Add the V0 and V00 checkpoint fields
-    void addVolCheckpointField(volScalarField::Internal& field);
-    // void addVolCheckpointFieldBuffer(volScalarField::Internal & field);
+    //- Add a labelUList mesh field (owner, neighbour)
+    void addMeshCheckpointField(Foam::labelUList& field);
 
-    // Add checkpoint fields, depending on the type
+    //- Add a surfaceScalarField mesh field (phi)
+    void addMeshCheckpointField(Foam::surfaceScalarField& field);
 
     //- Add a volScalarField to checkpoint
     void addCheckpointField(volScalarField* field);
@@ -374,10 +359,10 @@ private:
 
     // TODO Probably these can be included to the mesh checkpoints.
     //- Read the volume checkpoint - restore the mesh volume fields
-    void readVolCheckpoint();
+    void readMeshVolCheckpoint();
 
     //- Write the volume checkpoint to a buffer - restore the mesh volume fields
-    void writeVolCheckpoint();
+    void writeMeshVolCheckpoint();
 
     //- Destroy the preCICE interface and delete the allocated
     //  memory in a proper way. Called by the destructor.

--- a/Adapter.H
+++ b/Adapter.H
@@ -125,10 +125,12 @@ private:
     // Timesteps
 
     //- Timestep used by the solver
-    double timestepSolver_;
+    double timestepSolver_ = 0.0;
 
     //- Stored (fixed) timestep
     double timestepStored_;
+
+    double timeWithinIteration_ = 0.0;
 
     // Checkpointing
 

--- a/Adapter.H
+++ b/Adapter.H
@@ -141,6 +141,10 @@ private:
     bool meshCheckPointed = false;
     bool oldVolsStored = false;
 
+    //- Volume checkpointing counter (max value 3)
+    u_int8_t volumeCheckpointCounter;
+    bool subcycling = true;
+
     // Vectors of pointers to the checkpointed mesh fields and their copies
 
     //- Checkpointed mesh points, oldPoints
@@ -148,7 +152,6 @@ private:
     Foam::pointField* meshOldPoints_;
 
     //- Checkpointed volScalarField mesh fields (V, V0, V00)
-    std::vector<volScalarField::Internal*> meshVolFields_;
     std::vector<volScalarField::Internal*> meshVolFieldCopies_;
 
     //- Checkpointed surfaceScalarField mesh fields (phi)

--- a/Adapter.H
+++ b/Adapter.H
@@ -144,9 +144,6 @@ private:
 
     // Vectors of pointers to the checkpointed mesh fields and their copies
 
-    Foam::meshState* meshStatePtr_;
-    Foam::dictionary solverPerformanceDict_;
-
     //- Checkpointed mesh points, oldPoints
     Foam::pointField* meshPoints_;
     Foam::pointField* meshOldPoints_;

--- a/Adapter.H
+++ b/Adapter.H
@@ -139,7 +139,6 @@ private:
     Foam::label couplingIterationTimeIndex_;
 
     bool meshCheckPointed = false;
-    bool meshStartedMoving = false;
     bool oldVolsStored = false;
 
     // Vectors of pointers to the checkpointed mesh fields and their copies

--- a/Adapter.H
+++ b/Adapter.H
@@ -144,6 +144,9 @@ private:
 
     // Vectors of pointers to the checkpointed mesh fields and their copies
 
+    Foam::meshState* meshStatePtr_;
+    Foam::dictionary solverPerformanceDict_;
+
     //- Checkpointed mesh points, oldPoints
     Foam::pointField* meshPoints_;
     Foam::pointField* meshOldPoints_;

--- a/Adapter.H
+++ b/Adapter.H
@@ -295,12 +295,6 @@ private:
     //- Add a volScalarField::Internal mesh field (V, V0, V00)
     void addMeshVolCheckpointField(volScalarField::Internal& field);
 
-    //- Add a faceList mesh field (faces)
-    void addMeshCheckpointField(Foam::faceList& field);
-
-    //- Add a labelUList mesh field (owner, neighbour)
-    void addMeshCheckpointField(Foam::labelUList& field);
-
     //- Add a surfaceScalarField mesh field (phi)
     void addMeshCheckpointField(Foam::surfaceScalarField& field);
 

--- a/Adapter.H
+++ b/Adapter.H
@@ -152,14 +152,6 @@ private:
     std::vector<volScalarField::Internal*> meshVolFields_;
     std::vector<volScalarField::Internal*> meshVolFieldCopies_;
 
-    // //- Checkpointed faceCompactIOList mesh fields (faces)
-    // std::vector<Foam::faceList*> meshFaceLists_;
-    // std::vector<Foam::faceList*> meshFaceListCopies_;
-
-    // //- Checkpointed labelIOList mesh fields (owner, neighbour)
-    // std::vector<Foam::labelUList*> meshLabelLists_;
-    // std::vector<Foam::labelUList*> meshLabelListCopies_;
-
     //- Checkpointed surfaceScalarField mesh fields (phi)
     std::vector<Foam::surfaceScalarField*> meshSurfaceScalarFields_;
 

--- a/Adapter.H
+++ b/Adapter.H
@@ -143,7 +143,6 @@ private:
 
     //- Volume checkpointing counter (max value 3)
     u_int8_t volumeCheckpointCounter;
-    bool subcycling = true;
 
     // Vectors of pointers to the checkpointed mesh fields and their copies
 

--- a/Adapter.H
+++ b/Adapter.H
@@ -142,7 +142,7 @@ private:
     bool oldVolsStored = false;
 
     //- Volume checkpointing counter (max value 3)
-    u_int8_t volumeCheckpointCounter;
+    u_int8_t volumeCheckpointCounter = 0;
 
     // Vectors of pointers to the checkpointed mesh fields and their copies
 

--- a/Adapter.H
+++ b/Adapter.H
@@ -140,11 +140,11 @@ private:
 
     bool meshCheckPointed = false;
     bool meshStartedMoving = false;
+    bool oldVolsStored = false;
 
     // Vectors of pointers to the checkpointed mesh fields and their copies
 
     //- Checkpointed mesh points, oldPoints
-    // TODO: is oldPoints even needed?
     Foam::pointField* meshPoints_;
     Foam::pointField* meshOldPoints_;
 

--- a/Adapter.H
+++ b/Adapter.H
@@ -139,6 +139,7 @@ private:
     Foam::label couplingIterationTimeIndex_;
 
     bool meshCheckPointed = false;
+    bool meshStartedMoving = false;
 
     // Vectors of pointers to the checkpointed mesh fields and their copies
 

--- a/FSI/Displacement.C
+++ b/FSI/Displacement.C
@@ -38,13 +38,47 @@ void preciceAdapter::FSI::Displacement::initialize()
 
 std::size_t preciceAdapter::FSI::Displacement::write(double* buffer, bool meshConnectivity, const unsigned int dim)
 {
-    /* TODO: Implement
-     * We need two nested for-loops for each patch,
-     * the outer for the locations and the inner for the dimensions.
-     * See the preCICE writeBlockVectorData() implementation.
-     */
+    Foam::scalar maxDispMag = 0;
+    Foam::scalar sumDispMag = 0;
 
-    // Copy the displacement field from OpenFOAM to the buffer
+    if (this->locationType_ == LocationType::faceCenters)
+    {
+        for (const label patchID : patchIDs_)
+        {
+            const fvPatchVectorField& dispPatch = cellDisplacement_->boundaryField()[patchID];
+            forAll(dispPatch, i)
+            {
+                Foam::scalar magD = mag(dispPatch[i]);
+                sumDispMag += magD;
+                if (magD > maxDispMag)
+                {
+                    maxDispMag = magD;
+                }
+            }
+        }
+    }
+    else if (this->locationType_ == LocationType::faceNodes)
+    {
+        for (const label patchID : patchIDs_)
+        {
+            const labelList& meshPoints = mesh_.boundaryMesh()[patchID].meshPoints();
+            forAll(pointDisplacement_->boundaryField()[patchID], i)
+            {
+                const Foam::vector& disp = pointDisplacement_->internalField()[meshPoints[i]];
+                Foam::scalar magD = mag(disp);
+                sumDispMag += magD;
+                if (magD > maxDispMag)
+                {
+                    maxDispMag = magD;
+                }
+            }
+        }
+    }
+
+    DEBUG(adapterInfo(
+        "PRECICE_DEBUG_DISPLACEMENT_WRITE_MAX_MAG TIME=" + std::to_string(mesh_.time().value()) + " VALUE=" + std::to_string(maxDispMag)));
+    DEBUG(adapterInfo(
+        "PRECICE_DEBUG_DISPLACEMENT_WRITE_SUM_MAG TIME=" + std::to_string(mesh_.time().value()) + " VALUE=" + std::to_string(sumDispMag)));
 
     int bufferIndex = 0;
     if (this->locationType_ == LocationType::faceCenters)
@@ -138,6 +172,49 @@ void preciceAdapter::FSI::Displacement::read(double* buffer, const unsigned int 
             }
         }
     }
+
+    Foam::scalar maxDispMag = 0;
+    Foam::scalar sumDispMag = 0;
+
+    if (this->locationType_ == LocationType::faceCenters)
+    {
+        for (const label patchID : patchIDs_)
+        {
+            const fvPatchVectorField& dispPatch = cellDisplacement_->boundaryField()[patchID];
+            forAll(dispPatch, i)
+            {
+                Foam::scalar magD = mag(dispPatch[i]);
+                sumDispMag += magD;
+                if (magD > maxDispMag)
+                {
+                    maxDispMag = magD;
+                }
+            }
+        }
+    }
+    else if (this->locationType_ == LocationType::faceNodes)
+    {
+        for (const label patchID : patchIDs_)
+        {
+            const fixedValuePointPatchVectorField& dispPatch =
+                refCast<const fixedValuePointPatchVectorField>(
+                    pointDisplacement_->boundaryField()[patchID]);
+            forAll(dispPatch, i)
+            {
+                Foam::scalar magD = mag(dispPatch[i]);
+                sumDispMag += magD;
+                if (magD > maxDispMag)
+                {
+                    maxDispMag = magD;
+                }
+            }
+        }
+    }
+
+    DEBUG(adapterInfo(
+        "PRECICE_DEBUG_DISPLACEMENT_READ_MAX_MAG TIME=" + std::to_string(mesh_.time().value()) + " VALUE=" + std::to_string(maxDispMag)));
+    DEBUG(adapterInfo(
+        "PRECICE_DEBUG_DISPLACEMENT_READ_SUM_MAG TIME=" + std::to_string(mesh_.time().value()) + " VALUE=" + std::to_string(sumDispMag)));
 }
 
 bool preciceAdapter::FSI::Displacement::isLocationTypeSupported(const bool meshConnectivity) const

--- a/FSI/Force.C
+++ b/FSI/Force.C
@@ -75,6 +75,31 @@ void preciceAdapter::FSI::Force::read(double* buffer, const unsigned int dim)
             notImplemented("Read forces not implemented for faceNodes!");
         }
     }
+
+    Foam::scalar maxForceMag = 0;
+    Foam::scalar sumForceMag = 0;
+
+    if (this->locationType_ == LocationType::faceCenters)
+    {
+        for (const label patchID : patchIDs_)
+        {
+            const fvPatchVectorField& forcePatch = Force_->boundaryField()[patchID];
+            forAll(forcePatch, i)
+            {
+                Foam::scalar magF = mag(forcePatch[i]);
+                sumForceMag += magF;
+                if (magF > maxForceMag)
+                {
+                    maxForceMag = magF;
+                }
+            }
+        }
+    }
+
+    DEBUG(adapterInfo(
+        "PRECICE_DEBUG_FORCE_READ_MAX_MAG TIME=" + std::to_string(mesh_.time().value()) + " VALUE=" + std::to_string(maxForceMag)));
+    DEBUG(adapterInfo(
+        "PRECICE_DEBUG_FORCE_READ_SUM_MAG TIME=" + std::to_string(mesh_.time().value()) + " VALUE=" + std::to_string(sumForceMag)));
 }
 
 bool preciceAdapter::FSI::Force::isLocationTypeSupported(const bool meshConnectivity) const

--- a/FSI/ForceBase.C
+++ b/FSI/ForceBase.C
@@ -188,6 +188,29 @@ std::size_t preciceAdapter::FSI::ForceBase::writeToBuffer(double* buffer,
                     forceField.boundaryField()[patchID][i][d];
         }
     }
+
+    Foam::scalar maxForceMag = 0;
+    Foam::scalar sumForceMag = 0;
+
+    for (const label patchID : patchIDs_)
+    {
+        const fvPatchVectorField& forcePatch = forceField.boundaryField()[patchID];
+        forAll(forcePatch, i)
+        {
+            Foam::scalar magF = mag(forcePatch[i]);
+            sumForceMag += magF;
+            if (magF > maxForceMag)
+            {
+                maxForceMag = magF;
+            }
+        }
+    }
+
+    DEBUG(adapterInfo(
+        "PRECICE_DEBUG_FORCE_WRITE_MAX_MAG TIME=" + std::to_string(mesh_.time().value()) + " VALUE=" + std::to_string(maxForceMag)));
+    DEBUG(adapterInfo(
+        "PRECICE_DEBUG_FORCE_WRITE_SUM_MAG TIME=" + std::to_string(mesh_.time().value()) + " VALUE=" + std::to_string(sumForceMag)));
+
     return bufferIndex;
 }
 


### PR DESCRIPTION
  **Note: This Pull Request has been superseded and is now closed.**
  The work originally done in this PR has been cleaned up and split into two new PRs which solve two different issues.
 -  #369
- #370

<!-- Thank you for your contribution! Have a look at the file `CONTRIBUTING.md` for a few hints and guidelines. -->

>Main changes
>- Fixed meshOldPoints checkpointing. Previously mesh would move from incorrect interim state to meshPoints, instead of meshOldPoints (leads to incorrect mesh flux).
>- Removed comments and vectors to mesh fields which don't exist
>- Mesh volume checkpointing (needed for higher order time derivative schemes)
