### PR TITLE
Modernize codebase - use span instead of pointer for buffer

### DIFF
--- a/CHT/HeatFlux.C
+++ b/CHT/HeatFlux.C
@@ -18,7 +18,7 @@ preciceAdapter::CHT::HeatFlux::HeatFlux(
     dataType_ = scalar;
 }
 
-std::size_t preciceAdapter::CHT::HeatFlux::write(double* buffer, bool meshConnectivity, const unsigned int dim)
+std::size_t preciceAdapter::CHT::HeatFlux::write(precice::span<double> buffer, bool meshConnectivity, const unsigned int dim)
 {
     int bufferIndex = 0;
 
@@ -71,7 +71,7 @@ std::size_t preciceAdapter::CHT::HeatFlux::write(double* buffer, bool meshConnec
     return bufferIndex;
 }
 
-void preciceAdapter::CHT::HeatFlux::read(double* buffer, const unsigned int dim)
+void preciceAdapter::CHT::HeatFlux::read(precice::span<double> buffer, const unsigned int dim)
 {
     int bufferIndex = 0;
 

--- a/CHT/HeatFlux.H
+++ b/CHT/HeatFlux.H
@@ -33,11 +33,11 @@ public:
 
     //- Compute heat flux values from the temperature field
     //  and write them into the buffer
-    std::size_t write(double* buffer, bool meshConnectivity, const unsigned int dim) final;
+    std::size_t write(precice::span<double> buffer, bool meshConnectivity, const unsigned int dim) final;
 
     //- Read heat flux values from the buffer and assign them to
     //  the gradient of the temperature field
-    void read(double* buffer, const unsigned int dim) final;
+    void read(precice::span<double> buffer, const unsigned int dim) final;
 
     bool isLocationTypeSupported(const bool meshConnectivity) const final;
 

--- a/CHT/HeatTransferCoefficient.C
+++ b/CHT/HeatTransferCoefficient.C
@@ -20,7 +20,7 @@ preciceAdapter::CHT::HeatTransferCoefficient::HeatTransferCoefficient(
 }
 
 
-std::size_t preciceAdapter::CHT::HeatTransferCoefficient::write(double* buffer, bool meshConnectivity, const unsigned int dim)
+std::size_t preciceAdapter::CHT::HeatTransferCoefficient::write(precice::span<double> buffer, bool meshConnectivity, const unsigned int dim)
 {
     int bufferIndex = 0;
 
@@ -73,7 +73,7 @@ std::size_t preciceAdapter::CHT::HeatTransferCoefficient::write(double* buffer, 
 }
 
 
-void preciceAdapter::CHT::HeatTransferCoefficient::read(double* buffer, const unsigned int dim)
+void preciceAdapter::CHT::HeatTransferCoefficient::read(precice::span<double> buffer, const unsigned int dim)
 {
     int bufferIndex = 0;
 

--- a/CHT/HeatTransferCoefficient.H
+++ b/CHT/HeatTransferCoefficient.H
@@ -35,10 +35,10 @@ public:
         const std::string nameT);
 
     //- Write the heat transfer coefficient values into the buffer
-    std::size_t write(double* buffer, bool meshConnectivity, const unsigned int dim) final;
+    std::size_t write(precice::span<double> buffer, bool meshConnectivity, const unsigned int dim) final;
 
     //- Read the heat transfer coefficient values from the buffer
-    void read(double* buffer, const unsigned int dim) final;
+    void read(precice::span<double> buffer, const unsigned int dim) final;
 
     bool isLocationTypeSupported(const bool meshConnectivity) const final;
 

--- a/CHT/SinkTemperature.C
+++ b/CHT/SinkTemperature.C
@@ -14,7 +14,7 @@ preciceAdapter::CHT::SinkTemperature::SinkTemperature(
     dataType_ = scalar;
 }
 
-std::size_t preciceAdapter::CHT::SinkTemperature::write(double* buffer, bool meshConnectivity, const unsigned int dim)
+std::size_t preciceAdapter::CHT::SinkTemperature::write(precice::span<double> buffer, bool meshConnectivity, const unsigned int dim)
 {
     int bufferIndex = 0;
 
@@ -66,7 +66,7 @@ std::size_t preciceAdapter::CHT::SinkTemperature::write(double* buffer, bool mes
     return bufferIndex;
 }
 
-void preciceAdapter::CHT::SinkTemperature::read(double* buffer, const unsigned int dim)
+void preciceAdapter::CHT::SinkTemperature::read(precice::span<double> buffer, const unsigned int dim)
 {
     int bufferIndex = 0;
 

--- a/CHT/SinkTemperature.H
+++ b/CHT/SinkTemperature.H
@@ -26,10 +26,10 @@ public:
         const std::string nameT);
 
     //- Write the sink temperature values into the buffer
-    std::size_t write(double* buffer, bool meshConnectivity, const unsigned int dim) final;
+    std::size_t write(precice::span<double> buffer, bool meshConnectivity, const unsigned int dim) final;
 
     //- Read the sink temperature values from the buffer
-    void read(double* buffer, const unsigned int dim) final;
+    void read(precice::span<double> buffer, const unsigned int dim) final;
 
     bool isLocationTypeSupported(const bool meshConnectivity) const final;
 

--- a/CHT/Temperature.C
+++ b/CHT/Temperature.C
@@ -15,7 +15,7 @@ preciceAdapter::CHT::Temperature::Temperature(
     dataType_ = scalar;
 }
 
-std::size_t preciceAdapter::CHT::Temperature::write(double* buffer, bool meshConnectivity, const unsigned int dim)
+std::size_t preciceAdapter::CHT::Temperature::write(precice::span<double> buffer, bool meshConnectivity, const unsigned int dim)
 {
     int bufferIndex = 0;
 
@@ -82,7 +82,7 @@ std::size_t preciceAdapter::CHT::Temperature::write(double* buffer, bool meshCon
     return bufferIndex;
 }
 
-void preciceAdapter::CHT::Temperature::read(double* buffer, const unsigned int dim)
+void preciceAdapter::CHT::Temperature::read(precice::span<double> buffer, const unsigned int dim)
 {
     int bufferIndex = 0;
 

--- a/CHT/Temperature.H
+++ b/CHT/Temperature.H
@@ -27,10 +27,10 @@ public:
         const std::string nameT);
 
     //- Write the temperature values into the buffer
-    std::size_t write(double* buffer, bool meshConnectivity, const unsigned int dim) final;
+    std::size_t write(precice::span<double> buffer, bool meshConnectivity, const unsigned int dim) final;
 
     //- Read the temperature values from the buffer
-    void read(double* buffer, const unsigned int dim) final;
+    void read(precice::span<double> buffer, const unsigned int dim) final;
 
     bool isLocationTypeSupported(const bool meshConnectivity) const final;
 

--- a/CouplingDataUser.H
+++ b/CouplingDataUser.H
@@ -2,6 +2,7 @@
 #define COUPLINGDATAUSER_H
 
 #include "Utilities.H"
+#include <precice/precice.hpp>
 #include <vector>
 #include <string>
 
@@ -75,10 +76,10 @@ public:
 
     //- Write the coupling data to the buffer
     // Returns the number of entries that were filles in the buffer (nComp * vertices)
-    virtual std::size_t write(double* dataBuffer, bool meshConnectivity, const unsigned int dim) = 0;
+    virtual std::size_t write(precice::span<double> dataBuffer, bool meshConnectivity, const unsigned int dim) = 0;
 
     //- Read the coupling data from the buffer
-    virtual void read(double* dataBuffer, const unsigned int dim) = 0;
+    virtual void read(precice::span<double> dataBuffer, const unsigned int dim) = 0;
 
     //- Given the meshConnectivity, return if the underlying loactionType of the
     //- interface nodes is supported by the data set

--- a/FF/Alpha.C
+++ b/FF/Alpha.C
@@ -12,7 +12,7 @@ preciceAdapter::FF::Alpha::Alpha(
     dataType_ = scalar;
 }
 
-std::size_t preciceAdapter::FF::Alpha::write(double* buffer, bool meshConnectivity, const unsigned int dim)
+std::size_t preciceAdapter::FF::Alpha::write(precice::span<double> buffer, bool meshConnectivity, const unsigned int dim)
 {
     int bufferIndex = 0;
 
@@ -57,7 +57,7 @@ std::size_t preciceAdapter::FF::Alpha::write(double* buffer, bool meshConnectivi
     return bufferIndex;
 }
 
-void preciceAdapter::FF::Alpha::read(double* buffer, const unsigned int dim)
+void preciceAdapter::FF::Alpha::read(precice::span<double> buffer, const unsigned int dim)
 {
     int bufferIndex = 0;
 

--- a/FF/Alpha.H
+++ b/FF/Alpha.H
@@ -26,10 +26,10 @@ public:
         const std::string nameAlpha);
 
     //- Write the Alpha values into the buffer
-    std::size_t write(double* buffer, bool meshConnectivity, const unsigned int dim) final;
+    std::size_t write(precice::span<double> buffer, bool meshConnectivity, const unsigned int dim) final;
 
     //- Read the Alpha values from the buffer
-    void read(double* buffer, const unsigned int dim) final;
+    void read(precice::span<double> buffer, const unsigned int dim) final;
 
     bool isLocationTypeSupported(const bool meshConnectivity) const final;
 

--- a/FF/AlphaGradient.C
+++ b/FF/AlphaGradient.C
@@ -13,7 +13,7 @@ preciceAdapter::FF::AlphaGradient::AlphaGradient(
     dataType_ = scalar;
 }
 
-std::size_t preciceAdapter::FF::AlphaGradient::write(double* buffer, bool meshConnectivity, const unsigned int dim)
+std::size_t preciceAdapter::FF::AlphaGradient::write(precice::span<double> buffer, bool meshConnectivity, const unsigned int dim)
 {
     int bufferIndex = 0;
 
@@ -37,7 +37,7 @@ std::size_t preciceAdapter::FF::AlphaGradient::write(double* buffer, bool meshCo
     return bufferIndex;
 }
 
-void preciceAdapter::FF::AlphaGradient::read(double* buffer, const unsigned int dim)
+void preciceAdapter::FF::AlphaGradient::read(precice::span<double> buffer, const unsigned int dim)
 {
     int bufferIndex = 0;
 

--- a/FF/AlphaGradient.H
+++ b/FF/AlphaGradient.H
@@ -25,10 +25,10 @@ public:
         const std::string nameAlpha);
 
     //- Write the Alpha gradient values into the buffer
-    std::size_t write(double* buffer, bool meshConnectivity, const unsigned int dim) final;
+    std::size_t write(precice::span<double> buffer, bool meshConnectivity, const unsigned int dim) final;
 
     //- Read the Alpha gradient values from the buffer
-    void read(double* buffer, const unsigned int dim) final;
+    void read(precice::span<double> buffer, const unsigned int dim) final;
 
     bool isLocationTypeSupported(const bool meshConnectivity) const final;
 

--- a/FF/DragForce.C
+++ b/FF/DragForce.C
@@ -28,7 +28,7 @@ preciceAdapter::FF::DragForce::DragForce(
     dataType_ = vector;
 }
 
-std::size_t preciceAdapter::FF::DragForce::write(double* buffer, bool meshConnectivity, const unsigned int dim)
+std::size_t preciceAdapter::FF::DragForce::write(precice::span<double> buffer, bool meshConnectivity, const unsigned int dim)
 {
     int bufferIndex = 0;
 
@@ -106,7 +106,7 @@ std::size_t preciceAdapter::FF::DragForce::write(double* buffer, bool meshConnec
     return bufferIndex;
 }
 
-void preciceAdapter::FF::DragForce::read(double* buffer, const unsigned int dim)
+void preciceAdapter::FF::DragForce::read(precice::span<double> buffer, const unsigned int dim)
 {
     int bufferIndex = 0;
 

--- a/FF/DragForce.H
+++ b/FF/DragForce.H
@@ -26,10 +26,10 @@ public:
         const std::string nameFd);
 
     //- Write the velocity values into the buffer
-    std::size_t write(double* buffer, bool meshConnectivity, const unsigned int dim) final;
+    std::size_t write(precice::span<double> buffer, bool meshConnectivity, const unsigned int dim) final;
 
     //- Read the velocity values from the buffer
-    void read(double* buffer, const unsigned int dim) final;
+    void read(precice::span<double> buffer, const unsigned int dim) final;
 
     bool isLocationTypeSupported(const bool meshConnectivity) const final;
 

--- a/FF/ExplicitMomentum.C
+++ b/FF/ExplicitMomentum.C
@@ -28,7 +28,7 @@ preciceAdapter::FF::ExplicitMomentum::ExplicitMomentum(
     dataType_ = vector;
 }
 
-std::size_t preciceAdapter::FF::ExplicitMomentum::write(double* buffer, bool meshConnectivity, const unsigned int dim)
+std::size_t preciceAdapter::FF::ExplicitMomentum::write(precice::span<double> buffer, bool meshConnectivity, const unsigned int dim)
 {
     int bufferIndex = 0;
 
@@ -106,7 +106,7 @@ std::size_t preciceAdapter::FF::ExplicitMomentum::write(double* buffer, bool mes
     return bufferIndex;
 }
 
-void preciceAdapter::FF::ExplicitMomentum::read(double* buffer, const unsigned int dim)
+void preciceAdapter::FF::ExplicitMomentum::read(precice::span<double> buffer, const unsigned int dim)
 {
     int bufferIndex = 0;
 

--- a/FF/ExplicitMomentum.H
+++ b/FF/ExplicitMomentum.H
@@ -26,10 +26,10 @@ public:
         const std::string nameExplicitMomentum);
 
     //- Write the velocity values into the buffer
-    std::size_t write(double* buffer, bool meshConnectivity, const unsigned int dim) final;
+    std::size_t write(precice::span<double> buffer, bool meshConnectivity, const unsigned int dim) final;
 
     //- Read the velocity values from the buffer
-    void read(double* buffer, const unsigned int dim) final;
+    void read(precice::span<double> buffer, const unsigned int dim) final;
 
     bool isLocationTypeSupported(const bool meshConnectivity) const final;
 

--- a/FF/ImplicitMomentum.C
+++ b/FF/ImplicitMomentum.C
@@ -28,7 +28,7 @@ preciceAdapter::FF::ImplicitMomentum::ImplicitMomentum(
     dataType_ = scalar;
 }
 
-std::size_t preciceAdapter::FF::ImplicitMomentum::write(double* buffer, bool meshConnectivity, const unsigned int dim)
+std::size_t preciceAdapter::FF::ImplicitMomentum::write(precice::span<double> buffer, bool meshConnectivity, const unsigned int dim)
 {
     int bufferIndex = 0;
 
@@ -74,7 +74,7 @@ std::size_t preciceAdapter::FF::ImplicitMomentum::write(double* buffer, bool mes
     return bufferIndex;
 }
 
-void preciceAdapter::FF::ImplicitMomentum::read(double* buffer, const unsigned int dim)
+void preciceAdapter::FF::ImplicitMomentum::read(precice::span<double> buffer, const unsigned int dim)
 {
     int bufferIndex = 0;
 

--- a/FF/ImplicitMomentum.H
+++ b/FF/ImplicitMomentum.H
@@ -26,10 +26,10 @@ public:
         const std::string nameImplicitMomentum);
 
     //- Write the velocity values into the buffer
-    std::size_t write(double* buffer, bool meshConnectivity, const unsigned int dim) final;
+    std::size_t write(precice::span<double> buffer, bool meshConnectivity, const unsigned int dim) final;
 
     //- Read the velocity values from the buffer
-    void read(double* buffer, const unsigned int dim) final;
+    void read(precice::span<double> buffer, const unsigned int dim) final;
 
     bool isLocationTypeSupported(const bool meshConnectivity) const final;
 

--- a/FF/Phi.C
+++ b/FF/Phi.C
@@ -12,7 +12,7 @@ preciceAdapter::FF::Phi::Phi(
     dataType_ = scalar;
 }
 
-std::size_t preciceAdapter::FF::Phi::write(double* buffer, bool meshConnectivity, const unsigned int dim)
+std::size_t preciceAdapter::FF::Phi::write(precice::span<double> buffer, bool meshConnectivity, const unsigned int dim)
 {
     int bufferIndex = 0;
 
@@ -32,7 +32,7 @@ std::size_t preciceAdapter::FF::Phi::write(double* buffer, bool meshConnectivity
     return bufferIndex;
 }
 
-void preciceAdapter::FF::Phi::read(double* buffer, const unsigned int dim)
+void preciceAdapter::FF::Phi::read(precice::span<double> buffer, const unsigned int dim)
 {
     int bufferIndex = 0;
 

--- a/FF/Phi.H
+++ b/FF/Phi.H
@@ -25,10 +25,10 @@ public:
         const std::string namePhi);
 
     //- Write the Phi values into the buffer
-    std::size_t write(double* buffer, bool meshConnectivity, const unsigned int dim) final;
+    std::size_t write(precice::span<double> buffer, bool meshConnectivity, const unsigned int dim) final;
 
     //- Read the Phi values from the buffer
-    void read(double* buffer, const unsigned int dim) final;
+    void read(precice::span<double> buffer, const unsigned int dim) final;
 
     bool isLocationTypeSupported(const bool meshConnectivity) const final;
 

--- a/FF/Pressure.C
+++ b/FF/Pressure.C
@@ -13,7 +13,7 @@ preciceAdapter::FF::Pressure::Pressure(
     dataType_ = scalar;
 }
 
-std::size_t preciceAdapter::FF::Pressure::write(double* buffer, bool meshConnectivity, const unsigned int dim)
+std::size_t preciceAdapter::FF::Pressure::write(precice::span<double> buffer, bool meshConnectivity, const unsigned int dim)
 {
     int bufferIndex = 0;
 
@@ -58,7 +58,7 @@ std::size_t preciceAdapter::FF::Pressure::write(double* buffer, bool meshConnect
     return bufferIndex;
 }
 
-void preciceAdapter::FF::Pressure::read(double* buffer, const unsigned int dim)
+void preciceAdapter::FF::Pressure::read(precice::span<double> buffer, const unsigned int dim)
 {
     int bufferIndex = 0;
 

--- a/FF/Pressure.H
+++ b/FF/Pressure.H
@@ -26,10 +26,10 @@ public:
         const std::string nameP);
 
     //- Write the pressure values into the buffer
-    std::size_t write(double* buffer, bool meshConnectivity, const unsigned int dim) final;
+    std::size_t write(precice::span<double> buffer, bool meshConnectivity, const unsigned int dim) final;
 
     //- Read the pressure values from the buffer
-    void read(double* buffer, const unsigned int dim) final;
+    void read(precice::span<double> buffer, const unsigned int dim) final;
 
     bool isLocationTypeSupported(const bool meshConnectivity) const final;
 

--- a/FF/PressureGradient.C
+++ b/FF/PressureGradient.C
@@ -12,7 +12,7 @@ preciceAdapter::FF::PressureGradient::PressureGradient(
     dataType_ = scalar;
 }
 
-std::size_t preciceAdapter::FF::PressureGradient::write(double* buffer, bool meshConnectivity, const unsigned int dim)
+std::size_t preciceAdapter::FF::PressureGradient::write(precice::span<double> buffer, bool meshConnectivity, const unsigned int dim)
 {
     int bufferIndex = 0;
 
@@ -36,7 +36,7 @@ std::size_t preciceAdapter::FF::PressureGradient::write(double* buffer, bool mes
     return bufferIndex;
 }
 
-void preciceAdapter::FF::PressureGradient::read(double* buffer, const unsigned int dim)
+void preciceAdapter::FF::PressureGradient::read(precice::span<double> buffer, const unsigned int dim)
 {
     int bufferIndex = 0;
 

--- a/FF/PressureGradient.H
+++ b/FF/PressureGradient.H
@@ -25,10 +25,10 @@ public:
         const std::string nameP);
 
     //- Write the pressure gradient values into the buffer
-    std::size_t write(double* buffer, bool meshConnectivity, const unsigned int dim) override;
+    std::size_t write(precice::span<double> buffer, bool meshConnectivity, const unsigned int dim) override;
 
     //- Read the pressure gradient values from the buffer
-    void read(double* buffer, const unsigned int dim) override;
+    void read(precice::span<double> buffer, const unsigned int dim) override;
 
     bool isLocationTypeSupported(const bool meshConnectivity) const final;
 

--- a/FF/PressureGradientFull.C
+++ b/FF/PressureGradientFull.C
@@ -19,7 +19,7 @@ preciceAdapter::FF::PressureGradientFull::PressureGradientFull(
     dataType_ = vector;
 }
 
-std::size_t preciceAdapter::FF::PressureGradientFull::write(double* buffer, bool meshConnectivity, const unsigned int dim)
+std::size_t preciceAdapter::FF::PressureGradientFull::write(precice::span<double> buffer, bool meshConnectivity, const unsigned int dim)
 {
     int bufferIndex = 0;
     gradP_ = fvc::grad(*p_);
@@ -96,7 +96,7 @@ std::size_t preciceAdapter::FF::PressureGradientFull::write(double* buffer, bool
     return bufferIndex;
 }
 
-void preciceAdapter::FF::PressureGradientFull::read(double* buffer, const unsigned int dim)
+void preciceAdapter::FF::PressureGradientFull::read(precice::span<double> buffer, const unsigned int dim)
 {
     int bufferIndex = 0;
 

--- a/FF/PressureGradientFull.H
+++ b/FF/PressureGradientFull.H
@@ -28,10 +28,10 @@ public:
         const std::string nameP);
 
     //- Write the pressure gradient values into the buffer
-    std::size_t write(double* buffer, bool meshConnectivity, const unsigned int dim) override;
+    std::size_t write(precice::span<double> buffer, bool meshConnectivity, const unsigned int dim) override;
 
     //- Read the pressure gradient values from the buffer
-    void read(double* buffer, const unsigned int dim) override;
+    void read(precice::span<double> buffer, const unsigned int dim) override;
 
     bool isLocationTypeSupported(const bool meshConnectivity) const final;
 

--- a/FF/Temperature.C
+++ b/FF/Temperature.C
@@ -12,7 +12,7 @@ preciceAdapter::FF::Temperature::Temperature(
     dataType_ = scalar;
 }
 
-std::size_t preciceAdapter::FF::Temperature::write(double* buffer, bool meshConnectivity, const unsigned int dim)
+std::size_t preciceAdapter::FF::Temperature::write(precice::span<double> buffer, bool meshConnectivity, const unsigned int dim)
 {
     int bufferIndex = 0;
 
@@ -34,7 +34,7 @@ std::size_t preciceAdapter::FF::Temperature::write(double* buffer, bool meshConn
     return bufferIndex;
 }
 
-void preciceAdapter::FF::Temperature::read(double* buffer, const unsigned int dim)
+void preciceAdapter::FF::Temperature::read(precice::span<double> buffer, const unsigned int dim)
 {
     int bufferIndex = 0;
 

--- a/FF/Temperature.H
+++ b/FF/Temperature.H
@@ -25,10 +25,10 @@ public:
         const std::string nameT);
 
     //- Write the temperature values into the buffer
-    std::size_t write(double* buffer, bool meshConnectivity, const unsigned int dim) override;
+    std::size_t write(precice::span<double> buffer, bool meshConnectivity, const unsigned int dim) override;
 
     //- Read the temperature values from the buffer
-    void read(double* buffer, const unsigned int dim) override;
+    void read(precice::span<double> buffer, const unsigned int dim) override;
 
     bool isLocationTypeSupported(const bool meshConnectivity) const override;
 

--- a/FF/TemperatureGradient.C
+++ b/FF/TemperatureGradient.C
@@ -13,7 +13,7 @@ preciceAdapter::FF::TemperatureGradient::TemperatureGradient(
     dataType_ = scalar;
 }
 
-std::size_t preciceAdapter::FF::TemperatureGradient::write(double* buffer, bool meshConnectivity, const unsigned int dim)
+std::size_t preciceAdapter::FF::TemperatureGradient::write(precice::span<double> buffer, bool meshConnectivity, const unsigned int dim)
 {
     int bufferIndex = 0;
 
@@ -37,7 +37,7 @@ std::size_t preciceAdapter::FF::TemperatureGradient::write(double* buffer, bool 
     return bufferIndex;
 }
 
-void preciceAdapter::FF::TemperatureGradient::read(double* buffer, const unsigned int dim)
+void preciceAdapter::FF::TemperatureGradient::read(precice::span<double> buffer, const unsigned int dim)
 {
     int bufferIndex = 0;
 

--- a/FF/TemperatureGradient.H
+++ b/FF/TemperatureGradient.H
@@ -25,10 +25,10 @@ public:
         const std::string nameT);
 
     //- Write the Temperature gradient values into the buffer
-    std::size_t write(double* buffer, bool meshConnectivity, const unsigned int dim) final;
+    std::size_t write(precice::span<double> buffer, bool meshConnectivity, const unsigned int dim) final;
 
     //- Read the Temperature gradient values from the buffer
-    void read(double* buffer, const unsigned int dim) final;
+    void read(precice::span<double> buffer, const unsigned int dim) final;
 
     bool isLocationTypeSupported(const bool meshConnectivity) const final;
 

--- a/FF/Velocity.C
+++ b/FF/Velocity.C
@@ -33,7 +33,7 @@ preciceAdapter::FF::Velocity::Velocity(
     dataType_ = vector;
 }
 
-std::size_t preciceAdapter::FF::Velocity::write(double* buffer, bool meshConnectivity, const unsigned int dim)
+std::size_t preciceAdapter::FF::Velocity::write(precice::span<double> buffer, bool meshConnectivity, const unsigned int dim)
 {
     int bufferIndex = 0;
 
@@ -120,7 +120,7 @@ std::size_t preciceAdapter::FF::Velocity::write(double* buffer, bool meshConnect
     return bufferIndex;
 }
 
-void preciceAdapter::FF::Velocity::read(double* buffer, const unsigned int dim)
+void preciceAdapter::FF::Velocity::read(precice::span<double> buffer, const unsigned int dim)
 {
     int bufferIndex = 0;
 

--- a/FF/Velocity.H
+++ b/FF/Velocity.H
@@ -32,10 +32,10 @@ public:
         bool fluxCorrection = false);
 
     //- Write the velocity values into the buffer
-    std::size_t write(double* buffer, bool meshConnectivity, const unsigned int dim) final;
+    std::size_t write(precice::span<double> buffer, bool meshConnectivity, const unsigned int dim) final;
 
     //- Read the velocity values from the buffer
-    void read(double* buffer, const unsigned int dim) final;
+    void read(precice::span<double> buffer, const unsigned int dim) final;
 
     bool isLocationTypeSupported(const bool meshConnectivity) const final;
 

--- a/FF/VelocityGradient.C
+++ b/FF/VelocityGradient.C
@@ -13,7 +13,7 @@ preciceAdapter::FF::VelocityGradient::VelocityGradient(
     dataType_ = vector;
 }
 
-std::size_t preciceAdapter::FF::VelocityGradient::write(double* buffer, bool meshConnectivity, const unsigned int dim)
+std::size_t preciceAdapter::FF::VelocityGradient::write(precice::span<double> buffer, bool meshConnectivity, const unsigned int dim)
 {
     int bufferIndex = 0;
 
@@ -49,7 +49,7 @@ std::size_t preciceAdapter::FF::VelocityGradient::write(double* buffer, bool mes
     return bufferIndex;
 }
 
-void preciceAdapter::FF::VelocityGradient::read(double* buffer, const unsigned int dim)
+void preciceAdapter::FF::VelocityGradient::read(precice::span<double> buffer, const unsigned int dim)
 {
     int bufferIndex = 0;
 

--- a/FF/VelocityGradient.H
+++ b/FF/VelocityGradient.H
@@ -25,10 +25,10 @@ public:
         const std::string nameU);
 
     //- Write the velocity gradient values into the buffer
-    std::size_t write(double* buffer, bool meshConnectivity, const unsigned int dim) final;
+    std::size_t write(precice::span<double> buffer, bool meshConnectivity, const unsigned int dim) final;
 
     //- Read the velocity gradient values from the buffer
-    void read(double* buffer, const unsigned int dim) final;
+    void read(precice::span<double> buffer, const unsigned int dim) final;
 
     bool isLocationTypeSupported(const bool meshConnectivity) const final;
 

--- a/FSI/Displacement.C
+++ b/FSI/Displacement.C
@@ -36,7 +36,7 @@ void preciceAdapter::FSI::Displacement::initialize()
 }
 
 
-std::size_t preciceAdapter::FSI::Displacement::write(double* buffer, bool meshConnectivity, const unsigned int dim)
+std::size_t preciceAdapter::FSI::Displacement::write(precice::span<double> buffer, bool meshConnectivity, const unsigned int dim)
 {
     /* TODO: Implement
      * We need two nested for-loops for each patch,
@@ -91,7 +91,7 @@ std::size_t preciceAdapter::FSI::Displacement::write(double* buffer, bool meshCo
 
 
 // return the displacement to use later in the velocity?
-void preciceAdapter::FSI::Displacement::read(double* buffer, const unsigned int dim)
+void preciceAdapter::FSI::Displacement::read(precice::span<double> buffer, const unsigned int dim)
 {
     int bufferIndex = 0;
     for (unsigned int j = 0; j < patchIDs_.size(); j++)

--- a/FSI/Displacement.H
+++ b/FSI/Displacement.H
@@ -36,10 +36,10 @@ public:
         const std::string nameCellDisplacement);
 
     //- Write the displacement values into the buffer
-    std::size_t write(double* buffer, bool meshConnectivity, const unsigned int dim) final;
+    std::size_t write(precice::span<double> buffer, bool meshConnectivity, const unsigned int dim) final;
 
     //- Read the displacement values from the buffer
-    void read(double* buffer, const unsigned int dim) final;
+    void read(precice::span<double> buffer, const unsigned int dim) final;
 
     bool isLocationTypeSupported(const bool meshConnectivity) const final;
 

--- a/FSI/DisplacementDelta.C
+++ b/FSI/DisplacementDelta.C
@@ -34,7 +34,7 @@ void preciceAdapter::FSI::DisplacementDelta::initialize()
 }
 
 
-std::size_t preciceAdapter::FSI::DisplacementDelta::write(double* buffer, bool meshConnectivity, const unsigned int dim)
+std::size_t preciceAdapter::FSI::DisplacementDelta::write(precice::span<double> buffer, bool meshConnectivity, const unsigned int dim)
 {
     /* TODO: Implement
      * We need two nested for-loops for each patch,
@@ -46,7 +46,7 @@ std::size_t preciceAdapter::FSI::DisplacementDelta::write(double* buffer, bool m
 }
 
 // return the displacement to use later in the velocity?
-void preciceAdapter::FSI::DisplacementDelta::read(double* buffer, const unsigned int dim)
+void preciceAdapter::FSI::DisplacementDelta::read(precice::span<double> buffer, const unsigned int dim)
 {
     int bufferIndex = 0;
     for (unsigned int j = 0; j < patchIDs_.size(); j++)

--- a/FSI/DisplacementDelta.H
+++ b/FSI/DisplacementDelta.H
@@ -36,10 +36,10 @@ public:
         const std::string nameCellDisplacement);
 
     //- Write the displacementDelta values into the buffer
-    std::size_t write(double* buffer, bool meshConnectivity, const unsigned int dim) final;
+    std::size_t write(precice::span<double> buffer, bool meshConnectivity, const unsigned int dim) final;
 
     //- Read the displacementDelta values from the buffer
-    void read(double* buffer, const unsigned int dim) final;
+    void read(precice::span<double> buffer, const unsigned int dim) final;
 
     bool isLocationTypeSupported(const bool meshConnectivity) const final;
 

--- a/FSI/Force.C
+++ b/FSI/Force.C
@@ -36,12 +36,12 @@ preciceAdapter::FSI::Force::Force(
     }
 }
 
-std::size_t preciceAdapter::FSI::Force::write(double* buffer, bool meshConnectivity, const unsigned int dim)
+std::size_t preciceAdapter::FSI::Force::write(precice::span<double> buffer, bool meshConnectivity, const unsigned int dim)
 {
     return this->writeToBuffer(buffer, *Force_, dim);
 }
 
-void preciceAdapter::FSI::Force::read(double* buffer, const unsigned int dim)
+void preciceAdapter::FSI::Force::read(precice::span<double> buffer, const unsigned int dim)
 {
     // Copy the force field from the buffer to OpenFOAM
 

--- a/FSI/Force.H
+++ b/FSI/Force.H
@@ -26,10 +26,10 @@ public:
         const std::string nameForce);
 
     //- Write the forces values into the buffer
-    std::size_t write(double* buffer, bool meshConnectivity, const unsigned int dim) final;
+    std::size_t write(precice::span<double> buffer, bool meshConnectivity, const unsigned int dim) final;
 
     //- Read the forces values from the buffer
-    void read(double* buffer, const unsigned int dim) final;
+    void read(precice::span<double> buffer, const unsigned int dim) final;
 
     bool isLocationTypeSupported(const bool meshConnectivity) const final;
 

--- a/FSI/ForceBase.C
+++ b/FSI/ForceBase.C
@@ -123,7 +123,7 @@ Foam::tmp<Foam::volScalarField> preciceAdapter::FSI::ForceBase::mu() const
     }
 }
 
-std::size_t preciceAdapter::FSI::ForceBase::writeToBuffer(double* buffer,
+std::size_t preciceAdapter::FSI::ForceBase::writeToBuffer(precice::span<double> buffer,
                                                           volVectorField& forceField,
                                                           const unsigned int dim) const
 {
@@ -181,7 +181,7 @@ std::size_t preciceAdapter::FSI::ForceBase::writeToBuffer(double* buffer,
     return bufferIndex;
 }
 
-void preciceAdapter::FSI::ForceBase::readFromBuffer(double* buffer) const
+void preciceAdapter::FSI::ForceBase::readFromBuffer(precice::span<double> buffer) const
 {
     /* TODO: Implement (issue https://github.com/precice/openfoam-adapter/issues/240)
      * We need two nested for-loops for each patch,

--- a/FSI/ForceBase.H
+++ b/FSI/ForceBase.H
@@ -39,11 +39,11 @@ public:
         const Foam::fvMesh& mesh,
         const std::string solverType);
 
-    std::size_t writeToBuffer(double* buffer,
+    std::size_t writeToBuffer(precice::span<double> buffer,
                               Foam::volVectorField& forceField,
                               const unsigned int dim) const;
 
-    void readFromBuffer(double* buffer) const;
+    void readFromBuffer(precice::span<double> buffer) const;
 
     virtual Foam::tmp<Foam::vectorField> getFaceVectors(const unsigned int patchID) const = 0;
 };

--- a/FSI/Stress.C
+++ b/FSI/Stress.C
@@ -21,12 +21,12 @@ preciceAdapter::FSI::Stress::Stress(
             Foam::vector::zero));
 }
 
-std::size_t preciceAdapter::FSI::Stress::write(double* buffer, bool meshConnectivity, const unsigned int dim)
+std::size_t preciceAdapter::FSI::Stress::write(precice::span<double> buffer, bool meshConnectivity, const unsigned int dim)
 {
     return this->writeToBuffer(buffer, *Stress_, dim);
 }
 
-void preciceAdapter::FSI::Stress::read(double* buffer, const unsigned int dim)
+void preciceAdapter::FSI::Stress::read(precice::span<double> buffer, const unsigned int dim)
 {
     this->readFromBuffer(buffer);
 }

--- a/FSI/Stress.H
+++ b/FSI/Stress.H
@@ -27,10 +27,10 @@ public:
         const std::string solverType);
 
     //- Write the stress values into the buffer
-    std::size_t write(double* buffer, bool meshConnectivity, const unsigned int dim) final;
+    std::size_t write(precice::span<double> buffer, bool meshConnectivity, const unsigned int dim) final;
 
     //- Read the stress values from the buffer
-    void read(double* buffer, const unsigned int dim) final;
+    void read(precice::span<double> buffer, const unsigned int dim) final;
 
     bool isLocationTypeSupported(const bool meshConnectivity) const final;
 

--- a/Interface.C
+++ b/Interface.C
@@ -545,15 +545,16 @@ void preciceAdapter::Interface::readCouplingData(double relativeReadTime)
         // We could add a sanity check here
         // nReadData == vertexIDs_.size() * (1 + (dim_ - 1) * static_cast<int>(couplingDataReader->hasVectorData()));
 
+        precice::span<double> dataSpanRead {dataBuffer_.data(), nReadData};
         precice_.readData(
             meshName_,
             couplingDataReader->dataName(),
             vertexIDs_,
             relativeReadTime,
-            {dataBuffer_.data(), nReadData});
+            dataSpanRead);
 
         // Read the received data from the buffer
-        couplingDataReader->read(dataBuffer_.data(), dim_);
+        couplingDataReader->read(dataSpanRead, dim_);
     }
 }
 
@@ -571,14 +572,17 @@ void preciceAdapter::Interface::writeCouplingData()
             couplingDataWriter = couplingDataWriters_.at(i);
 
         // Write the data into the adapter's buffer
-        auto nWrittenData = couplingDataWriter->write(dataBuffer_.data(), meshConnectivity_, dim_);
+        precice::span<double> dataSpan {dataBuffer_};
+        auto nWrittenData = couplingDataWriter->write(dataSpan, meshConnectivity_, dim_);
+
+        precice::span<double> dataSpanWritten {dataBuffer_.data(), nWrittenData};
 
         // Make preCICE write vector or scalar data
         precice_.writeData(
             meshName_,
             couplingDataWriter->dataName(),
             vertexIDs_,
-            {dataBuffer_.data(), nWrittenData});
+            dataSpanWritten);
     }
     // }
 }

--- a/changelog-entries/397.md
+++ b/changelog-entries/397.md
@@ -1,0 +1,1 @@
+- Change function signatures of CouplingDataUser::Read and ::Write. Modernize buffer to be a span instead of a pointer [#397](https://github.com/precice/openfoam-adapter/pull/397).

--- a/module-generic/ReadWrite.C
+++ b/module-generic/ReadWrite.C
@@ -38,7 +38,7 @@ void preciceAdapter::Generic::ScalarFieldCoupler::initialize()
 }
 
 
-std::size_t preciceAdapter::Generic::ScalarFieldCoupler::write(double* buffer, bool meshConnectivity, const unsigned int dim)
+std::size_t preciceAdapter::Generic::ScalarFieldCoupler::write(precice::span<double> buffer, bool meshConnectivity, const unsigned int dim)
 {
     int bufferIndex = 0;
 
@@ -121,7 +121,7 @@ std::size_t preciceAdapter::Generic::ScalarFieldCoupler::write(double* buffer, b
     return bufferIndex;
 }
 
-void preciceAdapter::Generic::ScalarFieldCoupler::read(double* buffer, const unsigned int dim)
+void preciceAdapter::Generic::ScalarFieldCoupler::read(precice::span<double> buffer, const unsigned int dim)
 {
     int bufferIndex = 0;
 
@@ -224,7 +224,7 @@ void preciceAdapter::Generic::VectorFieldCoupler::initialize()
     }
 }
 
-std::size_t preciceAdapter::Generic::VectorFieldCoupler::write(double* buffer, bool meshConnectivity, const unsigned int dim)
+std::size_t preciceAdapter::Generic::VectorFieldCoupler::write(precice::span<double> buffer, bool meshConnectivity, const unsigned int dim)
 {
     int bufferIndex = 0;
 
@@ -296,7 +296,7 @@ std::size_t preciceAdapter::Generic::VectorFieldCoupler::write(double* buffer, b
     return bufferIndex;
 }
 
-void preciceAdapter::Generic::VectorFieldCoupler::read(double* buffer, const unsigned int dim)
+void preciceAdapter::Generic::VectorFieldCoupler::read(precice::span<double> buffer, const unsigned int dim)
 {
     int bufferIndex = 0;
 

--- a/module-generic/ReadWrite.H
+++ b/module-generic/ReadWrite.H
@@ -23,8 +23,8 @@ public:
     ScalarFieldCoupler(const Foam::fvMesh& mesh, const preciceAdapter::FieldConfig& FieldConfig);
 
     void initialize();
-    std::size_t write(double* buffer, bool meshConnectivity, const unsigned int dim);
-    void read(double* buffer, const unsigned int dim);
+    std::size_t write(precice::span<double> buffer, bool meshConnectivity, const unsigned int dim);
+    void read(precice::span<double> buffer, const unsigned int dim);
     bool isLocationTypeSupported(const bool meshConnectivity) const;
     std::string getDataName() const;
 
@@ -42,8 +42,8 @@ public:
     VectorFieldCoupler(const Foam::fvMesh& mesh, const preciceAdapter::FieldConfig& FieldConfig);
 
     void initialize();
-    std::size_t write(double* buffer, bool meshConnectivity, const unsigned int dim);
-    void read(double* buffer, const unsigned int dim);
+    std::size_t write(precice::span<double> buffer, bool meshConnectivity, const unsigned int dim);
+    void read(precice::span<double> buffer, const unsigned int dim);
     bool isLocationTypeSupported(const bool meshConnectivity) const;
     std::string getDataName() const;
 


### PR DESCRIPTION
While we're on the topic of modernizing the codebase, I found it not too difficult to replace all instances of `double* buffer` with `precice::span<double> dataBuffer`. Since preCICE implemented/backported its own version of `std::span` (since preCICE version 3.xx?), I've decided to use that instead, because `std:span` was only implemented in C++ 20.

To implement this change I had to import the preCICE header in `CouplingDataUser.H` and change the function signature of `CouplingDataUser::write` and `CouplingDataUser::read`. Since this is a base class, I've had to make changes to all the derived classes in all of the modules. 

<!-- Thank you for your contribution! Have a look at the file `CONTRIBUTING.md` for a few hints and guidelines. -->

TODO list:

- [ ] I updated the documentation in `docs/`
- [x] I added a changelog entry in `changelog-entries/` (create directory if missing)
