### PR TITLE
Implement mixed boundary condition (Robin) in Generic module

### DIFF
--- a/changelog-entries/400.md
+++ b/changelog-entries/400.md
@@ -1,0 +1,1 @@
+- Add support for Robin or mixed boundary condition in the Generic module. [#400](https://github.com/precice/openfoam-adapter/pull/400).

--- a/docs/config.md
+++ b/docs/config.md
@@ -302,7 +302,7 @@ Explicitly setting `locations volumeCenters;` in preciceDict is required for vol
 
 When reading on the OpenFOAM side, the Generic module automatically detects the boundary condition type of the coupled patch to apply the received data. The boundary condition must be respected, therefore the data received is applied either as a `fixedValue` or `fixedGradient` boundary condition, determined by the type set in the `0/` files.
 
-Additionally, the Robin or mixed boundary condition is now supported for surface coupling. The OpenFOAM boundary type `mixed` must be set for the coupled patch in the `0/` files like so:
+Additionally, the Robin or mixed boundary condition is now supported for scalar surface coupling. The OpenFOAM boundary type `mixed` or `mixedCoded` must be set for the coupled patch in the `0/` files like so:
 
 ```cpp
 // File 0/T
@@ -318,7 +318,11 @@ boundaryField
 }
 ```
 
-Any of the three fields `refValue`, `refGradient`, and `valueFraction` can be written or read using the adapter (the initial values will be overwritten by the adapter). To do so, specify the `operation` for each coupling data in `preciceDict` as `ref-value`, `ref-gradient`, or `value-fraction`. Be careful when using the `value-fraction` operation, as it is not a physical quantity and must be within the range of (0, 1). Please note that if you intend to use the `mixed` boundary condition for a heat transfer problem, the `valueFraction` is not the same as the heat transfer coefficient and it's not possible to explicitly set the heat transfer coefficient as a parameter.
+Any of the three fields `refValue`, `refGradient`, and `valueFraction` can be read from another participant (the initial values will be overwritten by the adapter). To do so, specify the `operation` for each coupling data in `preciceDict` as `ref-value`, `ref-gradient`, or `value-fraction`. Be careful when using the `value-fraction` operation, as it is not a physical quantity and must be within the range of [0, 1].
+
+These three operations are only supported for the read side. To write coupling data from a mixed boundary patch, just use the standard `value` or `surface-normal-gradient` operation. The `valueFraction` field of the mixed boundary condition is not exposed by the adapter for writing.
+
+Please note that if you intend to use the `mixed` boundary condition for a heat transfer problem, the `valueFraction` is not the same as the heat transfer coefficient and it's not possible to explicitly set the heat transfer coefficient as a parameter.
 
 Limitations:
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -318,7 +318,7 @@ boundaryField
 }
 ```
 
-Any of the three fields `refValue`, `refGradient`, and `valueFraction` can be written or read using the adapter (the initial values will be overwritten by the adapter in case of write). To do so, specify the `operation` for each coupling data in `preciceDict` as `ref-value`, `ref-gradient`, or `value-fraction`. Be careful when using the `value-fraction` operation, as it is not a physical quantity and must be within the range of (0, 1). Please note that if you intend to use the `mixed` boundary condition for a heat transfer problem, the `valueFraction` is not the same as the heat transfer coefficient and it's not possible to explictly set the heat transfer coefficient as a parameter.
+Any of the three fields `refValue`, `refGradient`, and `valueFraction` can be written or read using the adapter (the initial values will be overwritten by the adapter). To do so, specify the `operation` for each coupling data in `preciceDict` as `ref-value`, `ref-gradient`, or `value-fraction`. Be careful when using the `value-fraction` operation, as it is not a physical quantity and must be within the range of (0, 1). Please note that if you intend to use the `mixed` boundary condition for a heat transfer problem, the `valueFraction` is not the same as the heat transfer coefficient and it's not possible to explicitly set the heat transfer coefficient as a parameter.
 
 Limitations:
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -318,7 +318,7 @@ boundaryField
 }
 ```
 
-Any of the three fields `refValue`, `refGradient`, and `valueFraction` can be written or read using the adapter (the initial values will be overwritten by the adapter in case of write). To do so, specify the `operation` for each coupling data in `preciceDict` as `ref-value`, `ref-gradient`, or `value-fraction`. Be careful when using the `value-fraction` operation, as it is not a physical quantity and must be within the range of (0, 1).
+Any of the three fields `refValue`, `refGradient`, and `valueFraction` can be written or read using the adapter (the initial values will be overwritten by the adapter in case of write). To do so, specify the `operation` for each coupling data in `preciceDict` as `ref-value`, `ref-gradient`, or `value-fraction`. Be careful when using the `value-fraction` operation, as it is not a physical quantity and must be within the range of (0, 1). Please note that if you intend to use the `mixed` boundary condition for a heat transfer problem, the `valueFraction` is not the same as the heat transfer coefficient and it's not possible to explictly set the heat transfer coefficient as a parameter.
 
 Limitations:
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -302,6 +302,24 @@ Explicitly setting `locations volumeCenters;` in preciceDict is required for vol
 
 When reading on the OpenFOAM side, the Generic module automatically detects the boundary condition type of the coupled patch to apply the received data. The boundary condition must be respected, therefore the data received is applied either as a `fixedValue` or `fixedGradient` boundary condition, determined by the type set in the `0/` files.
 
+Additionally, the Robin or mixed boundary condition is now supported for surface coupling. The OpenFOAM boundary type `mixed` must be set for the coupled patch in the `0/` files like so:
+
+```cpp
+// File 0/T
+boundaryField
+{
+    interface
+    {
+        type            mixed;
+        refValue        uniform 1;
+        refGradient     uniform 1;
+        valueFraction   uniform 0.5;
+    }
+}
+```
+
+Any of the three fields `refValue`, `refGradient`, and `valueFraction` can be written or read using the adapter (the initial values will be overwritten by the adapter in case of write). To do so, specify the `operation` for each coupling data in `preciceDict` as `ref-value`, `ref-gradient`, or `value-fraction`. Be careful when using the `value-fraction` operation, as it is not a physical quantity and must be within the range of (0, 1).
+
 Limitations:
 
 - The operation `gradient` is currently only supported for writing scalar fields (resulting to a vector field).

--- a/module-generic/ReadWrite.C
+++ b/module-generic/ReadWrite.C
@@ -37,11 +37,11 @@ void preciceAdapter::Generic::ScalarFieldCoupler::initialize()
         adapterInfo("Generic module: The gradient operation is not yet supported for scalar fields. Maybe you meant surface-normal-gradient?", "error");
     }
 
-    if (fieldConfig_.operation == "ref-value" || fieldConfig_.operation == "ref-gradient")
+    if (fieldConfig_.operation == "ref-value" || fieldConfig_.operation == "ref-gradient" || fieldConfig_.operation == "value-fraction")
     {
         if (this->locationType_ != LocationType::faceCenters)
         {
-            adapterInfo("Generic module: Robin boundary conditions (ref-value and ref-gradient operations) are supported only for surface locations (faceCenters).", "error");
+            adapterInfo("Generic module: Robin boundary conditions (ref-value, ref-gradient, and value-fraction operations) are supported only for surface locations (faceCenters).", "error");
         }
     }
 }
@@ -197,6 +197,13 @@ void preciceAdapter::Generic::ScalarFieldCoupler::read(double* buffer, const uns
                 forAll(boundaryPatch, i)
                 {
                     boundaryPatch.refGrad()[i] = buffer[bufferIndex++];
+                }
+            }
+            else if (fieldConfig_.operation == "value-fraction")
+            {
+                forAll(boundaryPatch, i)
+                {
+                    boundaryPatch.valueFraction()[i] = buffer[bufferIndex++];
                 }
             }
         }

--- a/module-generic/ReadWrite.C
+++ b/module-generic/ReadWrite.C
@@ -280,6 +280,8 @@ void preciceAdapter::Generic::ScalarFieldCoupler::read(double* buffer, const uns
         else if (isA<mixedFvPatchScalarField>(bc))
         {
             auto& boundaryPatch = refCast<mixedFvPatchScalarField>(bc);
+            // Strictly speaking it should be just "ref-value", but I think it's nice to have \
+            // reading the value of a mixed BC using just operation "value".
             if (fieldConfig_.operation == "ref-value" || fieldConfig_.operation == "value")
             {
                 forAll(boundaryPatch, i)

--- a/module-generic/ReadWrite.C
+++ b/module-generic/ReadWrite.C
@@ -177,10 +177,6 @@ void preciceAdapter::Generic::ScalarFieldCoupler::read(double* buffer, const uns
         {
             adapterInfo("Generic module: Unsupported boundary condition type " + bc.type(), "error");
         }
-
-        // // evaluate the boundary condition, i.e., do some calculation to obtain the actual value provided refValue
-        // boundaryPatch.updateCoeffs();
-        // boundaryPatch.evaluate();
     }
 }
 

--- a/module-generic/ReadWrite.C
+++ b/module-generic/ReadWrite.C
@@ -160,6 +160,13 @@ std::size_t preciceAdapter::Generic::ScalarFieldCoupler::write(double* buffer, b
         return bufferIndex;
     }
 
+    if (fieldConfig_.operation == "ref-value" || fieldConfig_.operation == "ref-gradient" || fieldConfig_.operation == "value-fraction")
+    {
+        adapterInfo(
+            "Generic module: The mixed boundary condition operations (ref-value, ref-gradient, and value-fraction) are only supported for the read side. If you wish to write these fields, just use the value or surface-normal-gradient operations instead.",
+            "error");
+    }
+
     if (this->locationType_ == LocationType::volumeCenters)
     {
         if (cellSetNames_.empty())

--- a/module-generic/ReadWrite.C
+++ b/module-generic/ReadWrite.C
@@ -263,6 +263,13 @@ void preciceAdapter::Generic::ScalarFieldCoupler::read(double* buffer, const uns
 
         if (isA<fixedValueFvPatchScalarField>(bc))
         {
+            if (fieldConfig_.operation != "value")
+            {
+                adapterInfo(
+                    "Generic module: Unsupported operation " + fieldConfig_.operation + " for boundary condition type " + bc.type() + ". Supported operation is value.",
+                    "error");
+            }
+
             auto& boundaryPatch = refCast<fixedValueFvPatchScalarField>(bc);
             forAll(boundaryPatch, i)
             {
@@ -271,6 +278,13 @@ void preciceAdapter::Generic::ScalarFieldCoupler::read(double* buffer, const uns
         }
         else if (isA<fixedGradientFvPatchScalarField>(bc))
         {
+            if (fieldConfig_.operation != "value")
+            {
+                adapterInfo(
+                    "Generic module: Unsupported operation " + fieldConfig_.operation + " for boundary condition type " + bc.type() + ". Supported operation is value.",
+                    "error");
+            }
+
             auto& boundaryPatch = refCast<fixedGradientFvPatchScalarField>(bc);
             forAll(boundaryPatch, i)
             {
@@ -300,6 +314,12 @@ void preciceAdapter::Generic::ScalarFieldCoupler::read(double* buffer, const uns
                 {
                     boundaryPatch.valueFraction()[i] = buffer[bufferIndex++];
                 }
+            }
+            else
+            {
+                adapterInfo(
+                    "Generic module: Unsupported operation " + fieldConfig_.operation + " for boundary condition type " + bc.type() + ". Supported operations are ref-value, ref-gradient, and value-fraction.",
+                    "error");
             }
         }
         else

--- a/module-generic/ReadWrite.C
+++ b/module-generic/ReadWrite.C
@@ -4,6 +4,7 @@
 
 #include "fixedValueFvPatchFields.H"
 #include "fixedGradientFvPatchFields.H"
+#include "mixedFvPatchFields.H"
 
 using namespace Foam;
 
@@ -34,6 +35,14 @@ void preciceAdapter::Generic::ScalarFieldCoupler::initialize()
     if (fieldConfig_.operation == "gradient")
     {
         adapterInfo("Generic module: The gradient operation is not yet supported for scalar fields. Maybe you meant surface-normal-gradient?", "error");
+    }
+
+    if (fieldConfig_.operation == "ref-value" || fieldConfig_.operation == "ref-gradient")
+    {
+        if (this->locationType_ != LocationType::faceCenters)
+        {
+            adapterInfo("Generic module: Robin boundary conditions (ref-value and ref-gradient operations) are supported only for surface locations (faceCenters).", "error");
+        }
     }
 }
 
@@ -171,6 +180,24 @@ void preciceAdapter::Generic::ScalarFieldCoupler::read(double* buffer, const uns
             forAll(boundaryPatch, i)
             {
                 boundaryPatch.gradient()[i] = buffer[bufferIndex++];
+            }
+        }
+        else if (isA<mixedFvPatchScalarField>(bc))
+        {
+            auto& boundaryPatch = refCast<mixedFvPatchScalarField>(bc);
+            if (fieldConfig_.operation == "ref-value" || fieldConfig_.operation == "value")
+            {
+                forAll(boundaryPatch, i)
+                {
+                    boundaryPatch.refValue()[i] = buffer[bufferIndex++];
+                }
+            }
+            else if (fieldConfig_.operation == "ref-gradient")
+            {
+                forAll(boundaryPatch, i)
+                {
+                    boundaryPatch.refGrad()[i] = buffer[bufferIndex++];
+                }
             }
         }
         else

--- a/module-generic/ReadWrite.C
+++ b/module-generic/ReadWrite.C
@@ -280,9 +280,7 @@ void preciceAdapter::Generic::ScalarFieldCoupler::read(double* buffer, const uns
         else if (isA<mixedFvPatchScalarField>(bc))
         {
             auto& boundaryPatch = refCast<mixedFvPatchScalarField>(bc);
-            // Strictly speaking it should be just "ref-value", but I think it's nice to have \
-            // reading the value of a mixed BC using just operation "value".
-            if (fieldConfig_.operation == "ref-value" || fieldConfig_.operation == "value")
+            if (fieldConfig_.operation == "ref-value")
             {
                 forAll(boundaryPatch, i)
                 {


### PR DESCRIPTION
<!-- Thank you for your contribution! Have a look at the file `CONTRIBUTING.md` for a few hints and guidelines. -->

Implemented mixed boundary condition (Robin) in Generic module. This allows to replicate, for example, CHT cases where there are `Sink-Temperature` and `Heat-Transfer-Coefficient` coupling data. I've been able to validate the implementation on the tutorial `heat-exchanger` (pictures to follow).

There are new `operation` options available to set the mixed boundary conditions when reading data from preCICE:
- `ref-value` 
- `ref-gradient`
- `value-fraction`,
which will set the respective fields in the [OpenFOAM mixed BC](https://www.openfoam.com/documentation/guides/latest/doc/guide-bcs-mixed.html).

To test the implementation standalone from the CHT module, I created a new tutorial case `partitioned-heat-transfer-robin` on my [fork of the tutorials](https://github.com/vidulejs/tutorials/tree/robin-robin/partitioned-heat-conduction-robin). 

Here's the example preciceDict configuration for that case:
```preciceDict
participant Left;

modules (generic);

interfaces
{
  Interface1
  {
    mesh              Left-Mesh;
    patches           (interface);
    
    readData
    (
      Sink-Temp
      {
        name        Temperature-Right;
        solver_name T;
        operation   ref-value;
      }
      HTC
      {
        name        Gradient-Right;
        solver_name T;
        operation   ref-gradient;
        flip-normal true;
      }
    );
    
    writeData
    (
      Write-Temp
      {
        name        Temperature-Left;
        solver_name T;
        operation   value;
      }
      Write-Grad
      {
        name        Gradient-Left;
        solver_name T;
        operation   surface-normal-gradient;
      }
    );
  };
};
```

TODO list:

- [x] I updated the documentation in `docs/`
- [x] I added a changelog entry in `changelog-entries/` (create directory if missing)
