### PR TITLE
Fix dangling reference when creating interfaces (!)

### DIFF
--- a/Adapter.C
+++ b/Adapter.C
@@ -329,7 +329,7 @@ try
         DEBUG(adapterInfo("Adding coupling data writers..."));
         for (uint j = 0; j < interfacesConfig_.at(i).writeData.size(); j++)
         {
-            FieldConfig fieldConfig = interfacesConfig_.at(i).writeData.at(j);
+            const FieldConfig& fieldConfig = interfacesConfig_.at(i).writeData.at(j);
             std::string dataName = fieldConfig.name;
 
             unsigned int inModules = 0;
@@ -381,7 +381,7 @@ try
         DEBUG(adapterInfo("Adding coupling data readers..."));
         for (uint j = 0; j < interfacesConfig_.at(i).readData.size(); j++)
         {
-            FieldConfig fieldConfig = interfacesConfig_.at(i).readData.at(j);
+            const FieldConfig& fieldConfig = interfacesConfig_.at(i).readData.at(j);
             std::string dataName = fieldConfig.name;
 
             unsigned int inModules = 0;


### PR DESCRIPTION
<!-- Thank you for your contribution! Have a look at the file `CONTRIBUTING.md` for a few hints and guidelines. -->

In a previous PR I changed how the preciceDict is passed to the modules, where previously we had just associated a data name with each module, now we have a `FieldConfig` struct, which holds additional options for each field.

In doing that, I accidentally created a dangling reference to the `FieldConfig` object, where a new one was created every iteration of the interfaces loop, which subsequently went out of scope, but was passed as a reference to the modules and `CouplingDataUser`s.

It's a good thing I ran into this bug when testing some other things, because this failed silently and would cause incorrect field configurations.

TODO list:

- [ ] I updated the documentation in `docs/`
- [ ] I added a changelog entry in `changelog-entries/` (create directory if missing)
