### PR TITLE
Change NULL pointer values to C++11 nullptr

### DIFF
--- a/Adapter.C
+++ b/Adapter.C
@@ -649,7 +649,7 @@ void preciceAdapter::Adapter::initialize()
 
 void preciceAdapter::Adapter::finalize()
 {
-    if (NULL != precice_ && preciceInitialized_ && !isCouplingOngoing())
+    if (nullptr != precice_ && preciceInitialized_ && !isCouplingOngoing())
     {
         DEBUG(adapterInfo("Finalizing the preCICE solver interface..."));
 
@@ -796,7 +796,7 @@ bool preciceAdapter::Adapter::isCouplingOngoing()
     // the solver would try to access this method again,
     // giving a segmentation fault if precice_
     // was not available.
-    if (NULL != precice_)
+    if (nullptr != precice_)
     {
         isCouplingOngoing = precice_->isCouplingOngoing();
     }
@@ -1427,7 +1427,7 @@ void preciceAdapter::Adapter::end()
 try
 {
     // Throw a warning if the simulation exited before the coupling was complete
-    if (NULL != precice_ && isCouplingOngoing())
+    if (nullptr != precice_ && isCouplingOngoing())
     {
         adapterInfo("The solver exited before the coupling was complete.", "warning");
     }
@@ -1443,11 +1443,11 @@ void preciceAdapter::Adapter::teardown()
 {
     // If the solver interface was not deleted before, delete it now.
     // Normally it should be deleted when isCouplingOngoing() becomes false.
-    if (NULL != precice_)
+    if (nullptr != precice_)
     {
         DEBUG(adapterInfo("Destroying the preCICE solver interface..."));
         delete precice_;
-        precice_ = NULL;
+        precice_ = nullptr;
     }
 
     // Delete the preCICE solver interfaces
@@ -1549,35 +1549,35 @@ void preciceAdapter::Adapter::teardown()
     }
 
     // Delete the CHT module
-    if (NULL != CHT_)
+    if (nullptr != CHT_)
     {
         DEBUG(adapterInfo("Destroying the CHT module..."));
         delete CHT_;
-        CHT_ = NULL;
+        CHT_ = nullptr;
     }
 
     // Delete the FSI module
-    if (NULL != FSI_)
+    if (nullptr != FSI_)
     {
         DEBUG(adapterInfo("Destroying the FSI module..."));
         delete FSI_;
-        FSI_ = NULL;
+        FSI_ = nullptr;
     }
 
     // Delete the FF module
-    if (NULL != FF_)
+    if (nullptr != FF_)
     {
         DEBUG(adapterInfo("Destroying the FF module..."));
         delete FF_;
-        FF_ = NULL;
+        FF_ = nullptr;
     }
 
     // Delete the Generic module
-    if (NULL != Generic_)
+    if (nullptr != Generic_)
     {
         DEBUG(adapterInfo("Destroying the Generic module..."));
         delete Generic_;
-        Generic_ = NULL;
+        Generic_ = nullptr;
     }
 
     // NOTE: Delete your new module here

--- a/Adapter.H
+++ b/Adapter.H
@@ -123,16 +123,16 @@ private:
     bool preciceInitialized_ = false;
 
     //- Conjugate Heat Transfer module object
-    CHT::ConjugateHeatTransfer* CHT_ = NULL;
+    CHT::ConjugateHeatTransfer* CHT_ = nullptr;
 
     //- Fluid-Structure Interaction module object
-    FSI::FluidStructureInteraction* FSI_ = NULL;
+    FSI::FluidStructureInteraction* FSI_ = nullptr;
 
     //- Fluid-Fluid module object
-    FF::FluidFluid* FF_ = NULL;
+    FF::FluidFluid* FF_ = nullptr;
 
     //- Generic module object
-    Generic::GenericInterface* Generic_ = NULL;
+    Generic::GenericInterface* Generic_ = nullptr;
 
     // NOTE: Add here a pointer for your new module object
 


### PR DESCRIPTION
Following an outdated practice that accumulated over the years, our pointers were initialized or checked against `NULL`. Following the [C++ Core Guidelines](https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#es47-use-nullptr-rather-than-0-or-null), I replaced all of them with `nullptr`.

This pointer literal is [available since C++11](https://en.cppreference.com/w/cpp/language/nullptr.html), so we are fine in terms of support in recent OpenFOAM versions. If an older one does not support it, we should just add a fix in the respective patch.