### PR TITLE
Prepare documentation for rendering in Hugo (native)

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,10 +1,10 @@
 ---
 title: The OpenFOAM adapter
 permalink: adapter-openfoam-overview.html
-url: /adapter-openfoam-overview.html
-redirect_from: adapter-openfoam.html
 aliases:
+  - /adapter-openfoam-overview.html
   - /adapter-openfoam.html
+redirect_from: adapter-openfoam.html
 keywords: adapter, openfoam, cite, versions
 summary: An OpenFOAM function object for CHT, FSI, and fluid-fluid coupled simulations using preCICE.
 ---

--- a/docs/config.md
+++ b/docs/config.md
@@ -1,7 +1,8 @@
 ---
 title: Configure the OpenFOAM adapter
 permalink: adapter-openfoam-config.html
-url: /adapter-openfoam-config.html
+aliases:
+  - /adapter-openfoam-config.html
 keywords: adapter, openfoam, configuration, preciceDict, controlDict
 summary: "Write a system/preciceDict, set compatible boundary conditions, and activate the adapter in your system/controlDict."
 ---

--- a/docs/extend.md
+++ b/docs/extend.md
@@ -1,7 +1,8 @@
 ---
 title: Extend the OpenFOAM adapter
 permalink: adapter-openfoam-extend.html
-url: /adapter-openfoam-extend.html
+aliases:
+  - /adapter-openfoam-extend.html
 keywords: adapter, openfoam, development, modules
 summary: "An overview of the OpenFOAM adapter's architecture and which parts to modify if you want to add functionality."
 ---

--- a/docs/get.md
+++ b/docs/get.md
@@ -1,7 +1,8 @@
 ---
 title: Get the OpenFOAM adapter
 permalink: adapter-openfoam-get.html
-url: /adapter-openfoam-get.html
+aliases:
+  - /adapter-openfoam-get.html
 keywords: adapter, openfoam, building
 summary: "Get the code from GitHub and run ./Allwmake. If this fails, look into wmake.log and ldd.log."
 ---

--- a/docs/openfoam-support.md
+++ b/docs/openfoam-support.md
@@ -1,7 +1,8 @@
 ---
 title: OpenFOAM support
 permalink: adapter-openfoam-support.html
-url: /adapter-openfoam-support.html
+aliases:
+  - /adapter-openfoam-support.html
 keywords: adapter, openfoam, support, versions
 summary: Recent OpenFOAM.com versions work out-of-the-box. Recent OpenFOAM.org versions are also supported, but you will need a version-specific branch.
 ---


### PR DESCRIPTION
<!-- Thank you for your contribution! Have a look at the file `CONTRIBUTING.md` for a few hints and guidelines. -->
Preserve the existing openfoam-adapter documentation URL for the Hugo migration
TODO list:

- [x] I updated the documentation in `docs/`
- [ ] I added a changelog entry in `changelog-entries/` (create directory if missing)
