### PR TITLE
Implement `flip-normal` operation adapter-wide inside `CouplingDataUser`

### DIFF
--- a/Adapter.C
+++ b/Adapter.C
@@ -349,19 +349,19 @@ try
             unsigned int inModules = 0;
 
             // Add CHT-related coupling data writers
-            if (CHTenabled_ && CHT_->addWriters(dataName, interface))
+            if (CHTenabled_ && CHT_->addWriters(fieldConfig, interface))
             {
                 inModules++;
             }
 
             // Add FSI-related coupling data writers
-            if (FSIenabled_ && FSI_->addWriters(dataName, interface))
+            if (FSIenabled_ && FSI_->addWriters(fieldConfig, interface))
             {
                 inModules++;
             }
 
             // Add FF-related coupling data writers
-            if (FFenabled_ && FF_->addWriters(dataName, interface))
+            if (FFenabled_ && FF_->addWriters(fieldConfig, interface))
             {
                 inModules++;
             }
@@ -401,19 +401,19 @@ try
             unsigned int inModules = 0;
 
             // Add CHT-related coupling data readers
-            if (CHTenabled_ && CHT_->addReaders(dataName, interface))
+            if (CHTenabled_ && CHT_->addReaders(fieldConfig, interface))
             {
                 inModules++;
             }
 
             // Add FSI-related coupling data readers
-            if (FSIenabled_ && FSI_->addReaders(dataName, interface))
+            if (FSIenabled_ && FSI_->addReaders(fieldConfig, interface))
             {
                 inModules++;
             }
 
             // Add FF-related coupling data readers
-            if (FFenabled_ && FF_->addReaders(dataName, interface))
+            if (FFenabled_ && FF_->addReaders(fieldConfig, interface))
             {
                 inModules++;
             }

--- a/Adapter.C
+++ b/Adapter.C
@@ -31,7 +31,7 @@ void preciceAdapter::Adapter::readFieldConfigs(const std::string& listName, Foam
             word dataName;
             stream >> dataName;
 
-            struct FieldConfig FieldConfig;
+            struct FieldConfig fieldConfig;
 
             // If next token is '{', we have a dictionary (new schema).
             // We create a dictionary from the stream `dictionary dict(stream);`
@@ -42,12 +42,12 @@ void preciceAdapter::Adapter::readFieldConfigs(const std::string& listName, Foam
             if (stream.peek() == token::BEGIN_BLOCK)
             {
                 dictionary dict(stream);
-                FieldConfig.name = dict.get<word>("name"); // The 'name' entry is mandatory.
-                FieldConfig.solver_name = dict.lookupOrDefault<word>("solver_name", FieldConfig.name);
-                FieldConfig.operation = dict.lookupOrDefault<word>("operation", "value");
+                fieldConfig.name = dict.get<word>("name"); // The 'name' entry is mandatory.
+                fieldConfig.solver_name = dict.lookupOrDefault<word>("solver_name", fieldConfig.name);
+                fieldConfig.operation = dict.lookupOrDefault<word>("operation", "value");
                 try
                 {
-                    FieldConfig.flip_normal = dict.lookupOrDefault<bool>("flip-normal", false);
+                    fieldConfig.flip_normal = dict.lookupOrDefault<bool>("flip-normal", false);
                 }
                 catch (const Foam::IOerror& e)
                 {
@@ -57,19 +57,19 @@ void preciceAdapter::Adapter::readFieldConfigs(const std::string& listName, Foam
             // Else, we have a simple word entry (legacy schema/backwards compatibility).
             else
             {
-                FieldConfig.name = dataName;
-                FieldConfig.solver_name = "Undefined (legacy mode)";
-                FieldConfig.operation = "Undefined (legacy mode)";
-                FieldConfig.flip_normal = false;
+                fieldConfig.name = dataName;
+                fieldConfig.solver_name = "Undefined (legacy mode)";
+                fieldConfig.operation = "Undefined (legacy mode)";
+                fieldConfig.flip_normal = false;
             }
 
-            configs.push_back(FieldConfig);
+            configs.push_back(fieldConfig);
 
             DEBUG(adapterInfo("      - " + dataName));
-            DEBUG(adapterInfo("        name: " + FieldConfig.name));
-            DEBUG(adapterInfo("        solver_name: " + FieldConfig.solver_name));
-            DEBUG(adapterInfo("        operation  : " + FieldConfig.operation));
-            DEBUG(adapterInfo("        flip-normal: " + std::string(FieldConfig.flip_normal ? "true" : "false")));
+            DEBUG(adapterInfo("        name: " + fieldConfig.name));
+            DEBUG(adapterInfo("        solver_name: " + fieldConfig.solver_name));
+            DEBUG(adapterInfo("        operation  : " + fieldConfig.operation));
+            DEBUG(adapterInfo("        flip-normal: " + std::string(fieldConfig.flip_normal ? "true" : "false")));
         }
         stream >> _t; // Last token ')'
     }
@@ -343,8 +343,8 @@ try
         DEBUG(adapterInfo("Adding coupling data writers..."));
         for (uint j = 0; j < interfacesConfig_.at(i).writeData.size(); j++)
         {
-            FieldConfig FieldConfig = interfacesConfig_.at(i).writeData.at(j);
-            std::string dataName = FieldConfig.name;
+            FieldConfig fieldConfig = interfacesConfig_.at(i).writeData.at(j);
+            std::string dataName = fieldConfig.name;
 
             unsigned int inModules = 0;
 
@@ -370,7 +370,7 @@ try
             // Only add Generic interface if not found in other modules
             if (inModules == 0)
             {
-                if (genericModuleEnabled_ && Generic_->addWriters(FieldConfig, interface))
+                if (genericModuleEnabled_ && Generic_->addWriters(fieldConfig, interface))
                 {
                     inModules++;
                 };
@@ -395,8 +395,8 @@ try
         DEBUG(adapterInfo("Adding coupling data readers..."));
         for (uint j = 0; j < interfacesConfig_.at(i).readData.size(); j++)
         {
-            FieldConfig FieldConfig = interfacesConfig_.at(i).readData.at(j);
-            std::string dataName = FieldConfig.name;
+            FieldConfig fieldConfig = interfacesConfig_.at(i).readData.at(j);
+            std::string dataName = fieldConfig.name;
 
             unsigned int inModules = 0;
 
@@ -422,7 +422,7 @@ try
             // Only add Generic interface if not found in other modules
             if (inModules == 0)
             {
-                if (genericModuleEnabled_ && Generic_->addReaders(FieldConfig, interface))
+                if (genericModuleEnabled_ && Generic_->addReaders(fieldConfig, interface))
                 {
                     inModules++;
                 }

--- a/CHT/CHT.C
+++ b/CHT/CHT.C
@@ -127,14 +127,14 @@ bool preciceAdapter::CHT::ConjugateHeatTransfer::addWriters(const preciceAdapter
     if (matchingStrings(dataName, "Sink-Temperature"))
     {
         interface->addCouplingDataWriter(
-            dataName,
+            fieldConfig,
             new SinkTemperature(mesh_, nameT_));
         DEBUG(adapterInfo("Added writer: Sink Temperature."));
     }
     else if (matchingStrings(dataName, "Temperature"))
     {
         interface->addCouplingDataWriter(
-            dataName,
+            fieldConfig,
             new Temperature(mesh_, nameT_));
         DEBUG(adapterInfo("Added writer: Temperature."));
     }
@@ -143,21 +143,21 @@ bool preciceAdapter::CHT::ConjugateHeatTransfer::addWriters(const preciceAdapter
         if (solverType_.compare("compressible") == 0)
         {
             interface->addCouplingDataWriter(
-                dataName,
+                fieldConfig,
                 new HeatFlux_Compressible(mesh_, nameT_));
             DEBUG(adapterInfo("Added writer: Heat Flux for compressible solvers."));
         }
         else if (solverType_.compare("incompressible") == 0)
         {
             interface->addCouplingDataWriter(
-                dataName,
+                fieldConfig,
                 new HeatFlux_Incompressible(mesh_, nameT_, nameRho_, nameCp_, namePr_, nameAlphat_));
             DEBUG(adapterInfo("Added writer: Heat Flux for incompressible solvers. "));
         }
         else if (solverType_.compare("basic") == 0)
         {
             interface->addCouplingDataWriter(
-                dataName,
+                fieldConfig,
                 new HeatFlux_Basic(mesh_, nameT_, nameKappa_));
             DEBUG(adapterInfo("Added writer: Heat Flux for basic solvers. "));
         }
@@ -172,21 +172,21 @@ bool preciceAdapter::CHT::ConjugateHeatTransfer::addWriters(const preciceAdapter
         if (solverType_.compare("compressible") == 0)
         {
             interface->addCouplingDataWriter(
-                dataName,
+                fieldConfig,
                 new HeatTransferCoefficient_Compressible(mesh_, nameT_));
             DEBUG(adapterInfo("Added writer: Heat Transfer Coefficient for compressible solvers."));
         }
         else if (solverType_.compare("incompressible") == 0)
         {
             interface->addCouplingDataWriter(
-                dataName,
+                fieldConfig,
                 new HeatTransferCoefficient_Incompressible(mesh_, nameT_, nameRho_, nameCp_, namePr_, nameAlphat_));
             DEBUG(adapterInfo("Added writer: Heat Transfer Coefficient for incompressible solvers. "));
         }
         else if (solverType_.compare("basic") == 0)
         {
             interface->addCouplingDataWriter(
-                dataName,
+                fieldConfig,
                 new HeatTransferCoefficient_Basic(mesh_, nameT_, nameKappa_));
             DEBUG(adapterInfo("Added writer: Heat Transfer Coefficient for basic solvers. "));
         }
@@ -219,14 +219,14 @@ bool preciceAdapter::CHT::ConjugateHeatTransfer::addReaders(const preciceAdapter
     if (matchingStrings(dataName, "Sink-Temperature"))
     {
         interface->addCouplingDataReader(
-            dataName,
+            fieldConfig,
             new SinkTemperature(mesh_, nameT_));
         DEBUG(adapterInfo("Added reader: Sink Temperature."));
     }
     else if (matchingStrings(dataName, "Temperature"))
     {
         interface->addCouplingDataReader(
-            dataName,
+            fieldConfig,
             new Temperature(mesh_, nameT_));
         DEBUG(adapterInfo("Added reader: Temperature."));
     }
@@ -235,21 +235,21 @@ bool preciceAdapter::CHT::ConjugateHeatTransfer::addReaders(const preciceAdapter
         if (solverType_.compare("compressible") == 0)
         {
             interface->addCouplingDataReader(
-                dataName,
+                fieldConfig,
                 new HeatFlux_Compressible(mesh_, nameT_));
             DEBUG(adapterInfo("Added reader: Heat Flux for compressible solvers."));
         }
         else if (solverType_.compare("incompressible") == 0)
         {
             interface->addCouplingDataReader(
-                dataName,
+                fieldConfig,
                 new HeatFlux_Incompressible(mesh_, nameT_, nameRho_, nameCp_, namePr_, nameAlphat_));
             DEBUG(adapterInfo("Added reader: Heat Flux for incompressible solvers. "));
         }
         else if (solverType_.compare("basic") == 0)
         {
             interface->addCouplingDataReader(
-                dataName,
+                fieldConfig,
                 new HeatFlux_Basic(mesh_, nameT_, nameKappa_));
             DEBUG(adapterInfo("Added reader: Heat Flux for basic solvers. "));
         }
@@ -264,21 +264,21 @@ bool preciceAdapter::CHT::ConjugateHeatTransfer::addReaders(const preciceAdapter
         if (solverType_.compare("compressible") == 0)
         {
             interface->addCouplingDataReader(
-                dataName,
+                fieldConfig,
                 new HeatTransferCoefficient_Compressible(mesh_, nameT_));
             DEBUG(adapterInfo("Added reader: Heat Transfer Coefficient for compressible solvers."));
         }
         else if (solverType_.compare("incompressible") == 0)
         {
             interface->addCouplingDataReader(
-                dataName,
+                fieldConfig,
                 new HeatTransferCoefficient_Incompressible(mesh_, nameT_, nameRho_, nameCp_, namePr_, nameAlphat_));
             DEBUG(adapterInfo("Added reader: Heat Transfer Coefficient for incompressible solvers. "));
         }
         else if (solverType_.compare("basic") == 0)
         {
             interface->addCouplingDataReader(
-                dataName,
+                fieldConfig,
                 new HeatTransferCoefficient_Basic(mesh_, nameT_, nameKappa_));
             DEBUG(adapterInfo("Added reader: Heat Transfer Coefficient for basic solvers. "));
         }

--- a/CHT/CHT.C
+++ b/CHT/CHT.C
@@ -118,8 +118,10 @@ std::string preciceAdapter::CHT::ConjugateHeatTransfer::determineSolverType()
     return solverType;
 }
 
-bool preciceAdapter::CHT::ConjugateHeatTransfer::addWriters(std::string dataName, Interface* interface)
+bool preciceAdapter::CHT::ConjugateHeatTransfer::addWriters(const preciceAdapter::FieldConfig& fieldConfig, Interface* interface)
 {
+    std::string dataName = fieldConfig.name;
+
     bool found = true; // Set to false later, if needed.
 
     if (matchingStrings(dataName, "Sink-Temperature"))
@@ -208,8 +210,10 @@ bool preciceAdapter::CHT::ConjugateHeatTransfer::addWriters(std::string dataName
     return found;
 }
 
-bool preciceAdapter::CHT::ConjugateHeatTransfer::addReaders(std::string dataName, Interface* interface)
+bool preciceAdapter::CHT::ConjugateHeatTransfer::addReaders(const preciceAdapter::FieldConfig& fieldConfig, Interface* interface)
 {
+    std::string dataName = fieldConfig.name;
+
     bool found = true; // Set to false later, if needed.
 
     if (matchingStrings(dataName, "Sink-Temperature"))

--- a/CHT/CHT.H
+++ b/CHT/CHT.H
@@ -60,10 +60,10 @@ public:
     bool configure(const IOdictionary& adapterConfig);
 
     //- Add coupling data writers
-    bool addWriters(std::string dataName, Interface* interface);
+    bool addWriters(const preciceAdapter::FieldConfig& fieldConfig, Interface* interface);
 
     //- Add coupling data readers
-    bool addReaders(std::string dataName, Interface* interface);
+    bool addReaders(const preciceAdapter::FieldConfig& fieldConfig, Interface* interface);
 };
 
 }

--- a/CouplingDataUser.C
+++ b/CouplingDataUser.C
@@ -24,6 +24,22 @@ const std::string& preciceAdapter::CouplingDataUser::dataName()
     return dataName_;
 }
 
+void preciceAdapter::CouplingDataUser::setFlipNormal(bool flipNormal)
+{
+    flipNormal_ = flipNormal;
+}
+
+void preciceAdapter::CouplingDataUser::applyFlipNormal(double* dataBuffer, std::size_t size)
+{
+    if (flipNormal_)
+    {
+        for (std::size_t i = 0; i < size; ++i)
+        {
+            dataBuffer[i] *= -1.0;
+        }
+    }
+}
+
 void preciceAdapter::CouplingDataUser::setPatchIDs(std::vector<int> patchIDs)
 {
     patchIDs_ = patchIDs;

--- a/CouplingDataUser.C
+++ b/CouplingDataUser.C
@@ -29,13 +29,13 @@ void preciceAdapter::CouplingDataUser::setFlipNormal(bool flipNormal)
     flipNormal_ = flipNormal;
 }
 
-void preciceAdapter::CouplingDataUser::applyFlipNormal(double* dataBuffer, std::size_t size)
+void preciceAdapter::CouplingDataUser::applyFlipNormal(precice::span<double> dataBuffer)
 {
     if (flipNormal_)
     {
-        for (std::size_t i = 0; i < size; ++i)
+        for (double& val : dataBuffer)
         {
-            dataBuffer[i] *= -1.0;
+            val *= -1.0;
         }
     }
 }

--- a/CouplingDataUser.H
+++ b/CouplingDataUser.H
@@ -42,6 +42,9 @@ protected:
     //- location type of the interface
     LocationType locationType_ = LocationType::none;
 
+    //- flip normal option
+    bool flipNormal_ = false;
+
 public:
     //- Constructor
     CouplingDataUser();
@@ -57,6 +60,12 @@ public:
 
     //- Get the data name
     const std::string& dataName();
+
+    //- Set flip normal option
+    void setFlipNormal(bool flipNormal);
+
+    //- Apply flip normal to the data buffer (multiply by -1)
+    void applyFlipNormal(double* dataBuffer, std::size_t size);
 
     //- Set the patch IDs that form the interface
     void setPatchIDs(std::vector<int> patchIDs);

--- a/CouplingDataUser.H
+++ b/CouplingDataUser.H
@@ -2,6 +2,7 @@
 #define COUPLINGDATAUSER_H
 
 #include "Utilities.H"
+#include <precice/precice.hpp>
 #include <vector>
 #include <string>
 
@@ -65,7 +66,7 @@ public:
     void setFlipNormal(bool flipNormal);
 
     //- Apply flip normal to the data buffer (multiply by -1)
-    void applyFlipNormal(double* dataBuffer, std::size_t size);
+    void applyFlipNormal(precice::span<double> dataBuffer);
 
     //- Set the patch IDs that form the interface
     void setPatchIDs(std::vector<int> patchIDs);

--- a/FF/FF.C
+++ b/FF/FF.C
@@ -134,70 +134,70 @@ bool preciceAdapter::FF::FluidFluid::addWriters(const preciceAdapter::FieldConfi
     if (matchingStrings(dataName, "VelocityGradient"))
     {
         interface->addCouplingDataWriter(
-            dataName,
+            fieldConfig,
             new VelocityGradient(mesh_, nameU_));
         DEBUG(adapterInfo("Added writer: Velocity Gradient."));
     }
     else if (matchingStrings(dataName, "Velocity"))
     {
         interface->addCouplingDataWriter(
-            dataName,
+            fieldConfig,
             new Velocity(mesh_, nameU_, namePhi_, fluxCorrection_));
         DEBUG(adapterInfo("Added writer: Velocity."));
     }
     else if (matchingStrings(dataName, "PressureGradientFull"))
     {
         interface->addCouplingDataWriter(
-            dataName,
+            fieldConfig,
             new PressureGradientFull(mesh_, nameP_));
         DEBUG(adapterInfo("Added writer: Full Pressure Gradient."));
     }
     else if (matchingStrings(dataName, "PressureGradient"))
     {
         interface->addCouplingDataWriter(
-            dataName,
+            fieldConfig,
             new PressureGradient(mesh_, nameP_));
         DEBUG(adapterInfo("Added writer: Pressure Gradient."));
     }
     else if (matchingStrings(dataName, "Pressure"))
     {
         interface->addCouplingDataWriter(
-            dataName,
+            fieldConfig,
             new Pressure(mesh_, nameP_));
         DEBUG(adapterInfo("Added writer: Pressure."));
     }
     else if (matchingStrings(dataName, "FlowTemperatureGradient"))
     {
         interface->addCouplingDataWriter(
-            dataName,
+            fieldConfig,
             new TemperatureGradient(mesh_, nameT_));
         DEBUG(adapterInfo("Added writer: Flow Temperature Gradient."));
     }
     else if (matchingStrings(dataName, "FlowTemperature"))
     {
         interface->addCouplingDataWriter(
-            dataName,
+            fieldConfig,
             new Temperature(mesh_, nameT_));
         DEBUG(adapterInfo("Added writer: Flow Temperature."));
     }
     else if (matchingStrings(dataName, "AlphaGradient"))
     {
         interface->addCouplingDataWriter(
-            dataName,
+            fieldConfig,
             new AlphaGradient(mesh_, nameAlpha_));
         DEBUG(adapterInfo("Added writer: Alpha Gradient."));
     }
     else if (matchingStrings(dataName, "Alpha"))
     {
         interface->addCouplingDataWriter(
-            dataName,
+            fieldConfig,
             new Alpha(mesh_, nameAlpha_));
         DEBUG(adapterInfo("Added writer: Alpha."));
     }
     else if (matchingStrings(dataName, "Phi"))
     {
         interface->addCouplingDataWriter(
-            dataName,
+            fieldConfig,
             new Phi(mesh_, namePhi_));
         DEBUG(adapterInfo("Added writer: Phi."));
     }
@@ -224,84 +224,84 @@ bool preciceAdapter::FF::FluidFluid::addReaders(const preciceAdapter::FieldConfi
     if (matchingStrings(dataName, "VelocityGradient"))
     {
         interface->addCouplingDataReader(
-            dataName,
+            fieldConfig,
             new VelocityGradient(mesh_, nameU_));
         DEBUG(adapterInfo("Added reader: VelocityGradient."));
     }
     else if (matchingStrings(dataName, "Velocity"))
     {
         interface->addCouplingDataReader(
-            dataName,
+            fieldConfig,
             new Velocity(mesh_, nameU_, namePhi_));
         DEBUG(adapterInfo("Added reader: Velocity."));
     }
     else if (matchingStrings(dataName, "PressureGradient"))
     {
         interface->addCouplingDataReader(
-            dataName,
+            fieldConfig,
             new PressureGradient(mesh_, nameP_));
         DEBUG(adapterInfo("Added reader: Pressure Gradient."));
     }
     else if (matchingStrings(dataName, "Pressure"))
     {
         interface->addCouplingDataReader(
-            dataName,
+            fieldConfig,
             new Pressure(mesh_, nameP_));
         DEBUG(adapterInfo("Added reader: Pressure."));
     }
     else if (matchingStrings(dataName, "FlowTemperatureGradient"))
     {
         interface->addCouplingDataReader(
-            dataName,
+            fieldConfig,
             new TemperatureGradient(mesh_, nameT_));
         DEBUG(adapterInfo("Added reader: Flow Temperature Gradient."));
     }
     else if (matchingStrings(dataName, "FlowTemperature"))
     {
         interface->addCouplingDataReader(
-            dataName,
+            fieldConfig,
             new Temperature(mesh_, nameT_));
         DEBUG(adapterInfo("Added reader: Flow Temperature."));
     }
     else if (matchingStrings(dataName, "AlphaGradient"))
     {
         interface->addCouplingDataReader(
-            dataName,
+            fieldConfig,
             new AlphaGradient(mesh_, nameAlpha_));
         DEBUG(adapterInfo("Added reader: Alpha Gradient."));
     }
     else if (matchingStrings(dataName, "Alpha"))
     {
         interface->addCouplingDataReader(
-            dataName,
+            fieldConfig,
             new Alpha(mesh_, nameAlpha_));
         DEBUG(adapterInfo("Added reader: Alpha."));
     }
     else if (matchingStrings(dataName, "Phi"))
     {
         interface->addCouplingDataReader(
-            dataName,
+            fieldConfig,
             new Phi(mesh_, namePhi_));
         DEBUG(adapterInfo("Added reader: Phi."));
     }
     else if (matchingStrings(dataName, "DragForce"))
     {
         interface->addCouplingDataReader(
-            dataName,
+            fieldConfig,
             new DragForce(mesh_, nameDragForce_));
         DEBUG(adapterInfo("Added reader: DragForce."));
     }
     else if (matchingStrings(dataName, "ExplicitMomentum"))
     {
         interface->addCouplingDataReader(
-            dataName,
+            fieldConfig,
             new ExplicitMomentum(mesh_, nameExplicitMomentum_));
         DEBUG(adapterInfo("Added reader: ExplicitMomentum."));
     }
     else if (matchingStrings(dataName, "ImplicitMomentum"))
     {
         interface->addCouplingDataReader(
-            dataName,
+            fieldConfig,
             new ImplicitMomentum(mesh_, nameImplicitMomentum_));
         DEBUG(adapterInfo("Added reader: ImplicitMomentum."));
     }

--- a/FF/FF.C
+++ b/FF/FF.C
@@ -125,8 +125,10 @@ std::string preciceAdapter::FF::FluidFluid::determineSolverType()
     return solverType;
 }
 
-bool preciceAdapter::FF::FluidFluid::addWriters(std::string dataName, Interface* interface)
+bool preciceAdapter::FF::FluidFluid::addWriters(const preciceAdapter::FieldConfig& fieldConfig, Interface* interface)
 {
+    std::string dataName = fieldConfig.name;
+
     bool found = true; // Set to false later, if needed.
 
     if (matchingStrings(dataName, "VelocityGradient"))
@@ -213,8 +215,10 @@ bool preciceAdapter::FF::FluidFluid::addWriters(std::string dataName, Interface*
     return found;
 }
 
-bool preciceAdapter::FF::FluidFluid::addReaders(std::string dataName, Interface* interface)
+bool preciceAdapter::FF::FluidFluid::addReaders(const preciceAdapter::FieldConfig& fieldConfig, Interface* interface)
 {
+    std::string dataName = fieldConfig.name;
+
     bool found = true; // Set to false later, if needed.
 
     if (matchingStrings(dataName, "VelocityGradient"))

--- a/FF/FF.H
+++ b/FF/FF.H
@@ -77,10 +77,10 @@ public:
     bool configure(const IOdictionary& adapterConfig);
 
     //- Add coupling data writers
-    bool addWriters(std::string dataName, Interface* interface);
+    bool addWriters(const preciceAdapter::FieldConfig& fieldConfig, Interface* interface);
 
     //- Add coupling data readers
-    bool addReaders(std::string dataName, Interface* interface);
+    bool addReaders(const preciceAdapter::FieldConfig& fieldConfig, Interface* interface);
 };
 
 }

--- a/FSI/FSI.C
+++ b/FSI/FSI.C
@@ -139,7 +139,7 @@ bool preciceAdapter::FSI::FluidStructureInteraction::addWriters(const preciceAda
     if (matchingStrings(dataName, "Force"))
     {
         interface->addCouplingDataWriter(
-            dataName,
+            fieldConfig,
             new Force(mesh_, solverType_, nameForce_) /* TODO: Add any other arguments here */
         );
         DEBUG(adapterInfo("Added writer: Force."));
@@ -147,21 +147,21 @@ bool preciceAdapter::FSI::FluidStructureInteraction::addWriters(const preciceAda
     else if (matchingStrings(dataName, "DisplacementDelta"))
     {
         interface->addCouplingDataWriter(
-            dataName,
+            fieldConfig,
             new DisplacementDelta(mesh_, namePointDisplacement_, nameCellDisplacement_));
         DEBUG(adapterInfo("Added writer: DisplacementDelta."));
     }
     else if (matchingStrings(dataName, "Displacement"))
     {
         interface->addCouplingDataWriter(
-            dataName,
+            fieldConfig,
             new Displacement(mesh_, namePointDisplacement_, nameCellDisplacement_));
         DEBUG(adapterInfo("Added writer: Displacement."));
     }
     else if (matchingStrings(dataName, "Stress"))
     {
         interface->addCouplingDataWriter(
-            dataName,
+            fieldConfig,
             new Stress(mesh_, solverType_) /* TODO: Add any other arguments here */
         );
         DEBUG(adapterInfo("Added writer: Stress."));
@@ -189,7 +189,7 @@ bool preciceAdapter::FSI::FluidStructureInteraction::addReaders(const preciceAda
     if (matchingStrings(dataName, "Force"))
     {
         interface->addCouplingDataReader(
-            dataName,
+            fieldConfig,
             new Force(mesh_, solverType_, nameForce_) /* TODO: Add any other arguments here */
         );
         DEBUG(adapterInfo("Added reader: Force."));
@@ -197,21 +197,21 @@ bool preciceAdapter::FSI::FluidStructureInteraction::addReaders(const preciceAda
     else if (matchingStrings(dataName, "DisplacementDelta"))
     {
         interface->addCouplingDataReader(
-            dataName,
+            fieldConfig,
             new DisplacementDelta(mesh_, namePointDisplacement_, nameCellDisplacement_));
         DEBUG(adapterInfo("Added reader: DisplacementDelta."));
     }
     else if (matchingStrings(dataName, "Displacement"))
     {
         interface->addCouplingDataReader(
-            dataName,
+            fieldConfig,
             new Displacement(mesh_, namePointDisplacement_, nameCellDisplacement_));
         DEBUG(adapterInfo("Added reader: Displacement."));
     }
     else if (matchingStrings(dataName, "Stress"))
     {
         interface->addCouplingDataReader(
-            dataName,
+            fieldConfig,
             new Stress(mesh_, solverType_) /* TODO: Add any other arguments here */
         );
         DEBUG(adapterInfo("Added reader: Stress."));

--- a/FSI/FSI.C
+++ b/FSI/FSI.C
@@ -130,8 +130,10 @@ std::string preciceAdapter::FSI::FluidStructureInteraction::determineSolverType(
 }
 
 
-bool preciceAdapter::FSI::FluidStructureInteraction::addWriters(std::string dataName, Interface* interface)
+bool preciceAdapter::FSI::FluidStructureInteraction::addWriters(const preciceAdapter::FieldConfig& fieldConfig, Interface* interface)
 {
+    std::string dataName = fieldConfig.name;
+
     bool found = true; // Set to false later, if needed.
 
     if (matchingStrings(dataName, "Force"))
@@ -178,8 +180,10 @@ bool preciceAdapter::FSI::FluidStructureInteraction::addWriters(std::string data
     return found;
 }
 
-bool preciceAdapter::FSI::FluidStructureInteraction::addReaders(std::string dataName, Interface* interface)
+bool preciceAdapter::FSI::FluidStructureInteraction::addReaders(const preciceAdapter::FieldConfig& fieldConfig, Interface* interface)
 {
+    std::string dataName = fieldConfig.name;
+
     bool found = true; // Set to false later, if needed.
 
     if (matchingStrings(dataName, "Force"))

--- a/FSI/FSI.H
+++ b/FSI/FSI.H
@@ -62,10 +62,10 @@ public:
     bool configure(const IOdictionary& adapterConfig);
 
     //- Add coupling data writers
-    bool addWriters(std::string dataName, Interface* interface);
+    bool addWriters(const preciceAdapter::FieldConfig& fieldConfig, Interface* interface);
 
     //- Add coupling data readers
-    bool addReaders(std::string dataName, Interface* interface);
+    bool addReaders(const preciceAdapter::FieldConfig& fieldConfig, Interface* interface);
 
     //- Return the nameCellDisplacement_ field name
     std::string getCellDisplacementFieldName();

--- a/Interface.C
+++ b/Interface.C
@@ -529,10 +529,6 @@ void preciceAdapter::Interface::createBuffer()
     // Create the data buffer
     // An interface has only one data buffer, which is shared between several
     // CouplingDataUsers.
-    // TODO: Check (write tests) if this works properly when we have multiple
-    // scalar and vector coupling data users in an interface. With the current
-    // preCICE implementation, it should work as, when writing scalars,
-    // it should  only use the first 1/3 elements of the buffer.
     dataBuffer_.resize(dataBufferSize);
 }
 
@@ -568,10 +564,6 @@ void preciceAdapter::Interface::readCouplingData(double relativeReadTime)
 
 void preciceAdapter::Interface::writeCouplingData()
 {
-    // TODO: wrap around isWriteDataRequired
-    // Does the participant need to write data or is it subcycling?
-    // if (precice_.isWriteDataRequired(computedTimestepLength))
-    // {
     // Make every coupling data writer write
     for (uint i = 0; i < couplingDataWriters_.size(); i++)
     {
@@ -592,7 +584,6 @@ void preciceAdapter::Interface::writeCouplingData()
             vertexIDs_,
             {dataBuffer_.data(), nWrittenData});
     }
-    // }
 }
 
 preciceAdapter::Interface::~Interface()

--- a/Interface.C
+++ b/Interface.C
@@ -547,15 +547,16 @@ void preciceAdapter::Interface::readCouplingData(double relativeReadTime)
         // We could add a sanity check here
         // nReadData == vertexIDs_.size() * (1 + (dim_ - 1) * static_cast<int>(couplingDataReader->hasVectorData()));
 
+        precice::span<double> dataSpanRead {dataBuffer_.data(), nReadData};
         precice_.readData(
             meshName_,
             couplingDataReader->dataName(),
             vertexIDs_,
             relativeReadTime,
-            {dataBuffer_.data(), nReadData});
+            dataSpanRead);
 
         // Apply flip normal if required
-        couplingDataReader->applyFlipNormal(dataBuffer_.data(), nReadData);
+        couplingDataReader->applyFlipNormal(dataSpanRead);
 
         // Read the received data from the buffer
         couplingDataReader->read(dataBuffer_.data(), dim_);
@@ -574,15 +575,17 @@ void preciceAdapter::Interface::writeCouplingData()
         // Write the data into the adapter's buffer
         auto nWrittenData = couplingDataWriter->write(dataBuffer_.data(), meshConnectivity_, dim_);
 
+        precice::span<double> dataSpanWritten {dataBuffer_.data(), nWrittenData};
+
         // Apply flip normal if required
-        couplingDataWriter->applyFlipNormal(dataBuffer_.data(), nWrittenData);
+        couplingDataWriter->applyFlipNormal(dataSpanWritten);
 
         // Make preCICE write vector or scalar data
         precice_.writeData(
             meshName_,
             couplingDataWriter->dataName(),
             vertexIDs_,
-            {dataBuffer_.data(), nWrittenData});
+            dataSpanWritten);
     }
 }
 

--- a/Interface.C
+++ b/Interface.C
@@ -440,6 +440,9 @@ void preciceAdapter::Interface::addCouplingDataWriter(
     // Set the data name (from preCICE)
     couplingDataWriter->setDataName(fieldConfig.name);
 
+    // Set the flip normal option
+    couplingDataWriter->setFlipNormal(fieldConfig.flip_normal);
+
     // Set the patchIDs of the patches that form the interface
     couplingDataWriter->setPatchIDs(patchIDs_);
 
@@ -466,6 +469,9 @@ void preciceAdapter::Interface::addCouplingDataReader(
 {
     // Set the patchIDs of the patches that form the interface
     couplingDataReader->setDataName(fieldConfig.name);
+
+    // Set the flip normal option
+    couplingDataReader->setFlipNormal(fieldConfig.flip_normal);
 
     // Add the CouplingDataUser to the list of readers
     couplingDataReader->setPatchIDs(patchIDs_);
@@ -552,6 +558,9 @@ void preciceAdapter::Interface::readCouplingData(double relativeReadTime)
             relativeReadTime,
             {dataBuffer_.data(), nReadData});
 
+        // Apply flip normal if required
+        couplingDataReader->applyFlipNormal(dataBuffer_.data(), nReadData);
+
         // Read the received data from the buffer
         couplingDataReader->read(dataBuffer_.data(), dim_);
     }
@@ -572,6 +581,9 @@ void preciceAdapter::Interface::writeCouplingData()
 
         // Write the data into the adapter's buffer
         auto nWrittenData = couplingDataWriter->write(dataBuffer_.data(), meshConnectivity_, dim_);
+
+        // Apply flip normal if required
+        couplingDataWriter->applyFlipNormal(dataBuffer_.data(), nWrittenData);
 
         // Make preCICE write vector or scalar data
         precice_.writeData(

--- a/Interface.C
+++ b/Interface.C
@@ -434,11 +434,11 @@ void preciceAdapter::Interface::configureMesh(const fvMesh& mesh, const std::str
 
 
 void preciceAdapter::Interface::addCouplingDataWriter(
-    std::string dataName,
+    const FieldConfig& fieldConfig,
     CouplingDataUser* couplingDataWriter)
 {
     // Set the data name (from preCICE)
-    couplingDataWriter->setDataName(dataName);
+    couplingDataWriter->setDataName(fieldConfig.name);
 
     // Set the patchIDs of the patches that form the interface
     couplingDataWriter->setPatchIDs(patchIDs_);
@@ -461,11 +461,11 @@ void preciceAdapter::Interface::addCouplingDataWriter(
 
 
 void preciceAdapter::Interface::addCouplingDataReader(
-    std::string dataName,
+    const FieldConfig& fieldConfig,
     preciceAdapter::CouplingDataUser* couplingDataReader)
 {
     // Set the patchIDs of the patches that form the interface
-    couplingDataReader->setDataName(dataName);
+    couplingDataReader->setDataName(fieldConfig.name);
 
     // Add the CouplingDataUser to the list of readers
     couplingDataReader->setPatchIDs(patchIDs_);

--- a/Interface.H
+++ b/Interface.H
@@ -91,13 +91,13 @@ public:
 
     //- Add a CouplingDataUser to read data from the interface
     void addCouplingDataReader(
-        std::string dataName,
+        const FieldConfig& fieldConfig,
         CouplingDataUser* couplingDataReader);
 
 
     //- Add a CouplingDataUser to write data on the interface
     void addCouplingDataWriter(
-        std::string dataName,
+        const FieldConfig& fieldConfig,
         CouplingDataUser* couplingDataWriter);
 
     //- Allocate an appropriate buffer for scalar or vector data.

--- a/module-generic/Generic.C
+++ b/module-generic/Generic.C
@@ -41,32 +41,32 @@ bool preciceAdapter::Generic::GenericInterface::readConfig(const IOdictionary& a
     return true;
 }
 
-bool preciceAdapter::Generic::GenericInterface::addWriters(const preciceAdapter::FieldConfig& FieldConfig, Interface* interface)
+bool preciceAdapter::Generic::GenericInterface::addWriters(const preciceAdapter::FieldConfig& fieldConfig, Interface* interface)
 {
     bool found = false;
 
     // Force to use the new schema with the Generic module
-    if (FieldConfig.solver_name != "Undefined (legacy mode)")
+    if (fieldConfig.solver_name != "Undefined (legacy mode)")
     {
         // Determine type of field
-        if (mesh_.foundObject<volScalarField>(FieldConfig.solver_name))
+        if (mesh_.foundObject<volScalarField>(fieldConfig.solver_name))
         {
             found = true;
             interface->addCouplingDataWriter(
-                FieldConfig.name,
-                new ScalarFieldCoupler(mesh_, FieldConfig));
+                fieldConfig.name,
+                new ScalarFieldCoupler(mesh_, fieldConfig));
         }
-        else if (mesh_.foundObject<volVectorField>(FieldConfig.solver_name))
+        else if (mesh_.foundObject<volVectorField>(fieldConfig.solver_name))
         {
             found = true;
             interface->addCouplingDataWriter(
-                FieldConfig.name,
-                new VectorFieldCoupler(mesh_, FieldConfig));
+                fieldConfig.name,
+                new VectorFieldCoupler(mesh_, fieldConfig));
         }
         else
         {
             found = false;
-            std::string msg = "Generic module: Data \"" + FieldConfig.name + "\", solver name: \"" + FieldConfig.solver_name + "\" not found!\n";
+            std::string msg = "Generic module: Data \"" + fieldConfig.name + "\", solver name: \"" + fieldConfig.solver_name + "\" not found!\n";
             msg += "Available fields: " + availableVolScalarFields + availableVolVectorFields;
             adapterInfo(msg, "warning");
         }
@@ -74,37 +74,37 @@ bool preciceAdapter::Generic::GenericInterface::addWriters(const preciceAdapter:
 
     if (found)
     {
-        DEBUG(adapterInfo("Added writer: " + FieldConfig.name));
+        DEBUG(adapterInfo("Added writer: " + fieldConfig.name));
     }
     return found;
 }
 
-bool preciceAdapter::Generic::GenericInterface::addReaders(const preciceAdapter::FieldConfig& FieldConfig, Interface* interface)
+bool preciceAdapter::Generic::GenericInterface::addReaders(const preciceAdapter::FieldConfig& fieldConfig, Interface* interface)
 {
     bool found = false;
 
     // Force to use the new schema with the Generic modul
-    if (FieldConfig.solver_name != "Undefined (legacy mode)")
+    if (fieldConfig.solver_name != "Undefined (legacy mode)")
     {
         // Determine type of field
-        if (mesh_.foundObject<volScalarField>(FieldConfig.solver_name))
+        if (mesh_.foundObject<volScalarField>(fieldConfig.solver_name))
         {
             found = true;
             interface->addCouplingDataReader(
-                FieldConfig.name,
-                new ScalarFieldCoupler(mesh_, FieldConfig));
+                fieldConfig.name,
+                new ScalarFieldCoupler(mesh_, fieldConfig));
         }
-        else if (mesh_.foundObject<volVectorField>(FieldConfig.solver_name))
+        else if (mesh_.foundObject<volVectorField>(fieldConfig.solver_name))
         {
             found = true;
             interface->addCouplingDataReader(
-                FieldConfig.name,
-                new VectorFieldCoupler(mesh_, FieldConfig));
+                fieldConfig.name,
+                new VectorFieldCoupler(mesh_, fieldConfig));
         }
         else
         {
             found = false;
-            std::string msg = "Generic module: Data \"" + FieldConfig.name + "\" (solver name: \"" + FieldConfig.solver_name + "\") not found!\n";
+            std::string msg = "Generic module: Data \"" + fieldConfig.name + "\" (solver name: \"" + fieldConfig.solver_name + "\") not found!\n";
             msg += "Available fields: " + availableVolScalarFields + availableVolVectorFields;
             adapterInfo(msg, "warning");
         }
@@ -112,7 +112,7 @@ bool preciceAdapter::Generic::GenericInterface::addReaders(const preciceAdapter:
 
     if (found)
     {
-        DEBUG(adapterInfo("Added reader: " + FieldConfig.name));
+        DEBUG(adapterInfo("Added reader: " + fieldConfig.name));
     }
     return found;
 }

--- a/module-generic/Generic.C
+++ b/module-generic/Generic.C
@@ -53,14 +53,14 @@ bool preciceAdapter::Generic::GenericInterface::addWriters(const preciceAdapter:
         {
             found = true;
             interface->addCouplingDataWriter(
-                fieldConfig.name,
+                fieldConfig,
                 new ScalarFieldCoupler(mesh_, fieldConfig));
         }
         else if (mesh_.foundObject<volVectorField>(fieldConfig.solver_name))
         {
             found = true;
             interface->addCouplingDataWriter(
-                fieldConfig.name,
+                fieldConfig,
                 new VectorFieldCoupler(mesh_, fieldConfig));
         }
         else
@@ -91,14 +91,14 @@ bool preciceAdapter::Generic::GenericInterface::addReaders(const preciceAdapter:
         {
             found = true;
             interface->addCouplingDataReader(
-                fieldConfig.name,
+                fieldConfig,
                 new ScalarFieldCoupler(mesh_, fieldConfig));
         }
         else if (mesh_.foundObject<volVectorField>(fieldConfig.solver_name))
         {
             found = true;
             interface->addCouplingDataReader(
-                fieldConfig.name,
+                fieldConfig,
                 new VectorFieldCoupler(mesh_, fieldConfig));
         }
         else

--- a/module-generic/Generic.H
+++ b/module-generic/Generic.H
@@ -43,10 +43,10 @@ public:
     bool configure(const IOdictionary& adapterConfig);
 
     //- Add coupling data writers
-    bool addWriters(const preciceAdapter::FieldConfig& FieldConfig, Interface* interface);
+    bool addWriters(const preciceAdapter::FieldConfig& fieldConfig, Interface* interface);
 
     //- Add coupling data readers
-    bool addReaders(const preciceAdapter::FieldConfig& FieldConfig, Interface* interface);
+    bool addReaders(const preciceAdapter::FieldConfig& fieldConfig, Interface* interface);
 };
 
 }

--- a/module-generic/ReadWrite.C
+++ b/module-generic/ReadWrite.C
@@ -11,19 +11,19 @@ using namespace Foam;
 
 preciceAdapter::Generic::ScalarFieldCoupler::ScalarFieldCoupler(
     const Foam::fvMesh& mesh,
-    const preciceAdapter::FieldConfig& FieldConfig)
+    const preciceAdapter::FieldConfig& fieldConfig)
 : scalarField_(
     const_cast<volScalarField*>(
-        &mesh.lookupObject<volScalarField>(FieldConfig.solver_name))),
+        &mesh.lookupObject<volScalarField>(fieldConfig.solver_name))),
   mesh_(mesh),
-  FieldConfig_(FieldConfig)
+  fieldConfig_(fieldConfig)
 {
     dataType_ = scalar;
 }
 
 void preciceAdapter::Generic::ScalarFieldCoupler::initialize()
 {
-    if (FieldConfig_.operation == "surface-normal-gradient")
+    if (fieldConfig_.operation == "surface-normal-gradient")
     {
         if (this->locationType_ != LocationType::faceCenters)
         {
@@ -31,7 +31,7 @@ void preciceAdapter::Generic::ScalarFieldCoupler::initialize()
         }
     }
 
-    if (FieldConfig_.operation == "gradient")
+    if (fieldConfig_.operation == "gradient")
     {
         adapterInfo("Generic module: The gradient operation is not yet supported for scalar fields. Maybe you meant surface-normal-gradient?", "error");
     }
@@ -42,7 +42,7 @@ std::size_t preciceAdapter::Generic::ScalarFieldCoupler::write(double* buffer, b
 {
     int bufferIndex = 0;
 
-    if (FieldConfig_.operation == "surface-normal-gradient")
+    if (fieldConfig_.operation == "surface-normal-gradient")
     {
         // For every boundary patch of the interface
         for (uint j = 0; j < patchIDs_.size(); j++)
@@ -198,19 +198,19 @@ bool preciceAdapter::Generic::ScalarFieldCoupler::isLocationTypeSupported(const 
 
 std::string preciceAdapter::Generic::ScalarFieldCoupler::getDataName() const
 {
-    return FieldConfig_.name;
+    return fieldConfig_.name;
 }
 
 //----- preciceAdapter::Generic::VectorFieldCoupler -----------------------------------------
 
 preciceAdapter::Generic::VectorFieldCoupler::VectorFieldCoupler(
     const Foam::fvMesh& mesh,
-    const preciceAdapter::FieldConfig& FieldConfig)
+    const preciceAdapter::FieldConfig& fieldConfig)
 : vectorField_(
     const_cast<volVectorField*>(
-        &mesh.lookupObject<volVectorField>(FieldConfig.solver_name))),
+        &mesh.lookupObject<volVectorField>(fieldConfig.solver_name))),
   mesh_(mesh),
-  FieldConfig_(FieldConfig)
+  fieldConfig_(fieldConfig)
 {
     dataType_ = vector;
 }
@@ -218,7 +218,7 @@ preciceAdapter::Generic::VectorFieldCoupler::VectorFieldCoupler(
 void preciceAdapter::Generic::VectorFieldCoupler::initialize()
 {
     // In the Generic module, for vector fields only the value operation is supported for now, i.e., cannot write gradients.
-    if (FieldConfig_.operation == "gradient" || FieldConfig_.operation == "surface-normal-gradient")
+    if (fieldConfig_.operation == "gradient" || fieldConfig_.operation == "surface-normal-gradient")
     {
         adapterInfo("Generic module: The gradient operation is not yet supported for vector fields.", "error");
     }
@@ -400,5 +400,5 @@ bool preciceAdapter::Generic::VectorFieldCoupler::isLocationTypeSupported(const 
 
 std::string preciceAdapter::Generic::VectorFieldCoupler::getDataName() const
 {
-    return FieldConfig_.name;
+    return fieldConfig_.name;
 }

--- a/module-generic/ReadWrite.H
+++ b/module-generic/ReadWrite.H
@@ -17,10 +17,10 @@ class ScalarFieldCoupler : public CouplingDataUser // One CouplingDataUser for e
 protected:
     Foam::volScalarField* scalarField_;
     const Foam::fvMesh& mesh_;
-    const preciceAdapter::FieldConfig& FieldConfig_;
+    const preciceAdapter::FieldConfig& fieldConfig_;
 
 public:
-    ScalarFieldCoupler(const Foam::fvMesh& mesh, const preciceAdapter::FieldConfig& FieldConfig);
+    ScalarFieldCoupler(const Foam::fvMesh& mesh, const preciceAdapter::FieldConfig& fieldConfig);
 
     void initialize();
     std::size_t write(double* buffer, bool meshConnectivity, const unsigned int dim);
@@ -36,10 +36,10 @@ class VectorFieldCoupler : public CouplingDataUser
 protected:
     Foam::volVectorField* vectorField_;
     const Foam::fvMesh& mesh_;
-    const preciceAdapter::FieldConfig& FieldConfig_;
+    const preciceAdapter::FieldConfig& fieldConfig_;
 
 public:
-    VectorFieldCoupler(const Foam::fvMesh& mesh, const preciceAdapter::FieldConfig& FieldConfig);
+    VectorFieldCoupler(const Foam::fvMesh& mesh, const preciceAdapter::FieldConfig& fieldConfig);
 
     void initialize();
     std::size_t write(double* buffer, bool meshConnectivity, const unsigned int dim);


### PR DESCRIPTION
<!-- Thank you for your contribution! Have a look at the file `CONTRIBUTING.md` for a few hints and guidelines. -->

I decided that the most appropriate place to implement the new `flip-normal` operation is inside of the `CouplingDataUser`, because it 'owns' the data and is associated with that specific data. Therefore the operation is decoupled from the modules and supported by all the modules.

There looks to be a lot of changes in a lot of files, but it's actually quite simple if you look commit by commit. I had to refactor the `Interface::addCouplingDataReader` and `Interface::addCouplingDataWriter` methods to accept `struct FieldConfig` instead of just `string dataName`, because I need to read the `flip-normal` flag per each `CouplingDataUser`.

```cpp
// Interface.C
void preciceAdapter::Interface::addCouplingDataReader(
    const FieldConfig& fieldConfig,
    preciceAdapter::CouplingDataUser* couplingDataReader)
{
    // Set the patchIDs of the patches that form the interface
    couplingDataReader->setDataName(fieldConfig.name);

    // Set the flip normal option
    couplingDataReader->setFlipNormal(fieldConfig.flip_normal);

// ...
```

Now the `CouplingDataUser` has new methods `setFlipNormal` and `applyFlipNormal`.

```cpp
// CouplingDataUser.C
void preciceAdapter::CouplingDataUser::setFlipNormal(bool flipNormal)
{
    flipNormal_ = flipNormal;
}

void preciceAdapter::CouplingDataUser::applyFlipNormal(double* dataBuffer, std::size_t size)
{
    if (flipNormal_)
    {
        for (std::size_t i = 0; i < size; ++i)
        {
            dataBuffer[i] *= -1.0;
        }
    }
}
```

Additionally, I noticed that I had named instances of the `FieldConfig` struct starting with uppercase, so the first commit is lowercasing them.

TODO list:

- [ ] I updated the documentation in `docs/`
- [ ] I added a changelog entry in `changelog-entries/` (create directory if missing)
