### PR TITLE
Update meshConnectivity claims

### DIFF
--- a/Adapter.C
+++ b/Adapter.C
@@ -234,20 +234,6 @@ void preciceAdapter::Adapter::configFileRead()
     // FSI-specific options and configure it.
     if (FSIenabled_)
     {
-        // Check for unsupported FSI with meshConnectivity
-        for (uint i = 0; i < interfacesConfig_.size(); i++)
-        {
-            if (interfacesConfig_.at(i).meshConnectivity == true)
-            {
-                adapterInfo(
-                    "You have requested mesh connectivity (most probably for nearest-projection mapping) "
-                    "and you have enabled the FSI module. "
-                    "Mapping with connectivity information is not implemented for FSI, only for CHT-related fields. "
-                    "error");
-                return;
-            }
-        }
-
         FSI_ = new FSI::FluidStructureInteraction(mesh_, runTime_);
         if (!FSI_->configure(preciceDict))
         {

--- a/CHT/HeatFlux.C
+++ b/CHT/HeatFlux.C
@@ -105,14 +105,9 @@ void preciceAdapter::CHT::HeatFlux::read(double* buffer, const unsigned int dim)
 
 bool preciceAdapter::CHT::HeatFlux::isLocationTypeSupported(const bool meshConnectivity) const
 {
-    // For cases with mesh connectivity, we support:
-    // - face nodes, only for writing
-    // - face centers, only for reading
-    // However, since we do not distinguish between reading and writing in the code, we
-    // always return true and offload the handling to the user.
     if (meshConnectivity)
     {
-        return (this->locationType_ == LocationType::faceCenters || this->locationType_ == LocationType::faceNodes); // we currently do not support meshConnectivity for volumeCenters
+        return (this->locationType_ == LocationType::faceNodes);
     }
     else
     {

--- a/CHT/HeatTransferCoefficient.C
+++ b/CHT/HeatTransferCoefficient.C
@@ -118,14 +118,9 @@ void preciceAdapter::CHT::HeatTransferCoefficient::read(double* buffer, const un
 
 bool preciceAdapter::CHT::HeatTransferCoefficient::isLocationTypeSupported(const bool meshConnectivity) const
 {
-    // For cases with mesh connectivity, we support:
-    // - face nodes, only for writing
-    // - face centers, only for reading
-    // However, since we do not distinguish between reading and writing in the code, we
-    // always return true and offload the handling to the user.
     if (meshConnectivity)
     {
-        return (this->locationType_ == LocationType::faceCenters || this->locationType_ == LocationType::faceNodes); // we currently do not support meshConnectivity for volumeCenters
+        return (this->locationType_ == LocationType::faceNodes);
     }
     else
     {

--- a/CHT/SinkTemperature.C
+++ b/CHT/SinkTemperature.C
@@ -95,14 +95,9 @@ void preciceAdapter::CHT::SinkTemperature::read(double* buffer, const unsigned i
 
 bool preciceAdapter::CHT::SinkTemperature::isLocationTypeSupported(const bool meshConnectivity) const
 {
-    // For cases with mesh connectivity, we support:
-    // - face nodes, only for writing
-    // - face centers, only for reading
-    // However, since we do not distinguish between reading and writing in the code, we
-    // always return true and offload the handling to the user.
     if (meshConnectivity)
     {
-        return (this->locationType_ == LocationType::faceCenters || this->locationType_ == LocationType::faceNodes); // we currently do not support meshConnectivity for volumeCenters
+        return (this->locationType_ == LocationType::faceNodes);
     }
     else
     {

--- a/CHT/Temperature.C
+++ b/CHT/Temperature.C
@@ -128,14 +128,9 @@ void preciceAdapter::CHT::Temperature::read(double* buffer, const unsigned int d
 
 bool preciceAdapter::CHT::Temperature::isLocationTypeSupported(const bool meshConnectivity) const
 {
-    // For cases with mesh connectivity, we support:
-    // - face nodes, only for writing
-    // - face centers, only for reading
-    // However, since we do not distinguish between reading and writing in the code, we
-    // always return true and offload the handling to the user.
     if (meshConnectivity)
     {
-        return (this->locationType_ == LocationType::faceCenters || this->locationType_ == LocationType::faceNodes); // we currently do not support meshConnectivity for volumeCenters
+        return (this->locationType_ == LocationType::faceNodes);
     }
     else
     {

--- a/CouplingDataUser.C
+++ b/CouplingDataUser.C
@@ -51,11 +51,19 @@ void preciceAdapter::CouplingDataUser::checkDataLocation(const bool meshConnecti
         else if (locationType_ == LocationType::volumeCenters)
             location = "volumeCenters";
 
-        adapterInfo("\"locations = " + location + "\" is not supported for the data \""
-                        + getDataName() + "\". Please select a different "
-                                          "location type, a different data set or provide "
-                                          "additional connectivity information.",
-                    "error");
+        if (meshConnectivity)
+        {
+            adapterInfo("The data \"" + getDataName() + "\""
+                            + " does not currently support mesh connectivity (e.g., nearest-projection mapping) for location type "
+                            + "\"" + location + "\".",
+                        "error");
+        }
+        else
+        {
+            adapterInfo("The data \"" + getDataName() + "\" does not support location type \""
+                            + location + "\". Please select a different location type.",
+                        "error");
+        }
     }
 }
 

--- a/FF/Alpha.C
+++ b/FF/Alpha.C
@@ -102,7 +102,7 @@ bool preciceAdapter::FF::Alpha::isLocationTypeSupported(const bool meshConnectiv
 {
     if (meshConnectivity)
     {
-        return (this->locationType_ == LocationType::faceCenters);
+        return false;
     }
     else
     {

--- a/FF/DragForce.C
+++ b/FF/DragForce.C
@@ -189,7 +189,7 @@ bool preciceAdapter::FF::DragForce::isLocationTypeSupported(const bool meshConne
 {
     if (meshConnectivity)
     {
-        return (this->locationType_ == LocationType::faceCenters);
+        return false;
     }
     else
     {

--- a/FF/ExplicitMomentum.C
+++ b/FF/ExplicitMomentum.C
@@ -189,7 +189,7 @@ bool preciceAdapter::FF::ExplicitMomentum::isLocationTypeSupported(const bool me
 {
     if (meshConnectivity)
     {
-        return (this->locationType_ == LocationType::faceCenters);
+        return false;
     }
     else
     {

--- a/FF/ImplicitMomentum.C
+++ b/FF/ImplicitMomentum.C
@@ -125,7 +125,7 @@ bool preciceAdapter::FF::ImplicitMomentum::isLocationTypeSupported(const bool me
 {
     if (meshConnectivity)
     {
-        return (this->locationType_ == LocationType::faceCenters);
+        return false;
     }
     else
     {

--- a/FF/Pressure.C
+++ b/FF/Pressure.C
@@ -116,7 +116,7 @@ bool preciceAdapter::FF::Pressure::isLocationTypeSupported(const bool meshConnec
 {
     if (meshConnectivity)
     {
-        return (this->locationType_ == LocationType::faceCenters);
+        return false;
     }
     else
     {

--- a/FF/Velocity.C
+++ b/FF/Velocity.C
@@ -209,7 +209,7 @@ bool preciceAdapter::FF::Velocity::isLocationTypeSupported(const bool meshConnec
 {
     if (meshConnectivity)
     {
-        return (this->locationType_ == LocationType::faceCenters);
+        return false;
     }
     else
     {

--- a/FSI/Displacement.C
+++ b/FSI/Displacement.C
@@ -142,7 +142,15 @@ void preciceAdapter::FSI::Displacement::read(double* buffer, const unsigned int 
 
 bool preciceAdapter::FSI::Displacement::isLocationTypeSupported(const bool meshConnectivity) const
 {
-    return (this->locationType_ == LocationType::faceCenters || this->locationType_ == LocationType::faceNodes);
+    // Solid solver can allow connectivity for writing displacement
+    if (meshConnectivity)
+    {
+        return (this->locationType_ == LocationType::faceNodes);
+    }
+    else
+    {
+        return (this->locationType_ == LocationType::faceCenters || this->locationType_ == LocationType::faceNodes);
+    }
 }
 
 std::string preciceAdapter::FSI::Displacement::getDataName() const

--- a/FSI/DisplacementDelta.C
+++ b/FSI/DisplacementDelta.C
@@ -96,7 +96,15 @@ void preciceAdapter::FSI::DisplacementDelta::read(double* buffer, const unsigned
 
 bool preciceAdapter::FSI::DisplacementDelta::isLocationTypeSupported(const bool meshConnectivity) const
 {
-    return (this->locationType_ == LocationType::faceCenters || this->locationType_ == LocationType::faceNodes);
+    // Solid solver *could* allow connectivity for writing displacement
+    if (meshConnectivity)
+    {
+        return (this->locationType_ == LocationType::faceNodes);
+    }
+    else
+    {
+        return (this->locationType_ == LocationType::faceCenters || this->locationType_ == LocationType::faceNodes);
+    }
 }
 
 std::string preciceAdapter::FSI::DisplacementDelta::getDataName() const

--- a/FSI/Force.C
+++ b/FSI/Force.C
@@ -79,7 +79,14 @@ void preciceAdapter::FSI::Force::read(double* buffer, const unsigned int dim)
 
 bool preciceAdapter::FSI::Force::isLocationTypeSupported(const bool meshConnectivity) const
 {
-    return (this->locationType_ == LocationType::faceCenters);
+    if (meshConnectivity)
+    {
+        return false;
+    }
+    else
+    {
+        return (this->locationType_ == LocationType::faceCenters);
+    }
 }
 
 std::string preciceAdapter::FSI::Force::getDataName() const

--- a/FSI/Stress.C
+++ b/FSI/Stress.C
@@ -33,7 +33,14 @@ void preciceAdapter::FSI::Stress::read(double* buffer, const unsigned int dim)
 
 bool preciceAdapter::FSI::Stress::isLocationTypeSupported(const bool meshConnectivity) const
 {
-    return (this->locationType_ == LocationType::faceCenters);
+    if (meshConnectivity)
+    {
+        return false;
+    }
+    else
+    {
+        return (this->locationType_ == LocationType::faceCenters);
+    }
 }
 
 std::string preciceAdapter::FSI::Stress::getDataName() const

--- a/changelog-entries/394.md
+++ b/changelog-entries/394.md
@@ -1,0 +1,1 @@
+Refactored `isLocationTypeSupported` across all modules. FSI now allows mesh connectivity when writing Displacement.

--- a/changelog-entries/394.md
+++ b/changelog-entries/394.md
@@ -1,1 +1,1 @@
-Refactored `isLocationTypeSupported` across all modules. FSI now allows mesh connectivity when writing Displacement.
+Updated `isLocationTypeSupported` across all modules to remove unreachable conditions and to better reflect the implementation. FSI now allows mesh connectivity when writing Displacement.


### PR DESCRIPTION
<!-- Thank you for your contribution! Have a look at the file `CONTRIBUTING.md` for a few hints and guidelines. -->

### Updated `isLocationTypeSupported` across all modules
The `isLocationTypeSupported` methods were not entirely correct w.r.t. mesh connectivity support (implementation did not match the statements) and inconsistent across the modules. 

Previously we allowed mesh connectivity for face centers when reading, however that is wholly irrelevant, because only the writing participant determines mesh connectivity. See [David's comment](https://github.com/precice/openfoam-adapter/pull/392#discussion_r2817737302):
> That said, for reading data, connectivity is not relevant, one would configure the face centers and leave the connectivity definition to the writing side,

Furthermore, this condition was actually unreachable by the adapter, because in Adapter.C, line 100, we allow mesh connectivity only when location is face nodes.

```cpp
if (interfaceConfig.meshConnectivity && (interfaceConfig.locationsType == "faceCenters" || interfaceConfig.locationsType == "volumeCenters" || interfaceConfig.locationsType == "volumeCentres"))
{
    DEBUG(adapterInfo("Mesh connectivity is not supported for faceCenters or volumeCenters. \n"
                      "Please configure the desired interface with the locationsType faceNodes. \n"
                      "Have a look in the adapter documentation for detailed information.",
                      "error"));
    return;
}
```

### Updated support

- CHT module: mesh connectivity supported for writing faceNodes.
- FF module: no mesh connectivity support.
- FSI module:  Since we now have solid solvers in OpenFOAM, we can allow mesh connectivity for displacement, see [David's comment](https://github.com/precice/openfoam-adapter/pull/392#issuecomment-3919455527). 

TODO list:

- [ ] I updated the documentation in `docs/`
- [x] I added a changelog entry in `changelog-entries/` (create directory if missing)
