### PR TITLE
Initialize meshPoints_ to null pointers

### DIFF
--- a/Adapter.H
+++ b/Adapter.H
@@ -155,8 +155,8 @@ private:
     // Vectors of pointers to the checkpointed mesh fields and their copies
 
     //- Checkpointed mesh points, oldPoints
-    Foam::pointField* meshPoints_;
-    Foam::pointField* meshOldPoints_;
+    Foam::pointField* meshPoints_ = NULL;
+    Foam::pointField* meshOldPoints_ = NULL;
 
     //- Checkpointed surfaceScalarField mesh fields (phi)
     std::vector<Foam::surfaceScalarField*> meshSurfaceScalarFields_;

--- a/Adapter.H
+++ b/Adapter.H
@@ -155,8 +155,8 @@ private:
     // Vectors of pointers to the checkpointed mesh fields and their copies
 
     //- Checkpointed mesh points, oldPoints
-    Foam::pointField* meshPoints_ = NULL;
-    Foam::pointField* meshOldPoints_ = NULL;
+    Foam::pointField* meshPoints_ = nullptr;
+    Foam::pointField* meshOldPoints_ = nullptr;
 
     //- Checkpointed surfaceScalarField mesh fields (phi)
     std::vector<Foam::surfaceScalarField*> meshSurfaceScalarFields_;

--- a/changelog-entries/394.md
+++ b/changelog-entries/394.md
@@ -1,0 +1,1 @@
+- Fixed bug where meshPoints_ pointers were initialized with garbage non-zero values instead of null pointers. [#394](https://github.com/precice/openfoam-adapter/pull/394).

--- a/changelog-entries/394.md
+++ b/changelog-entries/394.md
@@ -1,1 +1,0 @@
-- Fixed bug where meshPoints_ pointers were initialized with garbage non-zero values instead of null pointers. [#394](https://github.com/precice/openfoam-adapter/pull/394).


### PR DESCRIPTION
<!-- Thank you for your contribution! Have a look at the file `CONTRIBUTING.md` for a few hints and guidelines. -->

Fixed bug where `storeMeshPoints()` would not store points because meshPoints_ pointer had garbage non-zero value.

```cpp
// Adapter.C
void preciceAdapter::Adapter::storeMeshPoints()
{
    if (!meshPoints_)
    {
        DEBUG(adapterInfo("Storing mesh points..."));
        // Add points and oldPoints
        meshPoints_ = new Foam::pointField(mesh_.points());
        meshOldPoints_ = new Foam::pointField(mesh_.oldPoints());
    }
    //... 
```

The fix was to initialize with null pointers:
```cpp
// Adapter.H
    //- Checkpointed mesh points, oldPoints
    Foam::pointField* meshPoints_ = NULL;
    Foam::pointField* meshOldPoints_ = NULL;
```
TODO list:

- [ ] I updated the documentation in `docs/`
- [x] I added a changelog entry in `changelog-entries/` (create directory if missing)
