### PR TITLE
Update coupledPressure / coupledVelocity BC for OpenFOAM v2606

### DIFF
--- a/FF/BoundaryConditions/coupledPressure/coupledPressureFvPatchField.C
+++ b/FF/BoundaryConditions/coupledPressure/coupledPressureFvPatchField.C
@@ -56,16 +56,6 @@ Foam::coupledPressureFvPatchField::coupledPressureFvPatchField(
 
 
 Foam::coupledPressureFvPatchField::coupledPressureFvPatchField(
-    const coupledPressureFvPatchField& ptf)
-: fixedFluxExtrapolatedPressureFvPatchScalarField(ptf),
-  refValue_(ptf.refValue_),
-  refGrad_(ptf.refGrad_),
-  valueFraction_(ptf.valueFraction_)
-{
-}
-
-
-Foam::coupledPressureFvPatchField::coupledPressureFvPatchField(
     const coupledPressureFvPatchField& ptf,
     const DimensionedField<Foam::scalar, volMesh>& iF)
 : fixedFluxExtrapolatedPressureFvPatchScalarField(ptf, iF),

--- a/FF/BoundaryConditions/coupledPressure/coupledPressureFvPatchField.H
+++ b/FF/BoundaryConditions/coupledPressure/coupledPressureFvPatchField.H
@@ -93,14 +93,7 @@ public:
 
     //- Construct as copy
     coupledPressureFvPatchField(
-        const coupledPressureFvPatchField&);
-
-    //- Construct and return a clone
-    virtual tmp<fvPatchScalarField> clone() const
-    {
-        return tmp<fvPatchScalarField>(
-            new coupledPressureFvPatchField(*this));
-    }
+        const coupledPressureFvPatchField&) = delete;
 
     //- Construct as copy setting internal field reference
     coupledPressureFvPatchField(

--- a/FF/BoundaryConditions/coupledVelocity/coupledVelocityFvPatchField.C
+++ b/FF/BoundaryConditions/coupledVelocity/coupledVelocityFvPatchField.C
@@ -57,16 +57,6 @@ Foam::coupledVelocityFvPatchField::coupledVelocityFvPatchField(
 
 
 Foam::coupledVelocityFvPatchField::coupledVelocityFvPatchField(
-    const coupledVelocityFvPatchField& ptf)
-: fvPatchField<vector>(ptf),
-  refValue_(ptf.refValue_),
-  refGrad_(ptf.refGrad_),
-  valueFraction_(ptf.valueFraction_)
-{
-}
-
-
-Foam::coupledVelocityFvPatchField::coupledVelocityFvPatchField(
     const coupledVelocityFvPatchField& ptf,
     const DimensionedField<vector, volMesh>& iF)
 : fvPatchField<vector>(ptf, iF),

--- a/FF/BoundaryConditions/coupledVelocity/coupledVelocityFvPatchField.H
+++ b/FF/BoundaryConditions/coupledVelocity/coupledVelocityFvPatchField.H
@@ -90,14 +90,7 @@ public:
 
     //- Construct as copy
     coupledVelocityFvPatchField(
-        const coupledVelocityFvPatchField&);
-
-    //- Construct and return a clone
-    virtual tmp<fvPatchVectorField> clone() const
-    {
-        return tmp<fvPatchVectorField>(
-            new coupledVelocityFvPatchField(*this));
-    }
+        const coupledVelocityFvPatchField&) = delete;
 
     //- Construct as copy setting internal field reference
     coupledVelocityFvPatchField(

--- a/changelog-entries/410.md
+++ b/changelog-entries/410.md
@@ -1,0 +1,1 @@
+- Fixed a compatibility issue with OpenFOAM v2606 affecting the coupledVelocity and coupledPressure boundary conditions [#410](https://github.com/precice/openfoam-adapter/pull/410)

--- a/docs/openfoam-support.md
+++ b/docs/openfoam-support.md
@@ -36,6 +36,7 @@ We provide version-specific [release archives](https://github.com/precice/openfo
 - OpenCFD / ESI (openfoam.com) - main focus:
   - [OpenFOAM v1812-v2512](https://github.com/precice/openfoam-adapter) or newer
   - [OpenFOAM v1612-v1806](https://github.com/precice/openfoam-adapter/tree/OpenFOAMv1806) (not tested)
+  - For OpenFOAM v2606, see a [patch (already merged)](https://github.com/precice/openfoam-adapter/pull/410)
 - OpenFOAM Foundation (openfoam.org) - secondary, consider experimental:
   - [OpenFOAM 10](https://github.com/precice/openfoam-adapter/tree/OpenFOAM10)
   - [OpenFOAM 9](https://github.com/precice/openfoam-adapter/tree/OpenFOAM9)


### PR DESCRIPTION
Fixes #408 by deleting the previously deprecated and now removed copy constructor (and corresponding `clone()` function) of `GeometricBoundaryField` derived fields, as described in the [porting guide for OpenFOAM v2606](https://gitlab.com/openfoam/core/openfoam/-/wikis/upgrade/v2606-Developer-Upgrade-Guide) (so nice to have such guides!).

The code seems to build with OpenFOAM v2606 and with v2512.

TODO list:

- [x] I added a changelog entry in `changelog-entries/` (create directory if missing)
